### PR TITLE
fix: UserPlant 등록 플로우에서 첫 식물 등록 메시지를 응답값에 추가

### DIFF
--- a/src/main/java/com/cookeep/cookeep/api/controller/MyPlantController.java
+++ b/src/main/java/com/cookeep/cookeep/api/controller/MyPlantController.java
@@ -38,11 +38,12 @@ public class MyPlantController {
             @ApiResponse(responseCode = "404", description = "유저 또는 식물을 찾을 수 없음")
     })
     @PostMapping("/{plantId}") // /api/my-plants/{plantId}
-    public DataResponse<Void> registerPlant(
+    public DataResponse<String> registerPlant(
             @AuthenticationPrincipal(expression = "userId") Long userId,
             @Parameter(description = "기본 식물 ID") @PathVariable long plantId) {
-        userPlantService.registerPlant(userId, plantId);
-        return DataResponse.from(null);
+        boolean isFirstPlant = userPlantService.registerPlant(userId, plantId);
+        String message = isFirstPlant ? "첫 식물 등록이 완료되었습니다." : "식물 등록이 완료되었습니다.";
+        return DataResponse.from(message);
     }
 
     @Operation(summary = "프로필 식물 지정", description = "내 보유 식물 ID를 경로에 전달하여 대표 프로필로 설정합니다.")

--- a/src/main/java/com/cookeep/cookeep/domain/plant/application/UserPlantService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/plant/application/UserPlantService.java
@@ -95,18 +95,21 @@ public class UserPlantService {
         user.updateProfilePlant(userPlant);
     }
 
-    // 현재 키우는 식물 등록
+    // 현재 키우는 식물 등록 (첫 식물 등록 여부 반환)
     @Transactional
-    public void registerPlant(Long userId, long plantId) {
+    public boolean registerPlant(Long userId, long plantId) {
         // 1. 유저 존재 확인
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new AppException(ErrorCode.NOT_FOUND));
 
-        // 2. 기본으로 존재하는 식물인지 확인
+        // 2. 첫 식물 등록 여부 확인
+        boolean isFirstPlant = !userPlantRepository.existsByUser(user);
+
+        // 3. 기본으로 존재하는 식물인지 확인
         Plant plant = plantRepository.findById(plantId)
                 .orElseThrow(() -> new AppException(ErrorCode.PLANT_NOT_FOUND));
 
-        // 3. UserPlant 엔티티 생성 및 저장
+        // 4. UserPlant 엔티티 생성 및 저장
         UserPlant newUserPlant = UserPlant.builder()
                 .user(user)
                 .plant(plant)
@@ -118,8 +121,10 @@ public class UserPlantService {
 
         userPlantRepository.save(newUserPlant);
 
-        // 4. 자동 모드(isProfileAutoUpdate=true)일 때만 프로필 갱신
+        // 5. 자동 모드(isProfileAutoUpdate=true)일 때만 프로필 갱신
         user.setProfilePlantAuto(newUserPlant);
+
+        return isFirstPlant;
     }
 
     // 식물 포기하기

--- a/src/main/java/com/cookeep/cookeep/domain/plant/dao/UserPlantRepository.java
+++ b/src/main/java/com/cookeep/cookeep/domain/plant/dao/UserPlantRepository.java
@@ -21,4 +21,7 @@ public interface UserPlantRepository extends JpaRepository<UserPlant, Long>{
 
     // 성장 정지된 식물이 존재하는지 확인
     boolean existsByUserAndIsFrozenTrue(User user);
+
+    // 유저가 보유한 식물이 존재하는지 확인
+    boolean existsByUser(User user);
 }


### PR DESCRIPTION
# Related Issue
CLOSE #67 

# Description
  응답 예시:
  - 첫 식물 등록 시: { "data": "첫 식물 등록이 완료되었습니다." }
  - 이후 등록 시: { "data": "식물 등록이 완료되었습니다." }

프론트측에서 무료 물주기 모달을 띄우기 위해 이렇게 분기하여 전달하도록 구현하였습니다.

# Changes

파일 | 변경 내용
-- | --
UserPlantRepository | existsByUser(User user) 메서드 추가
UserPlantService.registerPlant | save 전에 existsByUser로 첫 등록 여부 확인 후 boolean 반환
MyPlantController.registerPlant | 반환 타입 DataResponse → DataResponse, 메시지 분기 처리


<!-- notionvc: f064c25a-2651-4071-8fef-51ccc2323f27 -->