### PR TITLE
refactor: JWT 필터 및 UserPrincipal 기반 인증 구조 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,9 @@ dependencies {
 
 	// JSON 처리
 	implementation 'com.google.code.gson:gson:2.10.1'
+
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+	testImplementation 'org.springframework.security:spring-security-test'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/cookeep/cookeep/api/controller/AuthController.java
+++ b/src/main/java/com/cookeep/cookeep/api/controller/AuthController.java
@@ -2,11 +2,15 @@ package com.cookeep.cookeep.api.controller;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.cookeep.cookeep.api.dto.request.TokenRefreshRequestDTO;
 import com.cookeep.cookeep.api.dto.response.KakaoLoginResponseDTO;
+import com.cookeep.cookeep.api.dto.response.TokenRefreshResponseDTO;
 import com.cookeep.cookeep.common.dto.DataResponse;
 import com.cookeep.cookeep.domain.user.application.AuthService;
 
@@ -19,6 +23,13 @@ import lombok.RequiredArgsConstructor;
 public class AuthController {
 
 	private final AuthService authService;
+
+	@Operation(summary = "액세스 토큰 재발급 API")
+	@PostMapping("/refresh")
+	public ResponseEntity<DataResponse<TokenRefreshResponseDTO>> tokenRefresh(@RequestBody TokenRefreshRequestDTO tokenRefreshRequestDTO) {
+		return ResponseEntity.ok(DataResponse.from(authService.tokenRefresh(tokenRefreshRequestDTO)));
+
+	}
 
 	@Operation(summary = "카카오 로그인 API")
 	@GetMapping("/login/kakao")

--- a/src/main/java/com/cookeep/cookeep/api/controller/OnboardingController.java
+++ b/src/main/java/com/cookeep/cookeep/api/controller/OnboardingController.java
@@ -1,6 +1,7 @@
 package com.cookeep.cookeep.api.controller;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -11,6 +12,7 @@ import com.cookeep.cookeep.api.dto.request.AgreementRequestDTO;
 import com.cookeep.cookeep.api.dto.request.OnboardingRequestDTO;
 import com.cookeep.cookeep.api.dto.user.UserProvider;
 import com.cookeep.cookeep.common.dto.DataResponse;
+import com.cookeep.cookeep.config.UserPrincipal;
 import com.cookeep.cookeep.domain.onboarding.application.OnboardingService;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -25,7 +27,6 @@ import lombok.RequiredArgsConstructor;
 public class OnboardingController {
 
 	private final OnboardingService onboardingService;
-	private final UserProvider userProvider;
 
 	@Operation(summary = "약관 동의 여부 저장", description = "소셜로그인 회원을 대상으로 약관 동의 여부를 저장합니다.")
 	@ApiResponses(value = {
@@ -35,9 +36,10 @@ public class OnboardingController {
 	})
 	@PatchMapping("/agreements")
 	public ResponseEntity<DataResponse<Void>> saveAgreement(
+		@AuthenticationPrincipal UserPrincipal principal,
 		@RequestBody AgreementRequestDTO agreementRequestDTO
 		) {
-		Long userId = userProvider.getCurrentUserId();
+		Long userId = principal.userId();
 		onboardingService.saveAgreement(agreementRequestDTO, userId);
 		return ResponseEntity.ok(DataResponse.ok());
 	}
@@ -49,8 +51,10 @@ public class OnboardingController {
 		@ApiResponse(responseCode = "401", description = "회원 인증 실패, AccessToken이 없거나 유효하지 않음"),
 		@ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음")
 	})
-	public ResponseEntity<DataResponse<Void>> agreeMarketingPush() {
-		Long userId = userProvider.getCurrentUserId();
+	public ResponseEntity<DataResponse<Void>> agreeMarketingPush(
+		@AuthenticationPrincipal UserPrincipal principal
+	) {
+		Long userId = principal.userId();
 		onboardingService.agreeMarketingPush(userId);
 		return ResponseEntity.ok(DataResponse.ok());
 	}
@@ -64,9 +68,10 @@ public class OnboardingController {
 	})
 	@PostMapping("/onboarding")
 	public ResponseEntity<DataResponse<Void>> saveOnboarding(
+		@AuthenticationPrincipal UserPrincipal principal,
 		@Valid @RequestBody OnboardingRequestDTO onboardingRequestDTO
 	) {
-		Long userId = userProvider.getCurrentUserId();
+		Long userId = principal.userId();
 		onboardingService.saveOnboarding(userId, onboardingRequestDTO);
 		return ResponseEntity.ok(DataResponse.ok());
 	}

--- a/src/main/java/com/cookeep/cookeep/api/dto/request/TokenRefreshRequestDTO.java
+++ b/src/main/java/com/cookeep/cookeep/api/dto/request/TokenRefreshRequestDTO.java
@@ -1,0 +1,6 @@
+package com.cookeep.cookeep.api.dto.request;
+
+public record TokenRefreshRequestDTO(
+	String refreshToken
+) {
+}

--- a/src/main/java/com/cookeep/cookeep/api/dto/response/TokenRefreshResponseDTO.java
+++ b/src/main/java/com/cookeep/cookeep/api/dto/response/TokenRefreshResponseDTO.java
@@ -1,0 +1,6 @@
+package com.cookeep.cookeep.api.dto.response;
+
+public record TokenRefreshResponseDTO(
+	String accessToken
+) {
+}

--- a/src/main/java/com/cookeep/cookeep/common/exception/ErrorCode.java
+++ b/src/main/java/com/cookeep/cookeep/common/exception/ErrorCode.java
@@ -35,9 +35,9 @@ public enum ErrorCode {
 	INVALID_WEEKLY_GOAL_TARGET_COUNT(HttpStatus.BAD_REQUEST, "주간 목표가 설정된 경우 목표 횟수를 필수로 입력해야 합니다.", "ONBOARDING-002"),
 	INVALID_TARGET_COUNT(HttpStatus.BAD_REQUEST, "목표 횟수는 1에서 10 사이의 정수여야 합니다.", "ONBOARDING-003"),
 
-
 	// 401 UNAUTHORIZED (인증 관련)
 	UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증에 실패했습니다.", "AUTH-001"),
+	INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 리프레쉬 토큰입니다.", "AUTH-002"),
 
 	// 403 FORBIDDEN (권한 관련)
 	NOT_MY_PLANT(HttpStatus.FORBIDDEN, "해당 식물에 대한 권한이 없습니다.", "PLANT-001"),

--- a/src/main/java/com/cookeep/cookeep/config/JwtAuthenticationFilter.java
+++ b/src/main/java/com/cookeep/cookeep/config/JwtAuthenticationFilter.java
@@ -1,0 +1,60 @@
+package com.cookeep.cookeep.config;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import io.jsonwebtoken.JwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+	// JwtTokenProvider : 토큰 생성/검증/파싱
+	// JwtAuthenticationFilter : 요청에서 토큰을 추출하여 JwtTokenProvider로 검증, SecurityContext에 인증 정보 설정
+	// SecurityConfig : Spring Security 전반 설정
+
+	private final JwtTokenProvider jwtTokenProvider;
+
+	@Override
+	protected void doFilterInternal(HttpServletRequest request,
+		HttpServletResponse response,
+		FilterChain filterChain) throws ServletException, IOException {
+
+		// 요청 헤더의 Authorization 값을 가져옴
+		// "Bearer " 검사 후 토큰 추출, 잘못된 형식일 경우 null을 반환함
+		String token = extractBearerToken(request.getHeader(HttpHeaders.AUTHORIZATION));
+
+		try {
+			if (token != null && jwtTokenProvider.validateToken(token, false)) {
+				// 액세스 토큰이 존재하고 유효할 경우 userId를 추출
+				Long userId = jwtTokenProvider.getUserId(token, false);
+
+				UserPrincipal principal = new UserPrincipal(userId);
+
+				var authentication =
+					new UsernamePasswordAuthenticationToken(principal, null, List.of());
+
+				SecurityContextHolder.getContext().setAuthentication(authentication);
+			}
+		} catch (JwtException | IllegalArgumentException e) {
+			SecurityContextHolder.clearContext();
+		}
+
+		filterChain.doFilter(request, response);
+	}
+
+	private String extractBearerToken(String header) {
+		if (header == null) return null; // Authorization 헤더 없는 요청일 경우 null 반환
+		if (!header.startsWith("Bearer ")) return null; // "Bearer " 형식 아닐 경우 null 반환
+		String token = header.substring(7).trim();
+		return token.isEmpty() ? null : token;
+	}
+}

--- a/src/main/java/com/cookeep/cookeep/config/SecurityConfig.java
+++ b/src/main/java/com/cookeep/cookeep/config/SecurityConfig.java
@@ -1,0 +1,50 @@
+package com.cookeep.cookeep.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+	private final JwtTokenProvider jwtTokenProvider;
+
+	@Bean
+	public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+		http
+			.csrf(csrf -> csrf.disable())
+			.sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS)) // JWT 방식이므로 로그인 상태 저장 X
+			.formLogin(form -> form.disable()) // 별도의 로그인 api 존재하므로 스프링 시큐리티 기본 로그인 페이지는 비활성화하였음
+			.httpBasic(basic -> basic.disable())
+
+			.authorizeHttpRequests(auth -> auth
+				.requestMatchers(
+					// 아래 경로들은 로그인하지 않아도 접근 가능
+					// 나머지 경로는 모두 로그인해야 접근 가능함
+					"/api/auth/login/kakao",
+					"/api/auth/refresh",
+					"/swagger-ui/**",
+					"/v3/api-docs/**",
+					"/swagger-resources/**",
+					"/error"
+				).permitAll()
+
+				.anyRequest().authenticated()
+			)
+
+			// JWT 필터 먼저 실행
+			.addFilterBefore(
+				new JwtAuthenticationFilter(jwtTokenProvider),
+				UsernamePasswordAuthenticationFilter.class
+			);
+
+		return http.build();
+	}
+}

--- a/src/main/java/com/cookeep/cookeep/config/UserPrincipal.java
+++ b/src/main/java/com/cookeep/cookeep/config/UserPrincipal.java
@@ -1,0 +1,5 @@
+package com.cookeep.cookeep.config;
+
+// 현재 로그인한 사용자의 userId 정보를 담는 DTO
+public record UserPrincipal(Long userId) {
+}

--- a/src/main/java/com/cookeep/cookeep/domain/onboarding/application/OnboardingService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/onboarding/application/OnboardingService.java
@@ -17,6 +17,7 @@ import com.cookeep.cookeep.domain.onboarding.entity.GoalActionType;
 import com.cookeep.cookeep.domain.onboarding.entity.UserFoodPreference;
 import com.cookeep.cookeep.domain.onboarding.entity.UserOnboarding;
 import com.cookeep.cookeep.domain.onboarding.entity.WeeklyGoal;
+import com.cookeep.cookeep.domain.user.application.UserReader;
 import com.cookeep.cookeep.domain.user.dao.UserRepository;
 import com.cookeep.cookeep.domain.user.entity.User;
 
@@ -29,12 +30,12 @@ public class OnboardingService {
 	private final UserFoodPreferenceRepository userFoodPreferenceRepository;
 	private final UserOnboardingRepository userOnboardingRepository;
 	private final WeeklyGoalRepository weeklyGoalRepository;
+	private final UserReader userReader;
 
 	// 소셜 로그인 회원 대상 약관 동의 여부 저장
 	@Transactional
 	public void saveAgreement(AgreementRequestDTO agreementRequestDTO, Long userId) {
-		User user = userRepository.findById(userId)
-			.orElseThrow(() -> new AppException(ErrorCode.USER_NOT_FOUND));
+		User user = userReader.readById(userId);
 
 		// // 이미 마케팅 활용에 동의했는데 동일한 페이지에 재진입한 경우
 		// if (user.getMarketingConsent() != null) {
@@ -47,8 +48,7 @@ public class OnboardingService {
 	// 온보딩 과정에서 알림 켜기를 선택한 경우
 	@Transactional
 	public void agreeMarketingPush(Long userId) {
-		User user = userRepository.findById(userId)
-			.orElseThrow(() -> new AppException(ErrorCode.USER_NOT_FOUND));
+		User user = userReader.readById(userId);
 
 		// 알림 켜기 버튼을 누른 사용자만 해당 api 경로로 진입하므로 true로 설정
 		user.setMarketingPush(true);
@@ -56,8 +56,7 @@ public class OnboardingService {
 
 	@Transactional
 	public void saveOnboarding(Long userId, OnboardingRequestDTO onboardingRequestDTO) {
-		User user = userRepository.findById(userId)
-			.orElseThrow(() -> new AppException(ErrorCode.USER_NOT_FOUND));
+		User user = userReader.readById(userId);
 
 		// 서비스 플로우상 온보딩은 최초 1회만 하게 되지만,
 		// 중복 클릭, 네트워크 재시도 등으로 재요청이 들어오는 경우를 고려하여 업데이트 되도록 처리함

--- a/src/main/java/com/cookeep/cookeep/domain/user/application/AuthService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/user/application/AuthService.java
@@ -12,6 +12,7 @@ import com.cookeep.cookeep.api.dto.request.TokenRefreshRequestDTO;
 import com.cookeep.cookeep.api.dto.response.KakaoLoginResponseDTO;
 import com.cookeep.cookeep.api.dto.response.TokenRefreshResponseDTO;
 import com.cookeep.cookeep.config.JwtTokenProvider;
+import com.cookeep.cookeep.domain.onboarding.entity.UserOnboarding;
 import com.cookeep.cookeep.domain.user.dao.UserAuthRepository;
 import com.cookeep.cookeep.domain.user.dao.UserRepository;
 import com.cookeep.cookeep.domain.user.dao.UserSessionRepository;
@@ -119,13 +120,14 @@ public class AuthService {
 		String accessToken = jwtTokenProvider.createAccessToken(user.getUserId());
 		String refreshToken = jwtTokenProvider.createRefreshToken(user.getUserId());
 
-		userSessionRepository.save(
-			UserSession.builder()
+		UserSession userSession = userSessionRepository.findByUser(user)
+			.orElseGet(() -> UserSession.builder()
 				.user(user)
-				.refreshToken(refreshToken)
-				.expiresAt(LocalDateTime.now().plusDays(14))
-				.build()
-		);
+				.build());
+
+		userSession.update(refreshToken, LocalDateTime.now().plusDays(14));
+
+		userSessionRepository.save(userSession);
 
 		UserStatus userStatus = user.getUserStatus();
 		NextStep nextStep = null;

--- a/src/main/java/com/cookeep/cookeep/domain/user/application/AuthService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/user/application/AuthService.java
@@ -8,7 +8,9 @@ import java.util.Optional;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.cookeep.cookeep.api.dto.request.TokenRefreshRequestDTO;
 import com.cookeep.cookeep.api.dto.response.KakaoLoginResponseDTO;
+import com.cookeep.cookeep.api.dto.response.TokenRefreshResponseDTO;
 import com.cookeep.cookeep.config.JwtTokenProvider;
 import com.cookeep.cookeep.domain.user.dao.UserAuthRepository;
 import com.cookeep.cookeep.domain.user.dao.UserRepository;
@@ -19,6 +21,8 @@ import com.cookeep.cookeep.domain.user.entity.User;
 import com.cookeep.cookeep.domain.user.entity.UserAuth;
 import com.cookeep.cookeep.domain.user.entity.UserSession;
 import com.cookeep.cookeep.domain.user.entity.UserStatus;
+import com.cookeep.cookeep.common.exception.AppException;
+import com.cookeep.cookeep.common.exception.ErrorCode;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -33,6 +37,53 @@ public class AuthService {
 	private final UserAuthRepository userAuthRepository;
 	private final UserSessionRepository userSessionRepository;
 	private final JwtTokenProvider jwtTokenProvider;
+
+	@Transactional
+	public TokenRefreshResponseDTO tokenRefresh(TokenRefreshRequestDTO tokenRefreshRequestDTO) {
+		String refreshToken = tokenRefreshRequestDTO.refreshToken();
+
+		validateRefreshToken(refreshToken);
+
+		Long userId = extractUserIdFromRefreshToken(refreshToken);
+
+		UserSession userSession = userSessionRepository.findByUser_UserId(userId)
+			.orElseThrow(() -> new AppException(ErrorCode.INVALID_REFRESH_TOKEN));
+
+		// request로 들어온 리프레쉬 토큰이 DB에 저장되어있는 리프레쉬 토큰과 동일한지 검증
+		if (!userSession.getRefreshToken().equals(refreshToken)) {
+			throw new AppException(ErrorCode.INVALID_REFRESH_TOKEN);
+		}
+
+		// 유저 존재하는지 검증
+		User user = userRepository.findById(userId)
+			.orElseThrow(() -> new AppException(ErrorCode.USER_NOT_FOUND));
+
+		// 새로운 액세스토큰 발급
+		String accessToken = jwtTokenProvider.createAccessToken(user.getUserId());
+
+		return new TokenRefreshResponseDTO(accessToken);
+	}
+
+	private void validateRefreshToken(String refreshToken) {
+		// 위조/서명오류/만료된 리프레쉬 토큰인지 검증
+		boolean valid = jwtTokenProvider.validateToken(refreshToken, true);
+
+		if (!valid) {
+			throw new AppException(ErrorCode.INVALID_REFRESH_TOKEN); // 만료/위조/서명오류
+		}
+	}
+
+
+	private Long extractUserIdFromRefreshToken(String refreshToken) {
+		// 리프레쉬 토큰에서 UserId 추출
+		try {
+			return jwtTokenProvider.getUserId(refreshToken, true);
+		} catch (Exception e) {
+			throw new AppException(ErrorCode.INVALID_REFRESH_TOKEN);
+		}
+	}
+
+
 
 	// 카카오 로그인
 	@Transactional

--- a/src/main/java/com/cookeep/cookeep/domain/user/application/AuthService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/user/application/AuthService.java
@@ -38,6 +38,7 @@ public class AuthService {
 	private final UserAuthRepository userAuthRepository;
 	private final UserSessionRepository userSessionRepository;
 	private final JwtTokenProvider jwtTokenProvider;
+	private final UserReader userReader;
 
 	@Transactional
 	public TokenRefreshResponseDTO tokenRefresh(TokenRefreshRequestDTO tokenRefreshRequestDTO) {
@@ -55,9 +56,7 @@ public class AuthService {
 			throw new AppException(ErrorCode.INVALID_REFRESH_TOKEN);
 		}
 
-		// 유저 존재하는지 검증
-		User user = userRepository.findById(userId)
-			.orElseThrow(() -> new AppException(ErrorCode.USER_NOT_FOUND));
+		User user = userReader.readById(userId);
 
 		// 새로운 액세스토큰 발급
 		String accessToken = jwtTokenProvider.createAccessToken(user.getUserId());

--- a/src/main/java/com/cookeep/cookeep/domain/user/application/UserReader.java
+++ b/src/main/java/com/cookeep/cookeep/domain/user/application/UserReader.java
@@ -1,0 +1,24 @@
+package com.cookeep.cookeep.domain.user.application;
+
+import org.springframework.stereotype.Component;
+
+import com.cookeep.cookeep.common.exception.AppException;
+import com.cookeep.cookeep.common.exception.ErrorCode;
+import com.cookeep.cookeep.domain.user.dao.UserRepository;
+import com.cookeep.cookeep.domain.user.entity.User;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class UserReader {
+	private final UserRepository userRepository;
+
+	public User readById(Long userId) {
+		// 유저가 존재하는지 확인
+		User user = userRepository.findById(userId)
+			.orElseThrow(() -> new AppException(ErrorCode.USER_NOT_FOUND));
+
+		return user;
+	}
+}

--- a/src/main/java/com/cookeep/cookeep/domain/user/dao/UserSessionRepository.java
+++ b/src/main/java/com/cookeep/cookeep/domain/user/dao/UserSessionRepository.java
@@ -4,8 +4,10 @@ import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import com.cookeep.cookeep.domain.user.entity.User;
 import com.cookeep.cookeep.domain.user.entity.UserSession;
 
 public interface UserSessionRepository extends JpaRepository<UserSession, Long> {
 	Optional<UserSession> findByUser_UserId(Long userId);
+	Optional<UserSession> findByUser(User user);
 }

--- a/src/main/java/com/cookeep/cookeep/domain/user/dao/UserSessionRepository.java
+++ b/src/main/java/com/cookeep/cookeep/domain/user/dao/UserSessionRepository.java
@@ -1,8 +1,11 @@
 package com.cookeep.cookeep.domain.user.dao;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.cookeep.cookeep.domain.user.entity.UserSession;
 
 public interface UserSessionRepository extends JpaRepository<UserSession, Long> {
+	Optional<UserSession> findByUser_UserId(Long userId);
 }

--- a/src/main/java/com/cookeep/cookeep/domain/user/entity/UserSession.java
+++ b/src/main/java/com/cookeep/cookeep/domain/user/entity/UserSession.java
@@ -5,6 +5,7 @@ import java.time.LocalDateTime;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import com.cookeep.cookeep.common.entity.BaseEntity;
+import com.cookeep.cookeep.domain.onboarding.entity.CookingLevel;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -36,7 +37,7 @@ public class UserSession extends BaseEntity {
 	private Long sessionId;
 
 	@ManyToOne(fetch = FetchType.LAZY, optional = false)
-	@JoinColumn(name = "user_id", nullable = false)
+	@JoinColumn(name = "user_id", nullable = false, unique = true)
 	private User user;
 
 	@Setter
@@ -45,4 +46,9 @@ public class UserSession extends BaseEntity {
 
 	@Setter
 	private LocalDateTime expiresAt;
+
+	public void update(String refreshToken, LocalDateTime expiresAt) {
+		this.refreshToken = refreshToken;
+		this.expiresAt = expiresAt;
+	}
 }


### PR DESCRIPTION
# Related Issue
#26 
</br></br>
# Description 

## JWT 필터 및 UserPrincipal 기반 인증 구조 적용
- JwtAuthenticationFilter를 추가하여 JWT 검증을 공통 처리하도록 변경
- Spring Security의 SecurityContext에 인증 정보를 설정하는 구조로 변경
- 인증된 사용자 정보는 UserPrincipal 객체로 관리
- 컨트롤러에서 Request에 `@AuthenticationPrincipal UserPrincipal principal` 추가하여 사용 가능
- userId는 `Long userId = principal.userId();`와 같이 받아오면 됨

</br></br>
## 액세스 토큰 갱신 API 구현
- 액세스 토큰 만료시 리프레쉬 토큰을 이용하여 액세스 토큰 갱신 가능

</br></br>
## UserSession unique 제약 추가
- **사용자당 하나의 세션만 유지하도록** UserSession 테이블에 user_id **UNIQUE 제약 추가**
- 로그인 시 기존 세션 존재할 경우 refresh token과 만료 시간을 갱신
- 기존 세션 존재하지 않을 경우 신규 세션을 생성함

</br></br>
## User 조회 로직 공통화를 위한 UserReader 분리
- 여러 서비스에서 반복적으로 사용되던 **유저 조회 및 예외 처리 로직**을 **UserReader로 분리**하였습니다.
- 기존 코드
  - 		User user = userRepository.findById(userId)
			.orElseThrow(() -> new AppException(ErrorCode.USER_NOT_FOUND));
- UserReader 적용 코드
  - `User user = userReader.readById(userId);`

</br></br>
# Changes
- JWT 인증 필터 및 UserPrincipal 구조 추가
- SecurityConfig 설정 변경
- 액세스 토큰 갱신 API 구현
- UserSession user_id UNIQUE 제약 추가
- UserReader 추가 및 AuthService, OnboardingService 내 반영