### PR TITLE
fix: CORS 허용 도메인에 cookeep.store 추가

### DIFF
--- a/src/main/java/com/cookeep/cookeep/config/SecurityConfig.java
+++ b/src/main/java/com/cookeep/cookeep/config/SecurityConfig.java
@@ -33,7 +33,8 @@ public class SecurityConfig {
 		CorsConfiguration config = new CorsConfiguration();
 		config.setAllowedOrigins(List.of(
 			"http://localhost:5173",
-			"https://12th-coo-keep-fe.vercel.app"
+			"https://12th-coo-keep-fe.vercel.app",
+			"https://cookeep.store"
 		));
 		config.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
 		config.setAllowedHeaders(List.of("*"));


### PR DESCRIPTION
# Related Issue
CLOSE #58 

# Description
프론트엔드 커스텀 도메인(cookeep.store) 적용에 따라 CORS 허용 Origin에 `https://cookeep.store` 추가했습니다.

# Changes
`SecurityConfig`의 `allowedOrigins`에 `https://cookeep.store` 추가