### PR TITLE
Infra: AWS EC2 + Docker 기반 CI/CD 파이프라인 구축 및 CORS 설정

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+.git
+.github
+.idea
+.vscode
+build
+bin
+out
+*.md
+.env
+.env.*
+application-local.yml
+application-secret.yaml
+application-secret.yml

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,8 @@ name: CI/CD Pipeline
 
 on:
   push:
-    branches: [ develop, infra/27-cicd ]
+    branches: [ develop ]
+  workflow_dispatch:
 
 jobs:
   build-and-deploy:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,64 @@
+name: CI/CD Pipeline
+
+on:
+  push:
+    branches: [ develop, infra/27-cicd ]
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Build with Gradle
+        run: ./gradlew bootJar
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ secrets.DOCKER_USERNAME }}/cookeep:latest
+
+      - name: Deploy to EC2
+        uses: appleboy/ssh-action@v1.2.0
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ubuntu
+          key: ${{ secrets.EC2_SSH_KEY }}
+          script: |
+            docker pull ${{ secrets.DOCKER_USERNAME }}/cookeep:latest
+            docker stop cookeep || true
+            docker rm cookeep || true
+            docker run -d \
+              --name cookeep \
+              -p 8080:8080 \
+              -e DB_URL=${{ secrets.DB_URL }} \
+              -e DB_USERNAME=${{ secrets.DB_USERNAME }} \
+              -e DB_PASSWORD=${{ secrets.DB_PASSWORD }} \
+              -e CLIENT_ID=${{ secrets.CLIENT_ID }} \
+              -e CLIENT_SECRET=${{ secrets.CLIENT_SECRET }} \
+              -e REDIRECT_URI=${{ secrets.REDIRECT_URI }} \
+              -e JWT_ACCESS_SECRET_KEY=${{ secrets.JWT_ACCESS_SECRET_KEY }} \
+              -e JWT_REFRESH_SECRET_KEY=${{ secrets.JWT_REFRESH_SECRET_KEY }} \
+              -e GEMINI_API_KEY=${{ secrets.GEMINI_API_KEY }} \
+              -e YOUTUBE_API_KEY=${{ secrets.YOUTUBE_API_KEY }} \
+              ${{ secrets.DOCKER_USERNAME }}/cookeep:latest
+            docker image prune -f

--- a/.gitignore
+++ b/.gitignore
@@ -37,8 +37,7 @@ out/
 .vscode/
 
 # Secret Configuration
-application.yaml
-application.yml
+application-local.yml
 application-secret.yaml
 application-secret.yml
 **/application-secret.yaml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,12 @@
 # Stage 1: Build
-FROM gradle:8.12-jdk17 AS build
+FROM eclipse-temurin:17-jdk AS build
 WORKDIR /app
-COPY build.gradle settings.gradle ./
+COPY gradlew settings.gradle build.gradle ./
 COPY gradle ./gradle
-RUN gradle dependencies --no-daemon || true
+RUN chmod +x gradlew
+RUN ./gradlew dependencies --no-daemon || true
 COPY src ./src
-RUN gradle bootJar --no-daemon
+RUN ./gradlew bootJar --no-daemon
 
 # Stage 2: Run
 FROM eclipse-temurin:17-jre

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+# Stage 1: Build
+FROM gradle:8.12-jdk17 AS build
+WORKDIR /app
+COPY build.gradle settings.gradle ./
+COPY gradle ./gradle
+RUN gradle dependencies --no-daemon || true
+COPY src ./src
+RUN gradle bootJar --no-daemon
+
+# Stage 2: Run
+FROM eclipse-temurin:17-jre
+WORKDIR /app
+COPY --from=build /app/build/libs/*.jar app.jar
+EXPOSE 8080
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/src/main/java/com/cookeep/cookeep/config/SecurityConfig.java
+++ b/src/main/java/com/cookeep/cookeep/config/SecurityConfig.java
@@ -1,5 +1,7 @@
 package com.cookeep.cookeep.config;
 
+import java.util.List;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -8,6 +10,9 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 @Configuration
 @EnableWebSecurity
@@ -17,8 +22,22 @@ public class SecurityConfig {
 	private final JwtTokenProvider jwtTokenProvider;
 
 	@Bean
+	public CorsConfigurationSource corsConfigurationSource() {
+		CorsConfiguration config = new CorsConfiguration();
+		config.setAllowedOrigins(List.of("*")); // TODO: 추후 프론트엔드 도메인으로 설정 예정
+		config.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
+		config.setAllowedHeaders(List.of("*"));
+		config.setAllowCredentials(false);
+
+		UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+		source.registerCorsConfiguration("/**", config);
+		return source;
+	}
+
+	@Bean
 	public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
 		http
+			.cors(cors -> cors.configurationSource(corsConfigurationSource()))
 			.csrf(csrf -> csrf.disable())
 			.sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS)) // JWT 방식이므로 로그인 상태 저장 X
 			.formLogin(form -> form.disable()) // 별도의 로그인 api 존재하므로 스프링 시큐리티 기본 로그인 페이지는 비활성화하였음

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -34,8 +34,10 @@ jwt:
 
 google:
   gemini:
+    api-key: ${GEMINI_API_KEY}
     model: gemini-2.5-flash
   youtube:
+    api-key: ${YOUTUBE_API_KEY}
 
 ai:
   recipe:


### PR DESCRIPTION
# Related Issue
CLOSE #27 

# Description
GitHub Actions를 활용한 CI/CD 파이프라인을 구축하고, AWS EC2에 Docker 컨테이너 기반으로 자동 배포되는 환경을 구성했습니다.

 ### CI/CD 파이프라인 (.github/workflows/deploy.yml)                                                                                                             
  - **develop 브랜치에 push 시 자동 실행**                                                                                                                              
  - workflow_dispatch를 통한 수동 실행 지원 (push 없이도 원하는 브랜치 기준으로 파이프라인을 실행 가능함. 인프라 수정 후 테스트할 때 유용)                                                                                                                       
  - 파이프라인 흐름: Gradle 빌드 → Docker 이미지 빌드 → Docker Hub push → EC2 SSH 접속 → 컨테이너 배포                                                            
  - 환경변수는 GitHub Secrets에서 docker run -e 옵션으로 주입                                                                                                     
                                                                                                                                                                  
  ### Docker 환경 구성 (Dockerfile, .dockerignore)                                                                                                                
  - 멀티 스테이지 빌드 적용 (빌드: temurin JDK 17, 실행: temurin JRE 17)                                                                                          
  - gradlew를 사용하여 프로젝트 Gradle 버전과 일치하도록 구성                                                                                                     
  - 의존성 레이어를 분리하여 Docker 캐시 효율화                                                                                                                 
  - .dockerignore로 불필요한 파일(.git, .idea, build 등) 제외                                                                                                     
                                                                                                                                                                  
  ### CORS 설정 (SecurityConfig.java)                                                                                                                             
  - Spring Security 필터 체인에 CORS 설정 추가                                                                                                                    
  - 현재 모든 origin 허용 (추후에 프론트엔드 도메인으로 변경 예정)                                                                                                   
  - 허용 메서드: GET, POST, PUT, PATCH, DELETE, OPTIONS                                                                                                           
                                                                                                                                                                  
  ### 설정 파일 정리                                                                                                                                              
  - .gitignore에서 application.yaml 제거 (플레이스홀더만 포함되어 있어 추적 가능)                                                                                 
  - application.yaml에 Gemini, YouTube API 키 플레이스홀더 추가

  ### 참고 사항
  - 일단 Gemini, YouTube API 키는 우선 @chwwwon 형원님이 알려주신 방법대로 제가 생성한 걸로 넣어두었는데, 연동하면서 제한 걸리면 다른 분껄로 바꿔넣고 그런 식으로 하면 될까요? 아니면 제미나이 키 지금 무료 등급인데 유료로 전환하는 게 있는지? 그러면 제한 없는지?? 궁금                                                       
                                                                                                                                                                  
  ## GitHub Secrets 목록                                                                                                                                          
  | Secret | 용도 |                                                                                                                                               
  |--------|------|                                                                                                                                               
  | DOCKER_USERNAME / DOCKER_PASSWORD | Docker Hub 인증 |                                                                                                         
  | EC2_HOST / EC2_SSH_KEY | EC2 SSH 접속 |                                                                                                                       
  | DB_URL / DB_USERNAME / DB_PASSWORD | RDS 접속 |                                                                                                               
  | CLIENT_ID / CLIENT_SECRET / REDIRECT_URI | 카카오 로그인 |                                                                                                    
  | JWT_ACCESS_SECRET_KEY / JWT_REFRESH_SECRET_KEY | JWT 토큰 |                                                                                                   
  | GEMINI_API_KEY / YOUTUBE_API_KEY | 외부 API | 


# Changes
  - `.gitignore` — application.yaml Git 추적 허용                                                                                                                 
  - `application.yaml` — Gemini, YouTube API 키 플레이스홀더 추가                                                                                                 
  - `Dockerfile` — 멀티 스테이지 빌드 구성                                                                                                                        
  - `.dockerignore` — Docker 빌드 시 불필요한 파일 제외                                                                                                           
  - `.github/workflows/deploy.yml` — CI/CD 파이프라인                                                                                                             
  - `SecurityConfig.java` — CORS 설정 추가

# Test
  - [x] GitHub Actions CI/CD 파이프라인 정상 동작 확인                                                                                                            
  - [x] EC2 Docker 컨테이너 정상 실행 확인                                                                                                                        
  - [x] Swagger UI 접속 확인 (http://52.78.143.125:8080/swagger-ui/index.html)