### PR TITLE
Feat: (MAIN07) AI 대화 즐겨찾기 등록/삭제

### DIFF
--- a/src/main/java/com/cookeep/cookeep/api/controller/AiRecipeController.java
+++ b/src/main/java/com/cookeep/cookeep/api/controller/AiRecipeController.java
@@ -263,4 +263,32 @@ public class AiRecipeController {
 
         return ResponseEntity.ok(DataResponse.ok());
     }
+
+    @Operation(
+            summary = "(MAIN07) AI 대화 세션 즐겨찾기 추가/삭제",
+            description = "특정 세션의 즐겨찾기 상태를 변경합니다. (T -> F / F -> T)"
+    )
+    @SecurityRequirements
+    @ApiErrorCodeExamples({
+            ErrorCode.UNAUTHORIZED,
+            ErrorCode.AI_SESSION_NOT_FOUND,
+            ErrorCode.AI_SESSION_FORBIDDEN
+    })
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "즐겨찾기 상태 변경 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content),
+            @ApiResponse(responseCode = "403", description = "본인의 대화 세션이 아님", content = @Content),
+            @ApiResponse(responseCode = "404", description = "세션을 찾을 수 없음", content = @Content)
+    })
+    @PatchMapping("/sessions/{sessionId}")
+    public ResponseEntity<DataResponse<Void>> toggleFavorite(
+            @AuthenticationPrincipal(expression = "userId") Long userId,
+            @Parameter(description = "세션 ID", required = true)
+            @PathVariable Long sessionId
+    ) {
+
+        aiRecipeService.toggleFavorite(userId, sessionId);
+
+        return ResponseEntity.ok(DataResponse.ok());
+    }
 }

--- a/src/main/java/com/cookeep/cookeep/domain/recipe/application/AiRecipeService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/recipe/application/AiRecipeService.java
@@ -276,6 +276,28 @@ public class AiRecipeService {
         aiSessionRepository.delete(session);
     }
 
+    // (MAIN07) AI 대화 세션 즐겨찾기 추가/삭제
+    public void toggleFavorite(Long userId, Long sessionId) {
+        // 1. 세션 조회
+        AiSession session = aiSessionRepository.findById(sessionId)
+                .orElseThrow(() -> new AppException(ErrorCode.AI_SESSION_NOT_FOUND));
+
+        // 2. 본인 세션 여부 체크
+        if (!session.getUserId().equals(userId)) {
+            throw new AppException(ErrorCode.AI_SESSION_FORBIDDEN);
+        }
+
+        // 3. 즐겨찾기 상태 변경 (T -> F / F -> T)
+        if (Boolean.TRUE.equals(session.getIsPinned())) {
+            session.unpin();
+        } else {
+            session.pin();
+        }
+
+        // 4. 저장
+        aiSessionRepository.save(session);
+    }
+
     // --- 내부 메서드 ---
 
     // 요청 검증

--- a/src/main/java/com/cookeep/cookeep/domain/recipe/application/AiRecipeService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/recipe/application/AiRecipeService.java
@@ -224,12 +224,14 @@ public class AiRecipeService {
         // 즐겨찾기 대화 별도 정렬
         List<AiSessionListResponseDto.SessionSummary> pinned = allSessions.stream()
                 .filter(session -> Boolean.TRUE.equals(session.getIsPinned()))
+                .sorted((s1, s2) -> s2.getCreatedAt().compareTo(s1.getCreatedAt()))
                 .map(AiSessionListResponseDto.SessionSummary::from)
                 .collect(Collectors.toList());
 
         // 일반 대화 정렬
         List<AiSessionListResponseDto.SessionSummary> sessions = allSessions.stream()
                 .filter(session -> !Boolean.TRUE.equals(session.getIsPinned()))
+                .sorted((s1, s2) -> s2.getCreatedAt().compareTo(s1.getCreatedAt()))
                 .map(AiSessionListResponseDto.SessionSummary::from)
                 .collect(Collectors.toList());
 

--- a/src/main/java/com/cookeep/cookeep/domain/recipe/entity/AiSession.java
+++ b/src/main/java/com/cookeep/cookeep/domain/recipe/entity/AiSession.java
@@ -68,23 +68,6 @@ public class AiSession {
         this.completedAt = LocalDateTime.now();
     }
 
-    public void updateTitle(String title) {
-        this.title = title;
-    }
-
-    public void incrementAttemptNumber() {
-        if (this.attemptNumber == null) this.attemptNumber = 0;
-        this.attemptNumber++;
-    }
-
-    public boolean isChangeLimitExceeded(int max) {
-        return this.attemptNumber != null && this.attemptNumber >= max;
-    }
-
-    public boolean isCompletedSession() {
-        return Boolean.TRUE.equals(this.isCompleted);
-    }
-
     public void increaseAttempt() {
         this.attemptNumber++;
     }


### PR DESCRIPTION
# Related Issue
#34 

# Description
MAIN07 AI 세션 즐겨찾기 등록/삭제 구현
동일 API로 전송 /api/users/me/ai/recipes/sessions/{sessionId} 
- 등록: isPinned 상태가 false에서 true로 변경됨
- 삭제: isPinned 상태가 true에서 false로 변경됨

# Changes
- AiRecipeService에 즐겨찾기 등록 로직 추가
- AiRecipeController에 즐겨찾기 등록 로직 추가
- 유저 전체 대화 세션 조회시 시간 역순 정렬되도록 계산 로직 추가  

# Test checklist
- [X] 즐겨찾기 삭제 동작 확인 (포스트맨)
- [X] 즐겨찾기 등록 동작 확인 (포스트맨)
- [X] 전체 대화 세션 조회시 시간순 정렬 확인 (포스트맨)