### PR TITLE
feat: 카카오 로그인 구현 (#1)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,10 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.13'
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/cookeep/cookeep/api/controller/AuthController.java
+++ b/src/main/java/com/cookeep/cookeep/api/controller/AuthController.java
@@ -1,0 +1,29 @@
+package com.cookeep.cookeep.api.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.cookeep.cookeep.api.dto.KakaoLoginResponseDTO;
+import com.cookeep.cookeep.common.dto.DataResponse;
+import com.cookeep.cookeep.domain.user.application.AuthService;
+import com.cookeep.cookeep.domain.user.application.OAuthProvider;
+
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/auth")
+public class AuthController {
+
+	private final AuthService authService;
+
+	@Operation(summary = "카카오 로그인 API")
+	@GetMapping("/login/kakao")
+	public ResponseEntity<DataResponse<KakaoLoginResponseDTO>> kakaoLogin(@RequestParam String code) {
+		return ResponseEntity.ok(DataResponse.from(authService.kakaoLogin(code)));
+	}
+}

--- a/src/main/java/com/cookeep/cookeep/api/dto/KakaoLoginResponseDTO.java
+++ b/src/main/java/com/cookeep/cookeep/api/dto/KakaoLoginResponseDTO.java
@@ -1,0 +1,16 @@
+package com.cookeep.cookeep.api.dto;
+
+import java.util.Optional;
+
+import com.cookeep.cookeep.domain.user.entity.NextStep;
+import com.cookeep.cookeep.domain.user.entity.UserStatus;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+// nextStep은 null일 경우 JSON 응답에서 제외함
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record KakaoLoginResponseDTO(
+	Long userId, String accessToken,
+	String refreshToken, UserStatus userStatus,
+	NextStep nextStep // nullable
+) {
+}

--- a/src/main/java/com/cookeep/cookeep/config/JwtTokenProvider.java
+++ b/src/main/java/com/cookeep/cookeep/config/JwtTokenProvider.java
@@ -1,0 +1,94 @@
+package com.cookeep.cookeep.config;
+
+
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.nio.charset.StandardCharsets;
+import java.security.Key;
+import java.util.Date;
+
+@Component
+public class JwtTokenProvider {
+
+	private final Key accessKey;
+	private final Key refreshKey;
+
+	// 액세스토큰 30분
+	// 리프레쉬 토큰 14일
+	private static final long ACCESS_TTL  = 30 * 60 * 1000L;
+	private static final long REFRESH_TTL = 14L * 24 * 60 * 60 * 1000L;
+
+	public JwtTokenProvider(
+		@Value("${jwt.access-secret}") String accessSecret,
+		@Value("${jwt.refresh-secret}") String refreshSecret
+	) {
+		this.accessKey  = Keys.hmacShaKeyFor(accessSecret.getBytes(StandardCharsets.UTF_8));
+		this.refreshKey = Keys.hmacShaKeyFor(refreshSecret.getBytes(StandardCharsets.UTF_8));
+	}
+
+	// 액세스 토큰 생성
+	public String createAccessToken(Long userId) {
+		Date now = new Date(); // 발급 시간
+		Date exp = new Date(now.getTime() + ACCESS_TTL); // 만료 시간 (발급 시간 + 기한)
+
+		return Jwts.builder()
+			.setHeaderParam(Header.TYPE, Header.JWT_TYPE) // 명시적으로 typ=JWT임을 넣어줌
+			.setSubject(String.valueOf(userId)) // userId를 기준으로 액세스토큰 생성
+			.setIssuedAt(now) // 발급 시간
+			.setExpiration(exp) // 만료 시간
+			.claim("typ", "access")
+			.claim("jti", generateJti())
+			.signWith(accessKey, SignatureAlgorithm.HS256)
+			.compact();
+	}
+
+	// 리프레쉬 토큰 발급
+	public String createRefreshToken(Long userId) {
+		Date now = new Date();
+		Date exp = new Date(now.getTime() + REFRESH_TTL);
+
+		return Jwts.builder()
+			.setHeaderParam(Header.TYPE, Header.JWT_TYPE)
+			.setSubject(String.valueOf(userId))
+			.setIssuedAt(now)
+			.setExpiration(exp)
+			.claim("typ", "refresh")
+			.claim("jti", generateJti())
+			.signWith(refreshKey, SignatureAlgorithm.HS256)
+			.compact();
+	}
+
+	// 토큰 유효성 검사
+	public boolean validateToken(String token, boolean refresh) {
+		try {
+			Jwts.parserBuilder()
+				.setSigningKey(refresh ? refreshKey : accessKey)
+				.setAllowedClockSkewSeconds(60)
+				.build()
+				.parseClaimsJws(token);
+			return true;
+		} catch (ExpiredJwtException e) {
+			return false;
+		} catch (JwtException | IllegalArgumentException e) {
+			return false;
+		}
+	}
+
+	// 토큰 내 userId 추출
+	public Long getUserId(String token, boolean refresh) {
+		Claims claims = Jwts.parserBuilder()
+			.setSigningKey(refresh ? refreshKey : accessKey)
+			.setAllowedClockSkewSeconds(60)
+			.build()
+			.parseClaimsJws(token)
+			.getBody();
+		return Long.valueOf(claims.getSubject());
+	}
+
+	private String generateJti() {
+		return java.util.UUID.randomUUID().toString();
+	}
+}

--- a/src/main/java/com/cookeep/cookeep/domain/user/application/AuthService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/user/application/AuthService.java
@@ -1,0 +1,90 @@
+package com.cookeep.cookeep.domain.user.application;
+
+import static com.cookeep.cookeep.domain.user.entity.Provider.*;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.cookeep.cookeep.api.dto.KakaoLoginResponseDTO;
+import com.cookeep.cookeep.config.JwtTokenProvider;
+import com.cookeep.cookeep.domain.user.dao.UserAuthRepository;
+import com.cookeep.cookeep.domain.user.dao.UserRepository;
+import com.cookeep.cookeep.domain.user.dao.UserSessionRepository;
+import com.cookeep.cookeep.domain.user.dto.KakaoUserInfoResponseDTO;
+import com.cookeep.cookeep.domain.user.entity.NextStep;
+import com.cookeep.cookeep.domain.user.entity.User;
+import com.cookeep.cookeep.domain.user.entity.UserAuth;
+import com.cookeep.cookeep.domain.user.entity.UserSession;
+import com.cookeep.cookeep.domain.user.entity.UserStatus;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+	private final KakaoOAuthProvider kakaoOAuthProvider;
+	private final UserRepository userRepository;
+	private final UserAuthRepository userAuthRepository;
+	private final UserSessionRepository userSessionRepository;
+	private final JwtTokenProvider jwtTokenProvider;
+
+	// 카카오 로그인
+	@Transactional
+	public KakaoLoginResponseDTO kakaoLogin(String code) {
+		String kakaoAccessToken = kakaoOAuthProvider.getKakaoAccessToken(code);
+		KakaoUserInfoResponseDTO userInfo = kakaoOAuthProvider.getKakaoUserInfo(kakaoAccessToken);
+
+		String kakaoId = String.valueOf(userInfo.id());
+
+		// provider = KAKAO, providerUserId인 값을 통해 이미 가입된 회원인지 식별
+		Optional<UserAuth> existingUserAuth = userAuthRepository.findByProviderAndProviderUserId(KAKAO, kakaoId);
+
+		String email = userInfo.kakaoAccount().email();
+
+		// 신규 유저일 경우 User, UserAuth값을 새롭게 생성함
+		UserAuth userAuth = existingUserAuth
+			.orElseGet(() -> {
+				// User 값 새롭게 생성
+				User newUser = userRepository.save(User.builder()
+					.email(email)
+					.build());
+
+				return userAuthRepository.save(
+					UserAuth.builder()
+						.user(newUser)
+						.provider(KAKAO)
+						.providerUserId(kakaoId)
+						.build());
+			});
+
+		User user = userAuth.getUser();
+
+		String accessToken = jwtTokenProvider.createAccessToken(user.getUserId());
+		String refreshToken = jwtTokenProvider.createRefreshToken(user.getUserId());
+
+		userSessionRepository.save(
+			UserSession.builder()
+				.user(user)
+				.refreshToken(refreshToken)
+				.expiresAt(LocalDateTime.now().plusDays(14))
+				.build()
+		);
+
+		UserStatus userStatus = user.getUserStatus();
+		NextStep nextStep = null;
+		if (userStatus == UserStatus.CREATED) {
+			nextStep = NextStep.TERMS;
+		}
+
+		return new KakaoLoginResponseDTO(
+			user.getUserId(), accessToken, refreshToken,
+			userStatus, nextStep
+		);
+	}
+}

--- a/src/main/java/com/cookeep/cookeep/domain/user/application/KakaoOAuthProvider.java
+++ b/src/main/java/com/cookeep/cookeep/domain/user/application/KakaoOAuthProvider.java
@@ -1,0 +1,85 @@
+package com.cookeep.cookeep.domain.user.application;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.reactive.function.BodyInserters;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import com.cookeep.cookeep.domain.user.dao.UserRepository;
+import com.cookeep.cookeep.domain.user.dto.KakaoTokenResponseDTO;
+import com.cookeep.cookeep.domain.user.dto.KakaoUserInfoResponseDTO;
+import com.cookeep.cookeep.domain.user.entity.Provider;
+
+import io.netty.handler.codec.http.HttpHeaderValues;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import reactor.core.publisher.Mono;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class KakaoOAuthProvider implements OAuthProvider {
+
+	@Value("${kakao.auth.client}")
+	private String clientId;
+	@Value("${kakao.auth.secret}")
+	private String clientSecret;
+	@Value("${kakao.auth.accessTokenURL}")
+	private String KakaoAccessTokenURL;
+	@Value("${kakao.auth.userInfoURL}")
+	private String KakaoUserInfoURL;
+	@Value("${kakao.auth.redirect}")
+	private String redirectUri;
+
+	private final UserRepository userRepository;
+
+	@Override
+	public Provider provider() {
+		return Provider.KAKAO;
+	}
+
+	// 인가코드를 사용해 로그인할 유저의 카카오 액세스 토큰값을 받아옴
+	public String getKakaoAccessToken(String code) {
+		MultiValueMap<String, String> form = new LinkedMultiValueMap<>();
+		form.add("grant_type", "authorization_code");
+		form.add("client_id", clientId);
+		form.add("client_secret", clientSecret);
+		form.add("redirect_uri", redirectUri);
+		form.add("code", code);
+
+		KakaoTokenResponseDTO kakaoTokenResponseDTO = WebClient.create()
+			.post()
+			.uri(KakaoAccessTokenURL)
+			.contentType(MediaType.APPLICATION_FORM_URLENCODED)
+			.body(BodyInserters.fromFormData(form))
+			.retrieve()
+			.onStatus(HttpStatusCode::isError, res ->
+				res.bodyToMono(String.class).defaultIfEmpty("")
+					.doOnNext(body -> log.error("[KAKAO] /oauth/token error status={}, body={}", res.statusCode(), body))
+					.then(Mono.error(new RuntimeException("카카오 로그인 요청에 실패하였습니다.")))
+			)
+			.bodyToMono(KakaoTokenResponseDTO.class)
+			.block();
+
+		return kakaoTokenResponseDTO.accessToken();
+	}
+
+	// 카카오 액세스 토큰을 사용해 유저의 정보값을 받아옴
+	public KakaoUserInfoResponseDTO getKakaoUserInfo(String accessToken) {
+		return WebClient.create(KakaoUserInfoURL)
+			.get()
+			.uri(uriBuilder -> uriBuilder
+				.scheme("https")
+				.build(true))
+			.header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken) // access token 인가
+			.header(HttpHeaders.CONTENT_TYPE, HttpHeaderValues.APPLICATION_X_WWW_FORM_URLENCODED.toString())
+			.retrieve()
+			.bodyToMono(KakaoUserInfoResponseDTO.class)
+			.block();
+	}
+}

--- a/src/main/java/com/cookeep/cookeep/domain/user/application/OAuthProvider.java
+++ b/src/main/java/com/cookeep/cookeep/domain/user/application/OAuthProvider.java
@@ -1,0 +1,10 @@
+package com.cookeep.cookeep.domain.user.application;
+
+import com.cookeep.cookeep.domain.user.dto.KakaoUserInfoResponseDTO;
+import com.cookeep.cookeep.domain.user.entity.Provider;
+
+public interface OAuthProvider {
+	Provider provider();
+	String getKakaoAccessToken(String code);
+	KakaoUserInfoResponseDTO getKakaoUserInfo(String accessToken);
+}

--- a/src/main/java/com/cookeep/cookeep/domain/user/dao/UserAuthRepository.java
+++ b/src/main/java/com/cookeep/cookeep/domain/user/dao/UserAuthRepository.java
@@ -1,8 +1,12 @@
 package com.cookeep.cookeep.domain.user.dao;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import com.cookeep.cookeep.domain.user.entity.Provider;
 import com.cookeep.cookeep.domain.user.entity.UserAuth;
 
 public interface UserAuthRepository extends JpaRepository<UserAuth, Long> {
+	Optional<UserAuth> findByProviderAndProviderUserId(Provider provider, String providerUserId);
 }

--- a/src/main/java/com/cookeep/cookeep/domain/user/dao/UserSessionRepository.java
+++ b/src/main/java/com/cookeep/cookeep/domain/user/dao/UserSessionRepository.java
@@ -1,0 +1,8 @@
+package com.cookeep.cookeep.domain.user.dao;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.cookeep.cookeep.domain.user.entity.UserSession;
+
+public interface UserSessionRepository extends JpaRepository<UserSession, Long> {
+}

--- a/src/main/java/com/cookeep/cookeep/domain/user/dto/KakaoTokenResponseDTO.java
+++ b/src/main/java/com/cookeep/cookeep/domain/user/dto/KakaoTokenResponseDTO.java
@@ -1,0 +1,10 @@
+package com.cookeep.cookeep.domain.user.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record KakaoTokenResponseDTO(
+	@JsonProperty("access_token") String accessToken
+) {
+}

--- a/src/main/java/com/cookeep/cookeep/domain/user/dto/KakaoUserInfoResponseDTO.java
+++ b/src/main/java/com/cookeep/cookeep/domain/user/dto/KakaoUserInfoResponseDTO.java
@@ -1,0 +1,20 @@
+package com.cookeep.cookeep.domain.user.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+// DTO에서 요구로 하는 필드만 받아오도록 함
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record KakaoUserInfoResponseDTO(
+	@JsonProperty("id")
+	Long id,
+
+	@JsonProperty("kakao_account")
+	KakaoAccount kakaoAccount
+) {
+	@JsonIgnoreProperties(ignoreUnknown = true)
+	public record KakaoAccount(
+		@JsonProperty("email")
+		String email
+	) {}
+}

--- a/src/main/java/com/cookeep/cookeep/domain/user/entity/NextStep.java
+++ b/src/main/java/com/cookeep/cookeep/domain/user/entity/NextStep.java
@@ -1,0 +1,5 @@
+package com.cookeep.cookeep.domain.user.entity;
+
+public enum NextStep {
+	TERMS, ONBOARDING
+}

--- a/src/main/java/com/cookeep/cookeep/domain/user/entity/User.java
+++ b/src/main/java/com/cookeep/cookeep/domain/user/entity/User.java
@@ -36,7 +36,9 @@ public class User extends BaseEntity {
 	@GeneratedValue(strategy= GenerationType.IDENTITY)
 	private Long userId;
 
-	@Column(length = 20, nullable = false, unique = true)
+	// 닉네임 처리는 추후 값 전달받은 후에 업데이트할 예정
+	//@Column(length = 20, nullable = false, unique = true)
+	@Column(length = 20, unique = true)
 	private String nickname;
 
 	// 소셜 로그인은 전화번호를 수집하지 않으므로 nullable
@@ -61,11 +63,14 @@ public class User extends BaseEntity {
 
 	// 비밀번호 오류 횟수, 5회 오류시 LOCKED 상태됨
 	// 소셜로그인 회원은 별도로 카운트하지 않으므로 nullable
-	private int passwordCnt;
+	private Integer passwordCnt;
 
+	// @Builder 어노테이션 사용중이므로 기본값이 있는 필드에 @Builder.Default 추가
+	@Builder.Default
 	@Column(nullable = false)
 	private int cookieCnt = 0;
 
+	@Builder.Default
 	@Enumerated(EnumType.STRING)
 	@Column(nullable = false)
 	private UserStatus userStatus = UserStatus.CREATED;

--- a/src/main/java/com/cookeep/cookeep/domain/user/entity/UserSession.java
+++ b/src/main/java/com/cookeep/cookeep/domain/user/entity/UserSession.java
@@ -1,0 +1,48 @@
+package com.cookeep.cookeep.domain.user.entity;
+
+import java.time.LocalDateTime;
+
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import com.cookeep.cookeep.common.entity.BaseEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@EntityListeners(AuditingEntityListener.class)
+@Table(name = "User_Sessions")
+public class UserSession extends BaseEntity {
+	@Id
+	@GeneratedValue(strategy= GenerationType.IDENTITY)
+	private Long sessionId;
+
+	@ManyToOne(fetch = FetchType.LAZY, optional = false)
+	@JoinColumn(name = "user_id", nullable = false)
+	private User user;
+
+	@Setter
+	@Column(nullable = false)
+	private String refreshToken;
+
+	@Setter
+	private LocalDateTime expiresAt;
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -15,3 +15,14 @@ spring:
     properties:
       hibernate:
         format_sql: true
+
+kakao:
+  auth:
+    client: ${CLIENT_ID}
+    secret: ${CLIENT_SECRET}
+    redirect: ${REDIRECT_URI}
+    accessTokenURL: https://kauth.kakao.com/oauth/token
+    userInfoURL: https://kapi.kakao.com/v2/user/me
+jwt:
+  access-secret: ${JWT_ACCESS_SECRET_KEY}
+  refresh-secret: ${JWT_REFRESH_SECRET_KEY}


### PR DESCRIPTION
## Related Issue
https://github.com/IT-Cotato/12th-CooKeep-BE/issues/1
</br></br>
## Description
#### 인증 / 로그인 기능 추가
- JWT 발급 및 검증을 위해  **`JwtTokenProvider`** 추가
- 카카오 OAuth 인가 코드 기반 로그인 기능 구현
- 카카오 식별 ID를 기준으로 기존 회원 / 신규 회원 분기 처리
- 사용자 세션 관리를 위해 `UserSession` 엔티티 및 레포지토리 추가</br></br>
#### 사용자 상태 기반 로그인 응답 구조
- 프론트 화면 분기 처리를 위해 로그인 응답에 `userStatus` 및 `nextStep` 포함
  - 기존 회원(온보딩 완료): `ACTIVE`
  - 신규 소셜 로그인 회원: `CREATED`, `nextStep = TERMS`
  - 신규 자체 회원가입 회원(추후 구현 예정): `CREATED`, `nextStep = ONBOARDING` </br></br></br>
#### User 엔티티 일부 수정
  - `nickname`값 nullable로 임시 변경
    - 추후 랜덤 닉네임 값 전달받은 이후 업데이트할 예정
  - `passwordCnt`값 nullable이므로 타입 Integer로 변경하였음
  - @Builder 어노테이션 사용 중이므로 기본값이 있는 필드에 @Builder.Default 어노테이션 추가함


</br></br>
## Changes
- 인증/로그인 기능 추가
- 카카오 OAuth 로그인 구현
- User 엔티티 수정
- UserSession 엔티티 추가</br></br>