### PR TITLE
fix: 새로운 식물 등록시 userPlantId를 응답값에 포함

### DIFF
--- a/src/main/java/com/cookeep/cookeep/api/controller/MyPlantController.java
+++ b/src/main/java/com/cookeep/cookeep/api/controller/MyPlantController.java
@@ -1,6 +1,7 @@
 package com.cookeep.cookeep.api.controller;
 
 import com.cookeep.cookeep.api.dto.response.MyPlantResponseDto;
+import com.cookeep.cookeep.api.dto.response.RegisterPlantResponseDto;
 import com.cookeep.cookeep.common.dto.DataResponse;
 import com.cookeep.cookeep.domain.plant.application.UserPlantService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -38,12 +39,11 @@ public class MyPlantController {
             @ApiResponse(responseCode = "404", description = "유저 또는 식물을 찾을 수 없음")
     })
     @PostMapping("/{plantId}") // /api/my-plants/{plantId}
-    public DataResponse<String> registerPlant(
+    public DataResponse<RegisterPlantResponseDto> registerPlant(
             @AuthenticationPrincipal(expression = "userId") Long userId,
             @Parameter(description = "기본 식물 ID") @PathVariable long plantId) {
-        boolean isFirstPlant = userPlantService.registerPlant(userId, plantId);
-        String message = isFirstPlant ? "첫 식물 등록이 완료되었습니다." : "식물 등록이 완료되었습니다.";
-        return DataResponse.from(message);
+        RegisterPlantResponseDto response = userPlantService.registerPlant(userId, plantId);
+        return DataResponse.from(response);
     }
 
     @Operation(summary = "프로필 식물 지정", description = "내 보유 식물 ID를 경로에 전달하여 대표 프로필로 설정합니다.")

--- a/src/main/java/com/cookeep/cookeep/api/dto/response/RegisterPlantResponseDto.java
+++ b/src/main/java/com/cookeep/cookeep/api/dto/response/RegisterPlantResponseDto.java
@@ -1,0 +1,20 @@
+package com.cookeep.cookeep.api.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Schema(
+        name = "RegisterPlantResponse",
+        description = "식물 등록 성공 응답 DTO"
+)
+public class RegisterPlantResponseDto {
+
+    @Schema(description = "등록된 유저 식물 ID", example = "1")
+    private Long userPlantId;
+
+    @Schema(description = "응답 메시지", example = "첫 식물 등록이 완료되었습니다.")
+    private String message;
+}

--- a/src/main/java/com/cookeep/cookeep/domain/plant/application/UserPlantService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/plant/application/UserPlantService.java
@@ -1,6 +1,7 @@
 package com.cookeep.cookeep.domain.plant.application;
 
 import com.cookeep.cookeep.api.dto.response.MyPlantResponseDto;
+import com.cookeep.cookeep.api.dto.response.RegisterPlantResponseDto;
 import com.cookeep.cookeep.common.exception.AppException;
 import com.cookeep.cookeep.common.exception.ErrorCode;
 import com.cookeep.cookeep.domain.cookie.application.CookieService;
@@ -95,9 +96,9 @@ public class UserPlantService {
         user.updateProfilePlant(userPlant);
     }
 
-    // 현재 키우는 식물 등록 (첫 식물 등록 여부 반환)
+    // 현재 키우는 식물 등록 (첫 식물 등록 여부 + userPlantId 반환)
     @Transactional
-    public boolean registerPlant(Long userId, long plantId) {
+    public RegisterPlantResponseDto registerPlant(Long userId, long plantId) {
         // 1. 유저 존재 확인
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new AppException(ErrorCode.NOT_FOUND));
@@ -124,7 +125,8 @@ public class UserPlantService {
         // 5. 자동 모드(isProfileAutoUpdate=true)일 때만 프로필 갱신
         user.setProfilePlantAuto(newUserPlant);
 
-        return isFirstPlant;
+        String message = isFirstPlant ? "첫 식물 등록이 완료되었습니다." : "식물 등록이 완료되었습니다.";
+        return new RegisterPlantResponseDto(newUserPlant.getUserPlantId(), message);
     }
 
     // 식물 포기하기


### PR DESCRIPTION
# Related Issue
CLOSE #75 

# Description
유저가 새로운 식물을 등록할 때 응답값에 userPlantId를 포함시킵니다.

ex) 
  첫 식물 등록 시:
```json
  {
    "status": "OK",
    "timestamp": "2026-02-09 12:00:00",
    "data": {
      "userPlantId": 1,
      "message": "첫 식물 등록이 완료되었습니다."
    }
  }
```

  이후 등록 시:
```json
  {
    "status": "OK",
    "timestamp": "2026-02-09 12:00:00",
    "data": {
      "userPlantId": 2,
      "message": "식물 등록이 완료되었습니다."
    }
  }
```

# Changes


파일 | 변경 내용
-- | --
RegisterPlantResponseDto (신규) | userPlantId + message 필드를 가진 응답 DTO
UserPlantRepository | existsByUser() 메서드 추가
UserPlantService.registerPlant | 반환 타입 void → RegisterPlantResponseDto, 첫 등록 여부 확인 로직 추가
MyPlantController.registerPlant | 반환 타입 DataResponse<Void> → DataResponse<RegisterPlantResponseDto>


<!-- notionvc: 37b56bd1-d30e-47c8-a1af-8a8f96eaf414 -->