### PR TITLE
fix: Validation 예외 처리 로직 수정

### DIFF
--- a/src/main/java/com/cookeep/cookeep/common/dto/ErrorResponse.java
+++ b/src/main/java/com/cookeep/cookeep/common/dto/ErrorResponse.java
@@ -1,5 +1,7 @@
 package com.cookeep.cookeep.common.dto;
 
+import java.util.Map;
+
 import org.springframework.http.HttpStatus;
 
 import com.cookeep.cookeep.common.exception.ErrorCode;
@@ -15,12 +17,16 @@ public class ErrorResponse extends BaseResponse {
 	private final String method;
 	private final String requestURI;
 
-	private ErrorResponse(String code, String message, String method, String requestURI, HttpStatus httpStatus) {
+	private final Map<String, String> errors;
+
+	private ErrorResponse(String code, String message, String method, String requestURI,
+		Map<String, String> errors, HttpStatus httpStatus) {
 		super(httpStatus);
 		this.code = code;
 		this.message = message;
 		this.method = method;
 		this.requestURI = requestURI;
+		this.errors = errors;
 	}
 
 	public static ErrorResponse of(ErrorCode errorCode, HttpServletRequest request) {
@@ -29,6 +35,20 @@ public class ErrorResponse extends BaseResponse {
 			errorCode.getMessage(),
 			request.getMethod(),
 			request.getRequestURI(),
+			null, // errors가 없는 경우
+			errorCode.getHttpStatus()
+		);
+	}
+
+	// Validation 예외 전용 ErrorResponse 생성 메서드 (field errors 포함)
+	// 여러 필드에서 에러가 동시에 발생할 수 있으므로 Map 형태로 저장
+	public static ErrorResponse ofValidation(ErrorCode errorCode, Map<String, String> errors, HttpServletRequest request) {
+		return new ErrorResponse(
+			errorCode.getCode(),
+			errorCode.getMessage(),
+			request.getMethod(),
+			request.getRequestURI(),
+			errors, // Validation 실패 시 필드별 오류 메시지 (key: 필드명, value: 에러 메시지)
 			errorCode.getHttpStatus()
 		);
 	}

--- a/src/main/java/com/cookeep/cookeep/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/cookeep/cookeep/common/exception/GlobalExceptionHandler.java
@@ -17,6 +17,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
 
 import java.security.SignatureException;
+import java.util.Map;
 
 @Slf4j
 @RestControllerAdvice
@@ -57,18 +58,40 @@ public class GlobalExceptionHandler {
 	// Validation 실패 (필수값 누락, @Valid 검증 실패)
 	@ExceptionHandler(MethodArgumentNotValidException.class)
 	public ResponseEntity<ErrorResponse> handleValidationException(
-			MethodArgumentNotValidException e, HttpServletRequest request) {
+		MethodArgumentNotValidException e, HttpServletRequest request) {
+
 		log.error("Validation 에러 발생: {}", e.getBindingResult().getAllErrors().get(0).getDefaultMessage());
 		log.error("에러가 발생한 지점 {}, {}", request.getMethod(), request.getRequestURI());
 
-		ErrorResponse errorResponse = ErrorResponse.of(
-				ErrorCode.INGREDIENT_REQUIRED_FIELDS_MISSING,
-				request
+		Map<String, String> errors = new java.util.LinkedHashMap<>();
+
+		// 필드 에러
+		for (org.springframework.validation.FieldError fe : e.getBindingResult().getFieldErrors()) {
+			String msg = fe.getDefaultMessage(); // DTO 내 에러 메세지
+			if (msg == null || msg.isBlank()) msg = "요청 값이 올바르지 않습니다."; // 메세지가 비어있을 경우 기본 문구
+			// key와 value로 Map에 저장
+			// ex) SignupRequestDTO의 이메일 에러일 경우 key: "email", value: "이메일은 필수 입력 값입니다."
+			// 여러 필드에서 에러가 동시에 발생할 수 있으므로 Map 형태로 저장
+			// 동일 필드의 중복 에러는 첫 번째만 유지됨
+			errors.putIfAbsent(fe.getField(), msg);
+		}
+
+		// 글로벌 에러 (@PasswordMatch 같은 타입레벨)
+		for (org.springframework.validation.ObjectError oe : e.getBindingResult().getGlobalErrors()) {
+			String msg = oe.getDefaultMessage();
+			if (msg == null || msg.isBlank()) msg = "요청 값이 올바르지 않습니다.";
+			errors.putIfAbsent("_global", msg); // key를 _global로 처리
+		}
+
+		ErrorResponse errorResponse = ErrorResponse.ofValidation(
+			ErrorCode.INVALID_PARAMETER,
+			errors,
+			request
 		);
-		return ResponseEntity
-				.status(HttpStatus.BAD_REQUEST)
-				.body(errorResponse);
+
+		return ResponseEntity.status(org.springframework.http.HttpStatus.BAD_REQUEST).body(errorResponse);
 	}
+
 
 	// JSON 파싱 실패 또는 ENUM 타입 불일치
 	@ExceptionHandler(HttpMessageNotReadableException.class)


### PR DESCRIPTION
# Related Issue
#52 
</br></br>
# Description 

## 기존 문제 상황
- `@Valid` 검증이 실패했을 경우 무관한 도메인 api에서도 `INGREDIENT-001` 에러 코드가 반환되는 문제가 발생함
- 이는 `GlobalExceptionHandler`의 `handleValidationException`에서 Validation 예외를 공통 에러 코드가 아닌 **`ErrorCode.INGREDIENT_REQUIRED_FIELDS_MISSING`로 고정 처리하고 있었기 때문**
<img width="1550" height="377" alt="image" src="https://github.com/user-attachments/assets/fc08c6c8-d6fe-4c59-a294-17f6aae21e8e" />
</br></br>

## 해결 방안
### `ErrorResponse`에 **`ofValidation` 메서드 추가**
- Validation 예외 전용 응답 생성을 위해 `ErrorResponse.ofValidation()` 메서드 추가
- 기존 `of()` 메서드는 유지하여 기존 응답 구조와의 호환성 유지
- 사진과 같이 **필드별 검증 실패 메시지를 전달할 수 있도록** `Map<String, String> errors` 필드를 추가하였음
<img width="1495" height="422" alt="image" src="https://github.com/user-attachments/assets/a06b9886-4a02-4358-91cd-9cf3ba9b10f0" />
</br></br>

### handleValidationException 수정
- `MethodArgumentNotValidException` 발생 시 기존 도메인 고정 에러 코드 대신 **공통 에러 코드 `INVALID_PARAMETER`로 처리**하도록 수정
- `BindingResult`에서 `FieldError` 및 `GlobalError`를 추출하여 **필드별 Validation 메시지를 Map 형태로 구성**
- 구성된 errors를 `ErrorResponse.ofValidation()`을 통해 응답에 포함하도록 변경
</br>

### 결과
- Validation 예외가 특정 도메인 에러 코드로 반환되던 문제 해결
- 필드별 검증 메시지를 응답에 포함하도록 개선하였음
- 공통 에러 코드 사용으로 예외 처리 일관성 확보

</br></br>
# Changes
- `ErrorResponse`에 Validation 전용 팩토리 메서드 `ofValidation` 추가
- `errors (Map<String, String>)` 필드 추가
- `GlobalExceptionHandler`의 `handleValidationException` 로직 수정