### PR TITLE
Refactor: 66 recipe

### DIFF
--- a/src/main/java/com/cookeep/cookeep/api/controller/UserIngredientUpdateController.java
+++ b/src/main/java/com/cookeep/cookeep/api/controller/UserIngredientUpdateController.java
@@ -214,7 +214,7 @@ public class UserIngredientUpdateController {
     @Operation(
             summary = "6. 재료 섭취 완료",
             description = "식재료를 섭취 완료 처리합니다. (리워드를 지급 후 삭제)" +
-                    "1일 1회 기본 섭취 리워드(+1), 유통기한 임박 식재료(D-3 이하) 섭취 시 추가 리워드(+3)가 지급됩니다."
+                    "1일 1회 기본 섭취 리워드(+1) 지급됩니다. (유통기한 임박 여부 상관없이 모두 1개 지급)"
     )
     @ApiErrorCodeExamples({
             ErrorCode.INVALID_DELETE_REQUEST,

--- a/src/main/java/com/cookeep/cookeep/api/dto/response/AiRecipeResponseDto.java
+++ b/src/main/java/com/cookeep/cookeep/api/dto/response/AiRecipeResponseDto.java
@@ -1,9 +1,12 @@
 package com.cookeep.cookeep.api.dto.response;
 
 import com.cookeep.cookeep.domain.recipe.dto.GeminiRecipeResponseDto;
+import com.cookeep.cookeep.domain.recipe.dto.YoutubeReferenceDto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
+
+import java.util.List;
 
 @Schema(
         name = "AiRecipeResponse",
@@ -33,4 +36,10 @@ public class AiRecipeResponseDto {
             requiredMode = Schema.RequiredMode.REQUIRED
     )
     private GeminiRecipeResponseDto recipe;
+
+    @Schema(
+            description = "YouTube Data API로 조회한 실제 유튜브 영상 목록",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    private List<YoutubeReferenceDto> youtubeReferences;
 }

--- a/src/main/java/com/cookeep/cookeep/domain/ingredient/customingredient/entity/CustomIngredient.java
+++ b/src/main/java/com/cookeep/cookeep/domain/ingredient/customingredient/entity/CustomIngredient.java
@@ -50,6 +50,6 @@ public class CustomIngredient {
         this.storage = storage;
         this.category = category;
         this.userId = userId;
-        this.imageUrl = "https://s3.amazonaws.com/cookeep/ingredients/default.png"; // 디폴트 이미지 임시 url
+        this.imageUrl = "https://cookeep-images.s3.ap-northeast-2.amazonaws.com/ingredients/0a0cc3bd-1ade-46ed-897e-ba89ec09b7c0.png"; // 디폴트 이미지 임시 url
     }
 }

--- a/src/main/java/com/cookeep/cookeep/domain/recipe/application/AiRecipeService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/recipe/application/AiRecipeService.java
@@ -45,7 +45,7 @@ import static com.cookeep.cookeep.domain.recipe.entity.MessageType.*;
 public class AiRecipeService {
 
     private static final int MAX_RETRY_COUNT = 5;
-    private static final int URGENT = 3;
+    private static final int URGENT = 0;
 
     private final GeminiService geminiService;
     private final AiSessionRepository aiSessionRepository;
@@ -59,6 +59,7 @@ public class AiRecipeService {
     private final CookieLogRepository cookieLogRepository;
     private final DailyCookieGrantRepository dailyCookieGrantRepository;
     private final CookieService cookieService;
+    private final YoutubeSearchService youtubeSearchService;
 
     // sessionId 유무에 따라 신규/재요청 로직 분기
     public AiRecipeResponseDto generateRecipe(Long userId, AiRecipeRequestDto request) {
@@ -129,11 +130,17 @@ public class AiRecipeService {
         // 5. 세션 제목 업데이트
         updateSessionTitle(session, aiResponse);
 
-        // 6. 응답 반환
+        // 6. 유튜브 검색어로 실제 영상 조회
+        List<YoutubeReferenceDto> youtubeReferences =
+                youtubeSearchService.searchVideos(aiResponse.getYoutubeSearchQueries());
+
+
+        // 7. 응답 반환
         return AiRecipeResponseDto.builder()
                 .sessionId(session.getId())
                 .changeCount(session.getAttemptNumber())
                 .recipe(aiResponse)
+                .youtubeReferences(youtubeReferences)
                 .build();
     }
 
@@ -188,11 +195,17 @@ public class AiRecipeService {
         // 8. 세션 제목 업데이트
         updateSessionTitle(session, aiResponse);
 
-        // 9. 응답 반환
+        // 9. 유튜브 검색어로 실제 영상 조회
+        List<YoutubeReferenceDto> youtubeReferences =
+                youtubeSearchService.searchVideos(aiResponse.getYoutubeSearchQueries());
+
+
+        // 10. 응답 반환
         return AiRecipeResponseDto.builder()
                 .sessionId(session.getId())
                 .changeCount(session.getAttemptNumber())
                 .recipe(aiResponse)
+                .youtubeReferences(youtubeReferences)
                 .build();
     }
 
@@ -337,31 +350,6 @@ public class AiRecipeService {
         // 재요청은 기존 세션에서 정보 가져옴
     }
 
-    // 요청바디에 입력한 타입,아이디로 db에서 재료 단위/이름 조회 & 수량은 AI가 생성
-    private List<IngredientDetailDto> enrichIngredientsForAI(
-            Long userId,
-            List<IngredientSimpleDto> simpleIngredients
-    ) {
-        return simpleIngredients.stream()
-                .map(simple -> {
-                    // 1. 재료 이름 조회 (default_ingredients 또는 custom_ingredients)
-                    String name = getIngredientName(simple.getType(), simple.getReferenceId());
-
-                    // 2. 단위 조회 (user_ingredients)
-                    String unit = getUserIngredientUnit(userId, simple.getType(), simple.getReferenceId());
-
-                    // 3. DTO 생성 (quantity는 null, AI가 생성)
-                    return IngredientDetailDto.builder()
-                            .type(simple.getType())
-                            .referenceId(simple.getReferenceId())
-                            .name(name)
-                            .quantity(null)
-                            .unit(unit)
-                            .build();
-                })
-                .collect(Collectors.toList());
-    }
-
     // UserIngredient 엔티티에서 IngredientDetailDto로 변환
     private List<IngredientDetailDto> enrichIngredientsFromUserIngredients(
             List<UserIngredient> userIngredients
@@ -372,8 +360,7 @@ public class AiRecipeService {
                     String name = getIngredientName(ui.getType().name(), ui.getReferenceId());
 
                     return IngredientDetailDto.builder()
-                            .type(ui.getType().name())
-                            .referenceId(ui.getReferenceId())
+                            .ingredientId(ui.getIngredientId())
                             .name(name)
                             .quantity(null) // AI가 생성
                             .unit(ui.getUnit().name())
@@ -455,7 +442,7 @@ public class AiRecipeService {
         try {
             String ingredientsJson = objectMapper.writeValueAsString(recipe.getIngredients());
             String stepsJson = objectMapper.writeValueAsString(recipe.getSteps());
-            String youtubeUrlJson = objectMapper.writeValueAsString(recipe.getYoutubeReferences());
+            String youtubeUrlJson = objectMapper.writeValueAsString(recipe. getYoutubeSearchQueries());
 
             AiRecipe aiRecipe = AiRecipe.builder()
                     .title(recipe.getTitle())
@@ -560,16 +547,16 @@ public class AiRecipeService {
                 userIngredientRepository.findAllByIngredientIdInAndUser_UserId(ingredientIds, userId);
 
         if (userIngredients.isEmpty()) {
-            log.warn("No valid ingredients found for user {}. Skipping reward.", userId);
+            log.warn("유효한 재료 없음, 임박 리워드 생략: userId={}", userId);
             return;
         }
 
-        // 2. 임박 식재료 확인 (leftDays <= 3)
-        boolean hasUrgentIngredient = userIngredients.stream()
-                .anyMatch(ingredient -> ingredient.getLeftDays() <= URGENT);
+        // 2. 임박 식재료 확인 (leftDays <= 0)
+        boolean hasUrgent = userIngredients.stream()
+                .anyMatch(ui -> ui.getLeftDays() <= URGENT);
 
-        if (!hasUrgentIngredient) {
-            log.info("No urgent ingredients found for user {}. No reward granted.", userId);
+        if (!hasUrgent) {
+            log.info("임박 재료 없음, 임박 리워드 생략: userId={}", userId);
             return;
         }
 
@@ -580,14 +567,14 @@ public class AiRecipeService {
         if (newQuantity > 0) {
             // 수량만 감소
             targetIngredient.updateQuantity(newQuantity);
-            log.info("Decreased quantity of ingredient {} from {} to {}",
+            log.info("재료 수량 감소: ingredientId={}, {} → {}",
                     targetIngredient.getIngredientId(),
                     targetIngredient.getQuantity() + 1,
                     newQuantity);
         } else {
             // 수량이 0이 되면 삭제
             userIngredientRepository.delete(targetIngredient);
-            log.info("Deleted ingredient {} as quantity reached 0",
+            log.info("재료 삭제(수량 0): ingredientId={}",
                     targetIngredient.getIngredientId());
         }
 
@@ -596,11 +583,12 @@ public class AiRecipeService {
         boolean granted = cookieService.grantDailyCookie(userId, urgentType);
 
         if (granted) {
-            log.info("Granted urgent ingredient reward via recipe adopt: user={}, points={}",
+            log.info("임박 재료 리워드 지급: userId={}, amount={}",
                     userId, urgentType.getDefaultAmount());
         } else {
-            log.info("Urgent ingredient reward already granted today for user {}", userId);
+            log.info("임박 재료 리워드 오늘 이미 지급됨: userId={}", userId);
         }
     }
+
 
 }

--- a/src/main/java/com/cookeep/cookeep/domain/recipe/application/GeminiService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/recipe/application/GeminiService.java
@@ -37,8 +37,7 @@ public class GeminiService {
     public GeminiRecipeResponseDto generateRecipe(
             List<IngredientDetailDto> ingredients,
             Difficulty difficulty) {
-        String prompt = buildPrompt(ingredients, difficulty);
-        return generateRecipeByPrompt(prompt);
+        return generateRecipeByPrompt(buildPrompt(ingredients, difficulty));
     }
 
     public GeminiRecipeResponseDto generateRecipeWithExclusion(
@@ -155,19 +154,10 @@ public class GeminiService {
 
         // JSON 형식 (type, referenceId, name, unit만 전달)
         String ingredientsJson = ingredients.stream()
-                .map(i -> String.format("""
-                    {
-                      "type": "%s",
-                      "referenceId": %d,
-                      "name": "%s",
-                      "unit": "%s"
-                    }
-                    """,
-                        i.getType(),
-                        i.getReferenceId(),
-                        i.getName(),
-                        i.getUnit()))
-                .collect(Collectors.joining(",", "[", "]"));
+                .map(i -> String.format(
+                        "{ \"ingredientId\": %d, \"name\": \"%s\", \"unit\": \"%s\" }",
+                        i.getIngredientId(), i.getName(), i.getUnit()))
+                .collect(Collectors.joining(",\n    ", "[\n    ", "\n  ]"));
 
         return """
         당신은 요리 레시피 전문가입니다.
@@ -178,16 +168,21 @@ public class GeminiService {
         [난이도]
         %s
         
-        [규칙]
-        1. 제공된 재료의 단위를 반드시 사용하세요.
-        2. 각 재료의 적절한 수량(quantity)을 생성하세요. 수량은 0개 이상이어야 하며, 소수점 첫 번째 자리까지 표현 가능합니다.
-        3. user_ingredients에는 type, referenceId, name, quantity, unit을 모두 포함하세요.
-        4. 추가로 필요한 재료가 있다면 additional_ingredients에 포함하세요.
-        5. 생략 가능하거나 대체 가능한 재료는 optional_ingredients에 포함하세요.
-        6. 레시피와 관련된 실제 유튜브 동영상 1-3개를 추천해주세요.
-        7. 유튜브 인네일 URL은 https://img.youtube.com/vi/{VIDEO_ID}/default.jpg 형식을 사용하세요.
-        8. 반드시 JSON만 응답하세요. 설명 문구는 절대 포함하지 마세요.
-        9. steps는 간결하고 실용적인 요리 방법을 단계별로 작성하세요.
+                [규칙]
+                1. 제공된 재료의 단위를 반드시 사용하세요.
+                2. 각 재료의 적절한 수량(quantity)을 생성하세요.
+                   - 수량은 반드시 0보다 큰 양수여야 합니다. (0은 절대 불가)
+                   - 0.5, 1, 1.5, 2 등 소수점 첫 번째 자리까지 표현 가능합니다.
+                   - 예: 0은 불가, 최소 0.5 이상이어야 합니다.
+                3. user_ingredients에는 type, referenceId, name, quantity, unit을 모두 포함하세요.
+                4. 추가로 필요한 재료가 있다면 additional_ingredients에 포함하세요.
+                5. 생략 가능하거나 대체 가능한 재료는 optional_ingredients에 포함하세요.
+                6. youtube_search_queries에는 이 레시피를 유튜브에서 검색할 때 쓸 한국어 검색어를 1~3개 작성하세요.
+                   - 검색어는 실제로 유튜브에서 검색했을 때 관련 영상이 나올만한 구체적인 표현을 사용하세요.
+                   - 예: "김치볶음밥 만들기", "간단한 김치볶음밥 레시피", "볶음밥 황금레시피"
+                7. URL이나 링크는 절대 생성하지 마세요. 검색어만 제공하면 됩니다.
+                8. 반드시 JSON만 응답하세요. 설명 문구는 절대 포함하지 마세요.
+                9. steps는 간결하고 실용적인 요리 방법을 단계별로 작성하세요.
         
         [응답 형식]
         {

--- a/src/main/java/com/cookeep/cookeep/domain/recipe/application/YoutubeSearchService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/recipe/application/YoutubeSearchService.java
@@ -1,0 +1,130 @@
+package com.cookeep.cookeep.domain.recipe.application;
+
+import com.cookeep.cookeep.domain.recipe.dto.YoutubeReferenceDto;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class YoutubeSearchService {
+
+    @Value("${youtube.api.key}")
+    private String youtubeApiKey;
+
+    private final WebClient webClient;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    private static final String YOUTUBE_SEARCH_URL = "https://www.googleapis.com/youtube/v3/search";
+    private static final int MAX_RESULTS_PER_QUERY = 1;
+
+    /**
+     * [검색 방법]
+     * 1. Gemini가 유튜브 검색어 리스트 생성
+     * 2. YouTube Data API로 실제 영상을 검색하여 결과 리턴
+     *
+     * @param searchQueries Gemini가 생성한 한국어 검색어 목록 (예: ["김치볶음밥 만들기", "간단한 볶음밥"])
+     * @return 실제 유효한 YoutubeReferenceDto 리스트
+     */
+    public List<YoutubeReferenceDto> searchVideos(List<String> searchQueries) {
+        if (searchQueries == null || searchQueries.isEmpty()) {
+            return new ArrayList<>();
+        }
+
+        List<YoutubeReferenceDto> results = new ArrayList<>();
+
+        for (String query : searchQueries) {
+            try {
+                YoutubeReferenceDto video = searchSingleVideo(query);
+                if (video != null) {
+                    results.add(video);
+                }
+            } catch (Exception e) {
+                // 하나의 검색어가 실패해도 나머지는 계속 진행
+                log.warn("유튜브 검색 실패 (검색어: '{}'): {}", query, e.getMessage());
+            }
+        }
+
+        return results;
+    }
+
+    // --- 내부 메서드 ---
+
+    // 유튜브 영상 1개 검색 수행
+    private YoutubeReferenceDto searchSingleVideo(String query) {
+        try {
+            String responseBody = webClient.get()
+                    .uri(uriBuilder -> uriBuilder
+                            .scheme("https")
+                            .host("www.googleapis.com")
+                            .path("/youtube/v3/search")
+                            .queryParam("part", "snippet")
+                            .queryParam("q", query)
+                            .queryParam("type", "video")
+                            .queryParam("maxResults", MAX_RESULTS_PER_QUERY)
+                            .queryParam("regionCode", "KR")       // 한국 지역 영상 우선
+                            .queryParam("relevanceLanguage", "ko") // 한국어 영상 우선
+                            .queryParam("key", youtubeApiKey)
+                            .build()
+                    )
+                    .retrieve()
+                    .bodyToMono(String.class)
+                    .block();
+
+            return parseSearchResult(responseBody, query);
+
+        } catch (Exception e) {
+            log.error("YouTube API 호출 실패 (검색어: '{}')", query, e);
+            return null;
+        }
+    }
+
+    // YouTube API 응답 dto로 파싱
+    private YoutubeReferenceDto parseSearchResult(String responseBody, String searchQuery) {
+        try {
+            JsonNode root = objectMapper.readTree(responseBody);
+            JsonNode items = root.path("items");
+
+            if (items.isEmpty()) {
+                log.warn("유튜브 검색 결과 없음 (검색어: '{}')", searchQuery);
+                return null;
+            }
+
+            JsonNode firstItem = items.get(0);
+            JsonNode snippet = firstItem.path("snippet");
+            JsonNode videoId = firstItem.path("id").path("videoId");
+
+            if (videoId.isMissingNode() || videoId.isNull()) {
+                log.warn("videoId 없음 (검색어: '{}')", searchQuery);
+                return null;
+            }
+
+            String id = videoId.asText();
+            String title = snippet.path("title").asText(searchQuery);
+            // YouTube API가 제공하는 실제 썸네일 URL
+            String thumbnail = snippet.path("thumbnails").path("medium").path("url").asText(
+                    "https://img.youtube.com/vi/" + id + "/mqdefault.jpg"
+            );
+
+            log.info("유튜브 검색 성공 - 검색어: '{}', 제목: '{}', videoId: {}", searchQuery, title, id);
+
+            return YoutubeReferenceDto.builder()
+                    .title(title)
+                    .url("https://www.youtube.com/watch?v=" + id)
+                    .thumbnail(thumbnail)
+                    .build();
+
+        } catch (Exception e) {
+            log.error("유튜브 응답 파싱 실패 (검색어: '{}')", searchQuery, e);
+            return null;
+        }
+    }
+}

--- a/src/main/java/com/cookeep/cookeep/domain/recipe/dto/GeminiRecipeResponseDto.java
+++ b/src/main/java/com/cookeep/cookeep/domain/recipe/dto/GeminiRecipeResponseDto.java
@@ -39,8 +39,8 @@ public class GeminiRecipeResponseDto {
             description = "참고용 유튜브 영상 목록",
             requiredMode = Schema.RequiredMode.NOT_REQUIRED
     )
-    @JsonProperty("youtube_references")
-    private List<YoutubeReference> youtubeReferences;
+    @JsonProperty("youtube_search_queries")
+    private List<String> youtubeSearchQueries;
 
     @Schema(
             name = "GeminiRecipeIngredients",
@@ -81,18 +81,11 @@ public class GeminiRecipeResponseDto {
     public static class UserIngredient {
 
         @Schema(
-                description = "재료 타입 (DEFAULT / CUSTOM)",
-                example = "CUSTOM",
-                requiredMode = Schema.RequiredMode.REQUIRED
-        )
-        private String type;
-
-        @Schema(
-                description = "재료 참조 ID",
-                example = "5",
-                requiredMode = Schema.RequiredMode.REQUIRED
-        )
-        private Long referenceId;
+                description = "유저 식재료 ID (user_ingredients.ingredients_id)",
+                example = "7",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        @JsonProperty("ingredientId")
+        private Long ingredientId;
 
         @Schema(
                 description = "재료 이름",

--- a/src/main/java/com/cookeep/cookeep/domain/recipe/dto/IngredientDetailDto.java
+++ b/src/main/java/com/cookeep/cookeep/domain/recipe/dto/IngredientDetailDto.java
@@ -19,21 +19,11 @@ import lombok.NoArgsConstructor;
 public class IngredientDetailDto {
 
     @Schema(
-            description = "재료 타입 (기본/커스텀). DEFAULT 또는 CUSTOM",
-            example = "DEFAULT",
-            allowableValues = {"DEFAULT", "CUSTOM"},
-            requiredMode = Schema.RequiredMode.REQUIRED
-    )
-    @NotNull
-    private String type;
-
-    @Schema(
-            description = "재료 참조 ID (DEFAULT면 default_ingredients.id, CUSTOM이면 custom_ingredients.id)",
+            description = "유저 식재료 ID (user_ingredients.ingredients_id)",
             example = "7",
             requiredMode = Schema.RequiredMode.REQUIRED
     )
-    @NotNull
-    private Long referenceId;
+    private Long ingredientId;
 
     @Schema(
             description = "재료 이름 (서버에서 조회하여 채움)",
@@ -56,15 +46,5 @@ public class IngredientDetailDto {
             requiredMode = Schema.RequiredMode.NOT_REQUIRED
     )
     private String unit;
-
-    public static IngredientDetailDto from(UserIngredient entity) {
-        return IngredientDetailDto.builder()
-                .type(entity.getType().name())
-                .referenceId(entity.getReferenceId())
-                .name(entity.getMemo())
-                .quantity(entity.getQuantity())
-                .unit(entity.getUnit().name())
-                .build();
-    }
 
 }

--- a/src/main/java/com/cookeep/cookeep/domain/recipe/dto/YoutubeReferenceDto.java
+++ b/src/main/java/com/cookeep/cookeep/domain/recipe/dto/YoutubeReferenceDto.java
@@ -1,8 +1,10 @@
 package com.cookeep.cookeep.domain.recipe.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Schema(
         name = "YoutubeReference",
@@ -10,6 +12,8 @@ import lombok.Getter;
 )
 @Getter
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class YoutubeReferenceDto {
 
     @Schema(


### PR DESCRIPTION
# Issue
#66 

# Description
- 레시피 응답시 type, referenceId를 모두 ingredientId로 변경
- 스웨거 테스트 시 UNAUTHORIZED 오류 제거
- 재료 섭취 api 스웨거 설명 변경 (D-3부터 쿠키 지급 -> D-0만 쿠키 지급)
- 유튜브 링크 조회 로직 분리 및 변경

# Changes
- 기존 IngredientDetailDto를 ingredientId 만 사용하도록 변경
- YoutubeSearchService 추가하여 진짜 유튜브 Url 검색
- 썸네일도 진짜 썸네일 검색해서 가져옴

# Test Checklist
- [x] 스웨거에서 레시피 응답 생성 확인
- [x] 유튜브 링크 접속 확인
- [x] 썸네일 조회 확인

+) 레시피 채택시 쿠키 지급이랑 재료 차감은 여전히 안되는데 프론트 연동을 위해 먼저 머지하고 추후 수정하도록 하겠습니다
( 동작 자체에 문제는 없음. 채택 동작 자체는 확인 완료)