### PR TITLE
feat: 유저의 마지막 접속일 기반 식물 상태 자동 변화 기능 구현

### DIFF
--- a/src/main/java/com/cookeep/cookeep/api/dto/response/MyPlantResponseDto.java
+++ b/src/main/java/com/cookeep/cookeep/api/dto/response/MyPlantResponseDto.java
@@ -13,6 +13,7 @@ public class MyPlantResponseDto {
     private String imageUrl;       // 현재 단계에 맞는 이미지 URL
     private Integer level;         // 성장 단계 (1~4)
     private Boolean isHarvested;   // 수확 여부 (false면 '키우는 중', true면 '수확 완료')
+    private Boolean isFrozen;      // 성장 정지 여부 (14일 미접속 시 true)
     private Boolean isProfile;     // 현재 이 식물이 유저의 프로필 식물인지 여부
     private String createdAt;      // 언제부터 키웠는지 (BaseEntity 활용)
 
@@ -27,6 +28,7 @@ public class MyPlantResponseDto {
                 .imageUrl(userPlant.getCurrentImageUrl())
                 .level(userPlant.getLevel())
                 .isHarvested(userPlant.getIsHarvested())
+                .isFrozen(userPlant.getIsFrozen())
                 .isProfile(isProfile)
                 .createdAt(userPlant.getCreatedAt().toLocalDate().toString())
                 .build();

--- a/src/main/java/com/cookeep/cookeep/domain/plant/application/UserPlantService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/plant/application/UserPlantService.java
@@ -55,7 +55,9 @@ public class UserPlantService {
             // 7~13일 미접속: WILTING 상태 (성장 정지는 하지 않음)
             user.updatePlantStatus(PlantStatus.WILTING);
         } else {
-            user.updatePlantStatus(PlantStatus.NORMAL);
+            // 아직 성장 정지된 식물이 남아 있으면 FROZEN 유지 (유저가 살리기 전까지)
+            boolean hasFrozenPlant = userPlantRepository.existsByUserAndIsFrozenTrue(user);
+            user.updatePlantStatus(hasFrozenPlant ? PlantStatus.FROZEN : PlantStatus.NORMAL);
         }
     }
 
@@ -208,5 +210,8 @@ public class UserPlantService {
 
         // 5. 식물 살리기 수행 (isFrozen = false)
         userPlant.revive();
+
+        // 6. 유저의 plantStatus를 NORMAL로 변경
+        userPlant.getUser().updatePlantStatus(PlantStatus.NORMAL);
     }
 }

--- a/src/main/java/com/cookeep/cookeep/domain/plant/application/UserPlantService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/plant/application/UserPlantService.java
@@ -9,6 +9,7 @@ import com.cookeep.cookeep.domain.plant.dao.PlantRepository;
 import com.cookeep.cookeep.domain.plant.dao.UserPlantRepository;
 import com.cookeep.cookeep.domain.plant.dao.WateringLogRepository;
 import com.cookeep.cookeep.domain.plant.entity.Plant;
+import com.cookeep.cookeep.domain.plant.entity.PlantStatus;
 import com.cookeep.cookeep.domain.plant.entity.UserPlant;
 import com.cookeep.cookeep.domain.plant.entity.WateringLog;
 import com.cookeep.cookeep.domain.user.dao.UserRepository;
@@ -17,7 +18,10 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
@@ -28,6 +32,32 @@ public class UserPlantService {
     private final UserRepository userRepository;
     private final PlantRepository plantRepository;
     private final CookieService cookieService;
+
+    // 로그인/토큰 갱신 시 호출: 미접속 일수 기반 식물 상태 계산 및 성장 정지 처리
+    @Transactional
+    public void checkAndUpdatePlantStatus(User user) {
+        LocalDateTime lastAccess = user.getLastAccessAt();
+
+        // lastAccessAt이 null이면 (기존 유저 or 최초 적용) NORMAL 처리
+        if (lastAccess == null) {
+            user.updatePlantStatus(PlantStatus.NORMAL);
+            return;
+        }
+
+        long inactiveDays = ChronoUnit.DAYS.between(lastAccess, LocalDateTime.now());
+
+        if (inactiveDays >= 14) {
+            // 14일 이상 미접속: 키우는 식물 성장 정지 + FROZEN 상태
+            Optional<UserPlant> growingPlant = userPlantRepository.findByUserAndIsHarvestedFalseAndIsFrozenFalse(user);
+            growingPlant.ifPresent(UserPlant::freeze);
+            user.updatePlantStatus(PlantStatus.FROZEN);
+        } else if (inactiveDays >= 7) {
+            // 7~13일 미접속: WILTING 상태 (성장 정지는 하지 않음)
+            user.updatePlantStatus(PlantStatus.WILTING);
+        } else {
+            user.updatePlantStatus(PlantStatus.NORMAL);
+        }
+    }
 
     // 유저 보유 식물 목록 조회
     @Transactional(readOnly = true) // 성능 최적화를 위해 읽기 전용 설정

--- a/src/main/java/com/cookeep/cookeep/domain/plant/dao/UserPlantRepository.java
+++ b/src/main/java/com/cookeep/cookeep/domain/plant/dao/UserPlantRepository.java
@@ -18,4 +18,7 @@ public interface UserPlantRepository extends JpaRepository<UserPlant, Long>{
 
     // 현재 키우고 있는 식물 조회 (수확 완료되지 않고, 성장 정지되지 않은 식물)
     Optional<UserPlant> findByUserAndIsHarvestedFalseAndIsFrozenFalse(User user);
+
+    // 성장 정지된 식물이 존재하는지 확인
+    boolean existsByUserAndIsFrozenTrue(User user);
 }

--- a/src/main/java/com/cookeep/cookeep/domain/plant/dao/UserPlantRepository.java
+++ b/src/main/java/com/cookeep/cookeep/domain/plant/dao/UserPlantRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface UserPlantRepository extends JpaRepository<UserPlant, Long>{
@@ -14,4 +15,7 @@ public interface UserPlantRepository extends JpaRepository<UserPlant, Long>{
     // N+1 문제를 방지하기 위해 plant 엔티티를 fetch join으로 가져옵니다.
     @EntityGraph(attributePaths = {"plant"})
     List<UserPlant> findAllByUser(User user);
+
+    // 현재 키우고 있는 식물 조회 (수확 완료되지 않고, 성장 정지되지 않은 식물)
+    Optional<UserPlant> findByUserAndIsHarvestedFalseAndIsFrozenFalse(User user);
 }

--- a/src/main/java/com/cookeep/cookeep/domain/plant/entity/PlantStatus.java
+++ b/src/main/java/com/cookeep/cookeep/domain/plant/entity/PlantStatus.java
@@ -1,0 +1,7 @@
+package com.cookeep.cookeep.domain.plant.entity;
+
+public enum PlantStatus {
+	NORMAL,   // 정상 (미접속 0~6일)
+	WILTING,  // 시들어 가는 중 (미접속 7~13일)
+	FROZEN    // 시든 상태 = 성장 정지 (미접속 14일 이상)
+}

--- a/src/main/java/com/cookeep/cookeep/domain/user/application/AuthService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/user/application/AuthService.java
@@ -32,6 +32,8 @@ import com.cookeep.cookeep.domain.user.entity.UserStatus;
 import com.cookeep.cookeep.common.exception.AppException;
 import com.cookeep.cookeep.common.exception.ErrorCode;
 
+import com.cookeep.cookeep.domain.plant.application.UserPlantService;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -47,6 +49,7 @@ public class AuthService {
 	private final JwtTokenProvider jwtTokenProvider;
 	private final UserReader userReader;
 	private final PasswordEncoder passwordEncoder;
+	private final UserPlantService userPlantService;
 
 	// 액세스 토큰이 만료되었을 경우 리프레쉬 토큰으로 액세스 토큰 갱신
 	@Transactional
@@ -66,6 +69,10 @@ public class AuthService {
 		}
 
 		User user = userReader.readById(userId);
+
+		// 미접속 일수 기반 식물 상태 계산 및 성장 정지 처리
+		userPlantService.checkAndUpdatePlantStatus(user);
+		user.updateLastAccessAt(LocalDateTime.now());
 
 		// 새로운 액세스토큰 발급
 		String accessToken = jwtTokenProvider.createAccessToken(user.getUserId());
@@ -93,6 +100,10 @@ public class AuthService {
 	}
 
 	private TokenPair issueTokensAndUpsertSession(User user) {
+		// 미접속 일수 기반 식물 상태 계산 및 성장 정지 처리
+		userPlantService.checkAndUpdatePlantStatus(user);
+		user.updateLastAccessAt(LocalDateTime.now());
+
 		// 액세스 토큰, 리프레쉬 토큰 발급
 		String accessToken = jwtTokenProvider.createAccessToken(user.getUserId());
 		String refreshToken = jwtTokenProvider.createRefreshToken(user.getUserId());

--- a/src/main/java/com/cookeep/cookeep/domain/user/entity/User.java
+++ b/src/main/java/com/cookeep/cookeep/domain/user/entity/User.java
@@ -2,6 +2,7 @@ package com.cookeep.cookeep.domain.user.entity;
 
 import java.time.LocalDateTime;
 
+import com.cookeep.cookeep.domain.plant.entity.PlantStatus;
 import com.cookeep.cookeep.domain.plant.entity.UserPlant;
 import jakarta.persistence.*;
 import org.springframework.data.annotation.LastModifiedDate;
@@ -87,6 +88,12 @@ public class User extends BaseEntity {
 	@LastModifiedDate
 	private LocalDateTime updatedAt;
 
+	private LocalDateTime lastAccessAt;
+
+	@Builder.Default
+	@Enumerated(EnumType.STRING)
+	private PlantStatus plantStatus = PlantStatus.NORMAL;
+
 	@OneToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "profile_plant_id")
 	private UserPlant profilePlant;
@@ -118,5 +125,13 @@ public class User extends BaseEntity {
 
 	public void updatePassword(String password) {
 		this.password = password;
+	}
+
+	public void updateLastAccessAt(LocalDateTime lastAccessAt) {
+		this.lastAccessAt = lastAccessAt;
+	}
+
+	public void updatePlantStatus(PlantStatus plantStatus) {
+		this.plantStatus = plantStatus;
 	}
 }


### PR DESCRIPTION
# Related Issue
CLOSE #62 


# Description
 - `User` 엔티티에 `lastAccessAt` (마지막 접속일), `plantStatus` (현재 키우는 식물의 상태) 필드와 이를 업데이트하는 메서드를 추가했습니다.
 
  - 로그인/토큰 갱신 시 미접속 일수를 계산하여 식물 상태(`plantStatus`)를 자동으로 판단하는 메서드 `checkAndUpdatePlantStatus()`를 `UserPlantService`에 추가했습니다.
  
    - 0~6일: `NORMAL` (정상)
    - 7~13일: `WILTING` (시들어 가는 중)
    - 14일 이상: `FROZEN` (성장 정지) + 키우는 식물 자동 성장 정지 상태 처리(`UserPlant.isFrozen` = true)
    
  - `plantStatus`는 `User`에 저장되어, 추후 '쿠킵스'에 진입 시 이 `plantStatus`를 읽고 프론트에 전달 예정 (이때 프론트는 이 plantStatus를 보고 '시드는 중이에요' or '시들었어요' 팝업을 띄움)

  - 성장 정지된 식물이 존재하는 한 유저가 재접속해도 `plantStatus`는 `FROZEN` 유지
  
  - 도메인 책임 분리: 식물 상태 계산은 `UserPlantService`, `lastAccessAt` 갱신은 `AuthService`에서 담당

     - `AuthService`의 `issueTokensAndUpsertSession()`과 `tokenRefresh()`에서 `checkAndUpdatePlantStatus()`를 호출해 식물 상태 체크 + `lastAccessAt` 갱신을 호출합니다.

     - 두 곳 모두에 식물 상태 체크를 넣은 이유는, 유저가 언제 어떤 경로로 들어오든 빠짐없이 체크하기 위해서입니다.

          - `issueTokensAndUpsertSession()`— 로그인/회원가입 시 호출(액세스 토큰 + 리프레시 토큰 둘 다 새로 발급)

          - `tokenRefresh()` — 액세스 토큰 만료 시 호출(액세스 토큰 하나만 새로 발급 (리프레시 토큰은 기존 것 유지))

ex) 
 - 10일 만에 복귀 → 리프레시 토큰 아직 유효 → `tokenRefresh()`에서 체크
- 15일 만에 복귀 → 리프레시 토큰 만료 → 재로그인 → `issueTokensAndUpsertSession()`에서 체크
     
@0-x-14 님 혹시 틀린 내용 있으면 말씀해주세요!


# Changes


파일 | 변경 내용
-- | --
PlantStatus | 신규 — NORMAL, WILTING, FROZEN enum 생성
User | lastAccessAt, plantStatus 필드 및 update 메서드 추가
UserPlantRepository | findByUserAndIsHarvestedFalseAndIsFrozenFalse, existsByUserAndIsFrozenTrue 쿼리 추가
UserPlantService | checkAndUpdatePlantStatus() 메서드 추가, revivePlant()에서 plantStatus NORMAL 전환 추가
AuthService | UserPlantService 의존성 추가, issueTokensAndUpsertSession()과 tokenRefresh()에서 식물 상태 체크 및 lastAccessAt 갱신 호출
MyPlantResponseDto | isFrozen 필드 추가


<!-- notionvc: 76673491-7712-494f-8f1e-3d5874ce0bf8 -->