### PR TITLE
hotfix: userStatus 상태 변경

### DIFF
--- a/src/main/java/com/cookeep/cookeep/domain/onboarding/application/OnboardingService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/onboarding/application/OnboardingService.java
@@ -20,6 +20,7 @@ import com.cookeep.cookeep.domain.onboarding.entity.WeeklyGoal;
 import com.cookeep.cookeep.domain.user.application.UserReader;
 import com.cookeep.cookeep.domain.user.dao.UserRepository;
 import com.cookeep.cookeep.domain.user.entity.User;
+import com.cookeep.cookeep.domain.user.entity.UserStatus;
 
 import lombok.RequiredArgsConstructor;
 
@@ -64,6 +65,11 @@ public class OnboardingService {
 		upsertUserOnboarding(userId, user, onboardingRequestDTO);
 		upsertUserFoodPreference(userId, user, onboardingRequestDTO);
 		appendWeeklyGoal(user, onboardingRequestDTO);
+
+		// 온보딩을 마쳤으므로 userStatus를 ACTIVE로 변경
+		if (user.getUserStatus() == UserStatus.CREATED) {
+			user.activate();
+		}
 	}
 
 	// 온보딩 내 요리 수준을 upsert하는 메서드

--- a/src/main/java/com/cookeep/cookeep/domain/user/application/AuthService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/user/application/AuthService.java
@@ -163,7 +163,7 @@ public class AuthService {
 		if (user.getUserStatus() == UserStatus.CREATED) {
 			// 최초 회원가입인 경우 TERMS 페이지로 이동,
 			// 회원가입 이후 약관 동의까지 마친 경우 ONBOARDING 페이지로 이동
-			nextStep = (user.getMarketingConsent() == null)
+			nextStep = (marketingConsent == null)
 				? NextStep.TERMS
 				: NextStep.ONBOARDING;
 		}

--- a/src/main/java/com/cookeep/cookeep/domain/user/entity/User.java
+++ b/src/main/java/com/cookeep/cookeep/domain/user/entity/User.java
@@ -134,4 +134,9 @@ public class User extends BaseEntity {
 	public void updatePlantStatus(PlantStatus plantStatus) {
 		this.plantStatus = plantStatus;
 	}
+
+	public void activate() {
+		this.userStatus = UserStatus.ACTIVE;
+	}
+
 }


### PR DESCRIPTION
# Related Issue
#81 
</br></br>
# Description 

## 수정사항
- 카카오 회원가입 이후 약관 동의를 완료했는데도 재로그인 시 약관 동의 화면에 재진입하는 문제 발생
  - 선택 약관 미동의 시 프론트에서 api 호출을 하지 않아 발생한 문제로 추정
  - Swagger에서 api 호출로 선택 약관 값 주입 후 재로그인 시 문제 해결됨
  - 우선 온보딩 수정사항 배포 후 관련 사항 정리하여 프론트에 전달 예정
- 전화번호 기반 회원가입 이후 온보딩 응답을 완료했는데도 재로그인 시 온보딩 화면에 재진입하는 문제 발생
  - 온보딩 응답 시 userStatus == ACTIVE로 변경되도록 수정함
</br></br>

# Changes