### PR TITLE
fix: 스프링부트 서버 기본 시간대를 한국 시간으로 고정

### DIFF
--- a/src/main/java/com/cookeep/cookeep/CookeepApplication.java
+++ b/src/main/java/com/cookeep/cookeep/CookeepApplication.java
@@ -1,12 +1,21 @@
 package com.cookeep.cookeep;
 
+import jakarta.annotation.PostConstruct;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+import java.util.TimeZone;
+
 @SpringBootApplication
 @EnableJpaAuditing
 public class CookeepApplication {
+
+	@PostConstruct
+	public void started() {
+		// 기본 시간대를 한국 시간으로 설정
+		TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
+	}
 
 	public static void main(String[] args) {
 		SpringApplication.run(CookeepApplication.class, args);


### PR DESCRIPTION
# Relted Issue
CLOSE #76 

# Description
서버 환경 상관없이 기본 시간을 한국 시간으로 고정하기 위해 스프링 부트 메인 클래스에 설정을 추가했습니다.

# Changes
`CookeepApplication`

```java
@SpringBootApplication
@EnableJpaAuditing
public class CookeepApplication {

	@PostConstruct
	public void started() {
		// 기본 시간대를 한국 시간으로 설정
		TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
	}

	public static void main(String[] args) {
		SpringApplication.run(CookeepApplication.class, args);
	}

}
```