### PR TITLE
feat: 쿠키 도메인 개발 (#13)

### DIFF
--- a/src/main/java/com/cookeep/cookeep/api/controller/CookieController.java
+++ b/src/main/java/com/cookeep/cookeep/api/controller/CookieController.java
@@ -32,6 +32,10 @@ public class CookieController {
     public DataResponse<Integer> getMyCookies(
             @RequestHeader("Authorization") String authorization
     ) {
+        // TODO: 추루 시큐리티 설정(JwtAuthenticationFilter)이 완료되면
+        // TODO: @AuthenticationPrincipal 또는 커스텀 @LoginUser를 사용하여
+        // TODO: 컨트롤러 레이어에서 토큰 파싱 로직을 제거하고 보안 책임을 위임할 예정입니다.
+
         // AuthUtils를 사용해 안전하게 토큰 추출, null, 잘못된 형식, 공백 등을 자동으로 처리
         String token = AuthUtils.extractBearerToken(authorization);
 

--- a/src/main/java/com/cookeep/cookeep/api/controller/CookieController.java
+++ b/src/main/java/com/cookeep/cookeep/api/controller/CookieController.java
@@ -1,7 +1,8 @@
 package com.cookeep.cookeep.api.controller;
 
-import com.cookeep.cookeep.api.dto.user.UserProvider;
 import com.cookeep.cookeep.common.dto.DataResponse;
+import com.cookeep.cookeep.common.util.AuthUtils;
+import com.cookeep.cookeep.config.JwtTokenProvider;
 import com.cookeep.cookeep.domain.cookie.application.CookieService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -9,26 +10,33 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@Tag(name = "유저", description = "사용자 정보 및 쿠키 관련 API")
+@Tag(name = "쿠키", description = "쿠키 관련 API")
 @RestController
-@RequestMapping("/api/users")
+@RequestMapping("/api/users/me/cookies")
 @RequiredArgsConstructor
-public class UserController {
+public class CookieController {
 
     private final CookieService cookieService;
-    private final UserProvider userProvider; // 원활한 테스트 위해 만든 것. 추후 로그인 및 회원가입 이후에 협의 후 제거하거나 삭제 예정
+    private final JwtTokenProvider jwtTokenProvider;
 
     @Operation(summary = "보유 쿠키 조회", description = "현재 내가 보유하고 있는 쿠키의 총 개수를 조회합니다.")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "조회 성공")
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "401", description = "인증되지 않음")
     })
-    @GetMapping("/me/cookies")
-    public DataResponse<Integer> getMyCookies() {
-        // UserProvider를 통해 현재 유저 ID 추출
-        Long userId = userProvider.getCurrentUserId();
+    @GetMapping
+    public DataResponse<Integer> getMyCookies(
+            @RequestHeader("Authorization") String authorization
+    ) {
+        // AuthUtils를 사용해 안전하게 토큰 추출, null, 잘못된 형식, 공백 등을 자동으로 처리
+        String token = AuthUtils.extractBearerToken(authorization);
+
+        // JWT 토큰에서 userId 추출
+        Long userId = jwtTokenProvider.getUserId(token, false);
 
         // CookieService에서 실제 유저 엔티티의 cookieCnt 반환
         return DataResponse.from(cookieService.getMyCookies(userId));

--- a/src/main/java/com/cookeep/cookeep/api/controller/UserController.java
+++ b/src/main/java/com/cookeep/cookeep/api/controller/UserController.java
@@ -1,0 +1,36 @@
+package com.cookeep.cookeep.api.controller;
+
+import com.cookeep.cookeep.api.dto.user.UserProvider;
+import com.cookeep.cookeep.common.dto.DataResponse;
+import com.cookeep.cookeep.domain.cookie.application.CookieService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "유저", description = "사용자 정보 및 쿠키 관련 API")
+@RestController
+@RequestMapping("/api/users")
+@RequiredArgsConstructor
+public class UserController {
+
+    private final CookieService cookieService;
+    private final UserProvider userProvider; // 원활한 테스트 위해 만든 것. 추후 로그인 및 회원가입 이후에 협의 후 제거하거나 삭제 예정
+
+    @Operation(summary = "보유 쿠키 조회", description = "현재 내가 보유하고 있는 쿠키의 총 개수를 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공")
+    })
+    @GetMapping("/me/cookies")
+    public DataResponse<Integer> getMyCookies() {
+        // UserProvider를 통해 현재 유저 ID 추출
+        Long userId = userProvider.getCurrentUserId();
+
+        // CookieService에서 실제 유저 엔티티의 cookieCnt 반환
+        return DataResponse.from(cookieService.getMyCookies(userId));
+    }
+}

--- a/src/main/java/com/cookeep/cookeep/common/exception/ErrorCode.java
+++ b/src/main/java/com/cookeep/cookeep/common/exception/ErrorCode.java
@@ -19,6 +19,9 @@ public enum ErrorCode {
 
 	NOT_ENOUGH_COOKIES(HttpStatus.BAD_REQUEST, "보유한 쿠키가 부족합니다.", "COOKIE-001"),
 
+	// 401 UNAUTHORIZED (인증 관련)
+	UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증되지 않았습니다.", "AUTH-001"),
+
 	// 403 FORBIDDEN (권한 관련)
 	NOT_MY_PLANT(HttpStatus.FORBIDDEN, "해당 식물에 대한 권한이 없습니다.", "PLANT-001"),
 

--- a/src/main/java/com/cookeep/cookeep/common/exception/ErrorCode.java
+++ b/src/main/java/com/cookeep/cookeep/common/exception/ErrorCode.java
@@ -12,15 +12,20 @@ public enum ErrorCode {
 	//400
 	BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다.", "COMMON-001"),
 	INVALID_PARAMETER(HttpStatus.BAD_REQUEST, "요청 파라미터가 잘못되었습니다.", "COMMON-002"),
+
 	PLANT_NOT_FROZEN(HttpStatus.BAD_REQUEST, "성장 정지 상태가 아닙니다.", "PLANT-003"),
 	ALREADY_HARVESTED(HttpStatus.BAD_REQUEST, "이미 수확한 식물입니다.", "PLANT-004"),
 	PLANT_IS_FROZEN(HttpStatus.BAD_REQUEST, "성장 정지 상태의 식물입니다.", "PLANT-005"),
+
+	NOT_ENOUGH_COOKIES(HttpStatus.BAD_REQUEST, "보유한 쿠키가 부족합니다.", "COOKIE-001"),
 
 	// 403 FORBIDDEN (권한 관련)
 	NOT_MY_PLANT(HttpStatus.FORBIDDEN, "해당 식물에 대한 권한이 없습니다.", "PLANT-001"),
 
 	// 404 NOT FOUND
 	NOT_FOUND(HttpStatus.NOT_FOUND, "찾을 수 없습니다.", "COMMON-003"),
+	USER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 사용자입니다.", "COMMON-004"),
+
 	PLANT_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 식물입니다.", "PLANT-002"),
 
 	//500

--- a/src/main/java/com/cookeep/cookeep/common/util/AuthUtils.java
+++ b/src/main/java/com/cookeep/cookeep/common/util/AuthUtils.java
@@ -1,0 +1,43 @@
+package com.cookeep.cookeep.common.util;
+
+import com.cookeep.cookeep.common.exception.AppException;
+import com.cookeep.cookeep.common.exception.ErrorCode;
+
+public final class AuthUtils {
+
+    private AuthUtils() { /* util */ }
+
+    /**
+     * Authorization 헤더에서 Bearer 토큰을 안전하게 추출합니다.
+     *
+     * - null 체크
+     * - "Bearer " 접두사 확인 (대소문자 무시)
+     * - 공백 제거
+     * - 빈 토큰 검증
+     *
+     * @param authorizationHeader Authorization 헤더 값
+     * @return 추출된 토큰
+     * @throws AppException ErrorCode.UNAUTHORIZED
+     */
+    public static String extractBearerToken(String authorizationHeader) {
+        if (authorizationHeader == null) {
+            throw new AppException(ErrorCode.UNAUTHORIZED);
+        }
+
+        String header = authorizationHeader.trim();
+        if (header.length() < 7) { // "Bearer " 보다 짧으면 토큰 없음
+            throw new AppException(ErrorCode.UNAUTHORIZED);
+        }
+
+        // case-insensitive로 "Bearer " 접두사 체크 (7글자)
+        if (header.regionMatches(true, 0, "Bearer ", 0, 7)) {
+            String token = header.substring(7).trim();
+            if (token.isEmpty()) {
+                throw new AppException(ErrorCode.UNAUTHORIZED);
+            }
+            return token;
+        } else {
+            throw new AppException(ErrorCode.UNAUTHORIZED);
+        }
+    }
+}

--- a/src/main/java/com/cookeep/cookeep/domain/cookie/application/CookieService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/cookie/application/CookieService.java
@@ -1,0 +1,49 @@
+package com.cookeep.cookeep.domain.cookie.application;
+
+import com.cookeep.cookeep.common.exception.AppException;
+import com.cookeep.cookeep.common.exception.ErrorCode;
+import com.cookeep.cookeep.domain.cookie.dao.CookieLogRepository;
+import com.cookeep.cookeep.domain.cookie.entity.CookieLog;
+import com.cookeep.cookeep.domain.user.dao.UserRepository;
+import com.cookeep.cookeep.domain.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class CookieService {
+    private final UserRepository userRepository;
+    private final CookieLogRepository cookieLogRepository;
+
+    // 현재 보유 쿠키 조회
+    @Transactional(readOnly = true)
+    public int getMyCookies(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new AppException(ErrorCode.USER_NOT_FOUND));
+        return user.getCookieCnt(); // User 엔티티에서 관리 중인 필드 사용
+    }
+
+    // 쿠키 사용/지급 공통 로직
+    @Transactional
+    public void updateCookie(Long userId, int amount, CookieLog.CookieLogType type) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new AppException(ErrorCode.USER_NOT_FOUND));
+
+        // 쿠키 차감 시 잔액 검증
+        if (amount < 0 && user.getCookieCnt() < Math.abs(amount)) {
+            throw new AppException(ErrorCode.NOT_ENOUGH_COOKIES);
+        }
+
+        // 1. 유저 쿠키 개수 업데이트
+        user.updateCookieCnt(amount);
+
+        // 2. 트랜잭션 로그 저장
+        CookieLog log = CookieLog.builder()
+                .user(user)
+                .amount(amount)
+                .type(type)
+                .build();
+        cookieLogRepository.save(log);
+    }
+}

--- a/src/main/java/com/cookeep/cookeep/domain/cookie/application/CookieService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/cookie/application/CookieService.java
@@ -27,18 +27,18 @@ public class CookieService {
     // 쿠키 사용/지급 공통 로직
     @Transactional
     public void updateCookie(Long userId, int amount, CookieLog.CookieLogType type) {
-        User user = userRepository.findById(userId)
+        // 1. 비관적 락을 사용하여 유저 정보를 가져옴 (다른 트랜잭션 대기)
+        User user = userRepository.findByIdForUpdate(userId)
                 .orElseThrow(() -> new AppException(ErrorCode.USER_NOT_FOUND));
 
-        // 쿠키 차감 시 잔액 검증
+        // 2. 검증
         if (amount < 0 && user.getCookieCnt() < Math.abs(amount)) {
             throw new AppException(ErrorCode.NOT_ENOUGH_COOKIES);
         }
 
-        // 1. 유저 쿠키 개수 업데이트
+        // 3. 업데이트 및 로그 저장
         user.updateCookieCnt(amount);
 
-        // 2. 트랜잭션 로그 저장
         CookieLog log = CookieLog.builder()
                 .user(user)
                 .amount(amount)

--- a/src/main/java/com/cookeep/cookeep/domain/cookie/application/CookieService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/cookie/application/CookieService.java
@@ -26,7 +26,9 @@ public class CookieService {
 
     // 쿠키 사용/지급 공통 로직
     @Transactional
-    public void updateCookie(Long userId, int amount, CookieLog.CookieLogType type) {
+    public void updateCookie(Long userId, CookieLog.CookieLogType type) {
+        int amount = type.getDefaultAmount();
+
         // 1. 비관적 락을 사용하여 유저 정보를 가져옴 (다른 트랜잭션 대기)
         User user = userRepository.findByIdForUpdate(userId)
                 .orElseThrow(() -> new AppException(ErrorCode.USER_NOT_FOUND));

--- a/src/main/java/com/cookeep/cookeep/domain/cookie/application/CookieService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/cookie/application/CookieService.java
@@ -34,7 +34,8 @@ public class CookieService {
                 .orElseThrow(() -> new AppException(ErrorCode.USER_NOT_FOUND));
 
         // 2. 검증
-        if (amount < 0 && user.getCookieCnt() < Math.abs(amount)) {
+        if (amount == 0 ||
+                amount < 0 && (user.getCookieCnt() < Math.abs(amount))) {
             throw new AppException(ErrorCode.NOT_ENOUGH_COOKIES);
         }
 

--- a/src/main/java/com/cookeep/cookeep/domain/cookie/dao/CookieLogRepository.java
+++ b/src/main/java/com/cookeep/cookeep/domain/cookie/dao/CookieLogRepository.java
@@ -1,0 +1,10 @@
+package com.cookeep.cookeep.domain.cookie.dao;
+
+import com.cookeep.cookeep.domain.cookie.entity.CookieLog;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CookieLogRepository extends JpaRepository<CookieLog, Long> {
+
+}

--- a/src/main/java/com/cookeep/cookeep/domain/cookie/entity/CookieLog.java
+++ b/src/main/java/com/cookeep/cookeep/domain/cookie/entity/CookieLog.java
@@ -1,0 +1,46 @@
+package com.cookeep.cookeep.domain.cookie.entity;
+
+import com.cookeep.cookeep.common.entity.BaseEntity;
+import com.cookeep.cookeep.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Table(name = "Cookie_Logs")
+public class CookieLog extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long cookieLogId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(nullable = false)
+    private int amount; // 증감분 (예: -1, +5)
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private CookieLogType type;
+
+    public enum CookieLogType {
+        // --- 지급 ---
+        ONBOARDING_INGREDIENT,    // 최초 냉장고 재료 등록
+        ONBOARDING_RECIPE,        // 최초 레시피 받기 + 소비
+        DAILY_FIRST_CONSUME,      // 당일 최초 식재료 소비
+        RECIPE_LOAD,              // 레시피 불러오기
+        FOOD_PHOTO_REG,           // 음식 사진 등록
+        WEEKLY_GOAL_ACHIEVE,      // 금주 목표 달성 보너스
+        URGENT_INGREDIENT_USE,    // 유통기한 임박 재료 사용 보너스
+        PLANT_HARVEST_REWARD,     // 식물 키우기 완료 보너스
+        RETENTION_REWARD,         // 14일 이상 미접속 후 복귀 보너스
+
+        // --- 차감 ---
+        WATERING,                 // 식물 물 주기 (쿠키 10개 소모)
+        REVIVE_PLANT              // 식물 다시 살리기 (쿠키 5개 소모)
+    }
+}

--- a/src/main/java/com/cookeep/cookeep/domain/cookie/entity/CookieLog.java
+++ b/src/main/java/com/cookeep/cookeep/domain/cookie/entity/CookieLog.java
@@ -27,20 +27,28 @@ public class CookieLog extends BaseEntity {
     @Column(nullable = false)
     private CookieLogType type;
 
+    @Getter
     public enum CookieLogType {
         // --- 지급 ---
-        ONBOARDING_INGREDIENT,    // 최초 냉장고 재료 등록
-        ONBOARDING_RECIPE,        // 최초 레시피 받기 + 소비
-        DAILY_FIRST_CONSUME,      // 당일 최초 식재료 소비
-        RECIPE_LOAD,              // 레시피 불러오기
-        FOOD_PHOTO_REG,           // 음식 사진 등록
-        WEEKLY_GOAL_ACHIEVE,      // 금주 목표 달성 보너스
-        URGENT_INGREDIENT_USE,    // 유통기한 임박 재료 사용 보너스
-        PLANT_HARVEST_REWARD,     // 식물 키우기 완료 보너스
-        RETENTION_REWARD,         // 14일 이상 미접속 후 복귀 보너스
+        ONBOARDING_INGREDIENT(1),          // 최초 냉장고 재료 등록
+
+        BASIC_DAILY_FIRST_CONSUME(1),      // 냉장고 재료 직접 소비 (당일 최초)
+        BASIC_LOAD_RECIPE(1),              // 마이쿠킵에 레시피 등록
+        BASIC_FOOD_PHOTO_REG(1),           // 음식 사진 등록
+
+        BONUS_WEEKLY_GOAL_ACHIEVE(1),      // 주간 목표 달성
+        BONUS_URGENT_INGREDIENT_USE(3),    // 유통기한 임박 재료 레시피 + 소비
+        BONUS_PLANT_HARVEST_REWARD(15),    // 식물 키우기 완료 보너스
+        BONUS_RETENTION_REWARD(1),         // 14일 이상 미접속 후 복귀 보너스
 
         // --- 차감 ---
-        WATERING,                 // 식물 물 주기 (쿠키 10개 소모)
-        REVIVE_PLANT              // 식물 다시 살리기 (쿠키 5개 소모)
+        WATERING(10),                      // 식물 물 주기 (쿠키 10개 소모)
+        REVIVE_PLANT(5);                   // 식물 다시 살리기 (쿠키 5개 소모)
+
+        private final int defaultAmount;
+
+        CookieLogType(int defaultAmount) {
+            this.defaultAmount = defaultAmount;
+        }
     }
 }

--- a/src/main/java/com/cookeep/cookeep/domain/plant/application/UserPlantService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/plant/application/UserPlantService.java
@@ -3,6 +3,8 @@ package com.cookeep.cookeep.domain.plant.application;
 import com.cookeep.cookeep.api.dto.response.MyPlantResponse;
 import com.cookeep.cookeep.common.exception.AppException;
 import com.cookeep.cookeep.common.exception.ErrorCode;
+import com.cookeep.cookeep.domain.cookie.application.CookieService;
+import com.cookeep.cookeep.domain.cookie.entity.CookieLog;
 import com.cookeep.cookeep.domain.plant.dao.PlantRepository;
 import com.cookeep.cookeep.domain.plant.dao.UserPlantRepository;
 import com.cookeep.cookeep.domain.plant.entity.Plant;
@@ -22,6 +24,7 @@ public class UserPlantService {
     private final UserPlantRepository userPlantRepository;
     private final UserRepository userRepository;
     private final PlantRepository plantRepository;
+    private final CookieService cookieService;
 
     // 유저 보유 식물 목록 조회
     @Transactional(readOnly = true) // 성능 최적화를 위해 읽기 전용 설정
@@ -125,10 +128,15 @@ public class UserPlantService {
         }
 
         // 3. 쿠키 차감 로직 (Cookie 브랜치에서 구현 예정)
-        // TODO: useCookie(userId, 1);
+        cookieService.updateCookie(userId, -10, CookieLog.CookieLogType.WATERING);
 
         // 4. 물 주기 수행
         userPlant.giveWater();
+
+        // 5. 수확 완료 체크 및 보상 지급
+        if (userPlant.getIsHarvested()) {
+            cookieService.updateCookie(userId, 15, CookieLog.CookieLogType.PLANT_HARVEST_REWARD);
+        }
     }
 
     // 식물 살리기
@@ -149,7 +157,7 @@ public class UserPlantService {
         }
 
         // 4. 쿠키 차감 로직 (feat/Cookie 브랜치에서 구현 예정)
-        // TODO: useCookie(userId, 5); // 살리기는 쿠키 5개 소모 정책
+        cookieService.updateCookie(userId, -5, CookieLog.CookieLogType.REVIVE_PLANT);
 
         // 5. 식물 살리기 수행 (isFrozen = false)
         userPlant.revive();

--- a/src/main/java/com/cookeep/cookeep/domain/plant/application/UserPlantService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/plant/application/UserPlantService.java
@@ -127,7 +127,7 @@ public class UserPlantService {
             throw new AppException(ErrorCode.NOT_MY_PLANT); // 403
         }
 
-        // 3. 쿠키 차감 로직 (Cookie 브랜치에서 구현 예정)
+        // 3. 쿠키 차감 로직
         cookieService.updateCookie(userId, -10, CookieLog.CookieLogType.WATERING);
 
         // 4. 물 주기 수행
@@ -156,7 +156,7 @@ public class UserPlantService {
             throw new AppException(ErrorCode.PLANT_NOT_FROZEN); // 400
         }
 
-        // 4. 쿠키 차감 로직 (feat/Cookie 브랜치에서 구현 예정)
+        // 4. 쿠키 차감 로직
         cookieService.updateCookie(userId, -5, CookieLog.CookieLogType.REVIVE_PLANT);
 
         // 5. 식물 살리기 수행 (isFrozen = false)

--- a/src/main/java/com/cookeep/cookeep/domain/plant/application/UserPlantService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/plant/application/UserPlantService.java
@@ -128,14 +128,14 @@ public class UserPlantService {
         }
 
         // 3. 쿠키 차감 로직
-        cookieService.updateCookie(userId, -10, CookieLog.CookieLogType.WATERING);
+        cookieService.updateCookie(userId, CookieLog.CookieLogType.WATERING);
 
         // 4. 물 주기 수행
         userPlant.giveWater();
 
         // 5. 수확 완료 체크 및 보상 지급
         if (userPlant.getIsHarvested()) {
-            cookieService.updateCookie(userId, 15, CookieLog.CookieLogType.PLANT_HARVEST_REWARD);
+            cookieService.updateCookie(userId, CookieLog.CookieLogType.BONUS_PLANT_HARVEST_REWARD);
         }
     }
 
@@ -157,7 +157,7 @@ public class UserPlantService {
         }
 
         // 4. 쿠키 차감 로직
-        cookieService.updateCookie(userId, -5, CookieLog.CookieLogType.REVIVE_PLANT);
+        cookieService.updateCookie(userId, CookieLog.CookieLogType.REVIVE_PLANT);
 
         // 5. 식물 살리기 수행 (isFrozen = false)
         userPlant.revive();

--- a/src/main/java/com/cookeep/cookeep/domain/user/dao/UserRepository.java
+++ b/src/main/java/com/cookeep/cookeep/domain/user/dao/UserRepository.java
@@ -1,10 +1,19 @@
 package com.cookeep.cookeep.domain.user.dao;
 
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.cookeep.cookeep.domain.user.entity.User;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
 
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select u from User u where u.userId = :id")
+    Optional<User> findByIdForUpdate(@Param("id") Long id);
 }

--- a/src/main/java/com/cookeep/cookeep/domain/user/entity/User.java
+++ b/src/main/java/com/cookeep/cookeep/domain/user/entity/User.java
@@ -61,7 +61,6 @@ public class User extends BaseEntity {
 	// @Builder 어노테이션 사용중이므로 기본값이 있는 필드에 @Builder.Default 추가
 	@Builder.Default
 	@Column(nullable = false)
-	@Builder.Default
 	private int cookieCnt = 0;
 
 	@Builder.Default
@@ -91,5 +90,9 @@ public class User extends BaseEntity {
 		if (this.isProfileAutoUpdate) {
 			this.profilePlant = userPlant;
 		}
+	}
+
+	public void updateCookieCnt(int amount) {
+		this.cookieCnt += amount;
 	}
 }

--- a/src/main/java/com/cookeep/cookeep/domain/user/entity/User.java
+++ b/src/main/java/com/cookeep/cookeep/domain/user/entity/User.java
@@ -60,6 +60,7 @@ public class User extends BaseEntity {
 
 	// @Builder 어노테이션 사용중이므로 기본값이 있는 필드에 @Builder.Default 추가
 	@Column(nullable = false)
+	@Builder.Default
 	private int cookieCnt = 0;
 
 	@Builder.Default


### PR DESCRIPTION
# Related Issue
#13 

# Description
- 쿠키 도메인 기본 세팅 완료 (CookieLog, CookieLogRepository, CookieService)
- 식물 물주기 & 살리기에 쿠키 차감 로직 반영
- 보유 쿠키 조회 기능 API 구현

     - CookieController (보유 쿠키 조회 `GET` `/api/users/me/cookies`) jwt 토큰 방식으로 변경

# Changes
### 1. CookieLog 

CookieLog 엔티티 내에 `CookieLogType` enum을 보시면, 
현재 정책서상 쿠키 지급 및 차감이 되는 모든 경우의 수에 맞는 enum을 만들어두었습니다. 
각자 담당 기능 개발하시면서 쿠키 지급 및 차감 로직이 필요할 때 참고하셔서 사용하시면 될 것 같습니다!! (수정 필요하면 알려주세요!)
쿠키 지급 및 차감 로직은 아래에 적어두었듯이 
```java
updateCookie(userId, -10, CookieLog.CookieLogType.WATERING)
```
이런 식으로 userId, 증감분, 쿠키로그타입 함께 넘겨주시면 됩니다.


⬇️ UserPlantService 참고 ⬇️

```java
    // 식물에게 물 주기
        @Transactional
        public void giveWater(Long userId, Long userPlantId) {
            // 1. 식물 조회
            UserPlant userPlant = userPlantRepository.findById(userPlantId)
                    .orElseThrow(() -> new AppException(ErrorCode.PLANT_NOT_FOUND)); // 404
    
            // 2. 권한 체크
            if (!userPlant.getUser().getUserId().equals(userId)) {
                throw new AppException(ErrorCode.NOT_MY_PLANT); // 403
            }
    
           // 3. 쿠키 차감 로직
            cookieService.updateCookie(userId, -10, CookieLog.CookieLogType.WATERING);
    
            // 4. 물 주기 수행
            userPlant.giveWater();
    
            // 5. 수확 완료 체크 및 보상 지급
            if (userPlant.getIsHarvested()) {
                cookieService.updateCookie(userId, 15, CookieLog.CookieLogType.PLANT_HARVEST_REWARD);
            }
        }
    
        // 식물 살리기
        @Transactional
        public void revivePlant(Long userId, Long userPlantId) {
            // 1. 식물 조회
            UserPlant userPlant = userPlantRepository.findById(userPlantId)
                    .orElseThrow(() -> new AppException(ErrorCode.PLANT_NOT_FOUND)); // 404
    
            // 2. 권한 체크
            if (!userPlant.getUser().getUserId().equals(userId)) {
                throw new AppException(ErrorCode.NOT_MY_PLANT); // 403
            }
    
            // 3. 상태 체크: 성장 정지 상태가 아니면 살릴 수 없음
            if (!userPlant.getIsFrozen()) {
                throw new AppException(ErrorCode.PLANT_NOT_FROZEN); // 400
            }
    
            // 4. 쿠키 차감 로직
            cookieService.updateCookie(userId, -5, CookieLog.CookieLogType.REVIVE_PLANT);
    
            // 5. 식물 살리기 수행 (isFrozen = false)
            userPlant.revive();
        }
 ```

### 2. 📁 common/util/AuthUtils 추가

Authorization 헤더에서 Bearer 토큰을 안전하게 추출하는 공통 유틸을 따로 만들어 분리하였습니다.
이 유틸 내에서 null, 잘못된 형식, 공백 등을 자동으로 처리하여 Authorization 헤더에서 Bearer 토큰을 안전하게 추출하도록 하고, 
컨트롤러에서는 매번 추출할 필요 없이 extractBearerToken만 호출하면 되도록 구현했습니다.

### 3. ErrorCode에 401 UNAUTHORIZED 추가

이건 일단 필요해서 만들었는데 만약 겹치면 merge 하면서 지우거나 조정하겠습니당