### PR TITLE
fix: CORS 설정에 api.cookeep.store 도메인 추가

### DIFF
--- a/src/main/java/com/cookeep/cookeep/config/SecurityConfig.java
+++ b/src/main/java/com/cookeep/cookeep/config/SecurityConfig.java
@@ -34,7 +34,8 @@ public class SecurityConfig {
 		config.setAllowedOrigins(List.of(
 			"http://localhost:5173",
 			"https://12th-coo-keep-fe.vercel.app",
-			"https://cookeep.store"
+			"https://cookeep.store",
+			"https://api.cookeep.store"
 		));
 		config.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
 		config.setAllowedHeaders(List.of("*"));


### PR DESCRIPTION
# Related Issue
#73 

# Description
브라우저에서 `https://api.cookeep.store/swagger-ui/index.html`에 접속해 API 호출 테스트를 하려고 했으나
시큐리티 설정의 allowedOrigins 목록에는 `api.` 서브도메인이 포함된 주소가 없어서 호출이 불가능한 이슈가 있었습니다.
(프론트 분들은 그동안 swagger 말고 코드에서 API 바로 호출해서 개발해오셨다고 합니다)

# Changes
SecurityConfig에 `https://api.cookeep.store` 추가

(확인 후 바로 머지 부탁드립니다!)