### PR TITLE
fix: 카카오 로그인 redirect_uri를 프론트에서 전달받도록 변경

### DIFF
--- a/src/main/java/com/cookeep/cookeep/api/controller/AuthController.java
+++ b/src/main/java/com/cookeep/cookeep/api/controller/AuthController.java
@@ -35,7 +35,7 @@ public class AuthController {
 	@GetMapping("/login/kakao")
 	public ResponseEntity<DataResponse<KakaoLoginResponseDTO>> kakaoLogin(
 			@RequestParam String code,
-			@RequestParam("redirect_uri") String redirectUri) {
+			@RequestParam(value = "redirect_uri", required = false) String redirectUri) {
 		return ResponseEntity.ok(DataResponse.from(authService.kakaoLogin(code, redirectUri)));
 	}
 }

--- a/src/main/java/com/cookeep/cookeep/api/controller/AuthController.java
+++ b/src/main/java/com/cookeep/cookeep/api/controller/AuthController.java
@@ -33,7 +33,9 @@ public class AuthController {
 
 	@Operation(summary = "카카오 로그인 API")
 	@GetMapping("/login/kakao")
-	public ResponseEntity<DataResponse<KakaoLoginResponseDTO>> kakaoLogin(@RequestParam String code) {
-		return ResponseEntity.ok(DataResponse.from(authService.kakaoLogin(code)));
+	public ResponseEntity<DataResponse<KakaoLoginResponseDTO>> kakaoLogin(
+			@RequestParam String code,
+			@RequestParam("redirect_uri") String redirectUri) {
+		return ResponseEntity.ok(DataResponse.from(authService.kakaoLogin(code, redirectUri)));
 	}
 }

--- a/src/main/java/com/cookeep/cookeep/domain/user/application/AuthService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/user/application/AuthService.java
@@ -87,8 +87,8 @@ public class AuthService {
 
 	// 카카오 로그인
 	@Transactional
-	public KakaoLoginResponseDTO kakaoLogin(String code) {
-		String kakaoAccessToken = kakaoOAuthProvider.getKakaoAccessToken(code);
+	public KakaoLoginResponseDTO kakaoLogin(String code, String redirectUri) {
+		String kakaoAccessToken = kakaoOAuthProvider.getKakaoAccessToken(code, redirectUri);
 		KakaoUserInfoResponseDTO userInfo = kakaoOAuthProvider.getKakaoUserInfo(kakaoAccessToken);
 
 		String kakaoId = String.valueOf(userInfo.id());

--- a/src/main/java/com/cookeep/cookeep/domain/user/application/KakaoOAuthProvider.java
+++ b/src/main/java/com/cookeep/cookeep/domain/user/application/KakaoOAuthProvider.java
@@ -33,6 +33,8 @@ public class KakaoOAuthProvider implements OAuthProvider {
 	private String KakaoAccessTokenURL;
 	@Value("${kakao.auth.userInfoURL}")
 	private String KakaoUserInfoURL;
+	@Value("${kakao.auth.redirect}")
+	private String defaultRedirectUri;
 
 	private final UserRepository userRepository;
 
@@ -43,11 +45,13 @@ public class KakaoOAuthProvider implements OAuthProvider {
 
 	// 인가코드를 사용해 로그인할 유저의 카카오 액세스 토큰값을 받아옴
 	public String getKakaoAccessToken(String code, String redirectUri) {
+		String actualRedirectUri = (redirectUri != null) ? redirectUri : defaultRedirectUri;
+
 		MultiValueMap<String, String> form = new LinkedMultiValueMap<>();
 		form.add("grant_type", "authorization_code");
 		form.add("client_id", clientId);
 		form.add("client_secret", clientSecret);
-		form.add("redirect_uri", redirectUri);
+		form.add("redirect_uri", actualRedirectUri);
 		form.add("code", code);
 
 		KakaoTokenResponseDTO kakaoTokenResponseDTO = WebClient.create()

--- a/src/main/java/com/cookeep/cookeep/domain/user/application/KakaoOAuthProvider.java
+++ b/src/main/java/com/cookeep/cookeep/domain/user/application/KakaoOAuthProvider.java
@@ -33,8 +33,6 @@ public class KakaoOAuthProvider implements OAuthProvider {
 	private String KakaoAccessTokenURL;
 	@Value("${kakao.auth.userInfoURL}")
 	private String KakaoUserInfoURL;
-	@Value("${kakao.auth.redirect}")
-	private String redirectUri;
 
 	private final UserRepository userRepository;
 
@@ -44,7 +42,7 @@ public class KakaoOAuthProvider implements OAuthProvider {
 	}
 
 	// 인가코드를 사용해 로그인할 유저의 카카오 액세스 토큰값을 받아옴
-	public String getKakaoAccessToken(String code) {
+	public String getKakaoAccessToken(String code, String redirectUri) {
 		MultiValueMap<String, String> form = new LinkedMultiValueMap<>();
 		form.add("grant_type", "authorization_code");
 		form.add("client_id", clientId);

--- a/src/main/java/com/cookeep/cookeep/domain/user/application/OAuthProvider.java
+++ b/src/main/java/com/cookeep/cookeep/domain/user/application/OAuthProvider.java
@@ -5,6 +5,6 @@ import com.cookeep.cookeep.domain.user.entity.Provider;
 
 public interface OAuthProvider {
 	Provider provider();
-	String getKakaoAccessToken(String code);
+	String getKakaoAccessToken(String code, String redirectUri);
 	KakaoUserInfoResponseDTO getKakaoUserInfo(String accessToken);
 }


### PR DESCRIPTION
# Related Issue
CLOSE #43 

# Description
- 문제 상황
  기존에는 카카오 로그인 후 redirect_uri가 백엔드 주소로 설정되어 있어서:
  1. 카카오 로그인 완료 → 백엔드로 리다이렉트
  2. 백엔드가 JSON 응답 반환
  3. **브라우저에 JSON이 그대로 표시됨** (React 앱이 언마운트되어 응답 처리 불가)

- 해결 방법
  redirect_uri를 프론트엔드 주소로 변경하여:
  1. 카카오 로그인 완료 → **프론트엔드로 리다이렉트** (인가코드 전달)
  2. 프론트엔드가 `fetch()`로 백엔드 API 호출
  3. JSON 응답을 프론트엔드에서 정상적으로 처리 가능

- redirect_uri를 프론트엔드 주소로 변경한 이유 : 

  프론트 → 카카오: redirect_uri=https://12th-coo-keep-fe.vercel.app/kakao/callback
  백엔드 → 카카오: redirect_uri=https://api.cookeep.store/api/auth/login/kakao  ← 🔴 불일치!

     => 카카오가 "redirect_uri 불일치" 에러를 반환

- 카카오 로그인 시 **`redirect_uri`를 프론트엔드에서 파라미터로 전달받도록** 변경

- 프론트엔드가 인가코드를 먼저 받고, 백엔드 API를 호출하는 방식으로 로그인 플로우 개선

# Changes


파일 | 변경 내용
-- | --
AuthController | redirect_uri 파라미터 추가 (optional)
AuthService | redirectUri 파라미터 전달
KakaoOAuthProvider | redirectUri 파라미터 사용, 없으면 설정값 사용
OAuthProvider | 인터페이스 메서드 시그니처 변경


<!-- notionvc: 25e626d2-cb68-4942-990e-69eaee09f74b -->

# API 변경사항
  **Before:**
  GET /api/auth/login/kakao?code=인가코드

  **After:**
  GET /api/auth/login/kakao?code=인가코드&redirect_uri=프론트콜백URL (optional)
 
@0-x-14 주영님 담당 기능이나 토요일까지 코드작업 어려우신 관계로 (로그인 먼저 연동돼야 프론트측에서 다른 작업 진행하시기 원활하다고 하신 것 같아서) 제가 진행했습니다. API 변경사항 꼭 확인해주시면 감사하겠습니다!

그리고 위 내용 보시면 아시겠지만 배포 서버는 프론트에서 전달해주는 redirect_uri를 사용하기 때문에 기존에 환경변수에 있던 REDIRECT_URI(https://api.cookeep.store/api/auth/login/kakao)는 이제 배포 서버에서는 사용하지 않습니다.
다만, application.yaml과 깃허브 시크릿에는 우선 그대로 두었습니다. (저희 백엔드가 직접 테스트할 때는 프론트에서 주는 redirect_uri가 없기 때문에 대신 redirect_uri를 optional로 설정해 없을 경우 기본값을 사용함으로써, 기존에 백엔드로 직접 리다이렉트되는 방식을 유지하도록 한 것입니다)

정리:
  - 배포 서버 + 프론트 연동 → 프론트가 주는 redirect_uri 사용
  - 백엔드 직접 테스트 → 설정값 REDIRECT_URI 사용 (optional 기본값)               
  
혹시 이해 안 가면 말씀해주세용..