### PR TITLE
Refactor/63 signup

### DIFF
--- a/src/main/java/com/cookeep/cookeep/common/exception/ErrorCode.java
+++ b/src/main/java/com/cookeep/cookeep/common/exception/ErrorCode.java
@@ -84,7 +84,7 @@ public enum ErrorCode {
 	DAILY_RECIPE_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 데일리 레시피로 등록된 AI 레시피입니다.", "DAILY_RECIPE-005"),
 
 	// 429
-	SMS_RESEND_TOO_FAST(HttpStatus.TOO_MANY_REQUESTS, "인증번호 재전송 요청이 너무 빠릅니다. 잠시 후 다시 시도해주세요.ㄱ", "SMS-005"),
+	SMS_RESEND_TOO_FAST(HttpStatus.TOO_MANY_REQUESTS, "인증번호 재전송 요청이 너무 빠릅니다. 잠시 후 다시 시도해주세요.", "SMS-005"),
 	SMS_TOO_MANY_ATTEMPTS(HttpStatus.TOO_MANY_REQUESTS, "인증 시도 횟수를 초과하였습니다. 잠시 후 다시 시도해주세요.", "SMS-006"),
 
 	//500

--- a/src/main/java/com/cookeep/cookeep/common/exception/ErrorCode.java
+++ b/src/main/java/com/cookeep/cookeep/common/exception/ErrorCode.java
@@ -78,6 +78,9 @@ public enum ErrorCode {
 	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부에서 에러가 발생하였습니다.", "COMMON-006"),
 	RECIPE_TITLE_PARSE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR,"레시피 제목 파싱 실패","RECIPE-020"),
 	INGREDIENTS_JSON_CONVERSION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR,"재료 JSON 변환에 실패했습니다.","RECIPE-021"),
+
+	// 503 SERVICE_UNAVAILABLE
+	NICKNAME_GENERATION_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE,"닉네임을 생성할 수 없습니다. 잠시 후 다시 시도해주세요.", "NICKNAME-001"),
 	;
 
 	private final HttpStatus httpStatus;

--- a/src/main/java/com/cookeep/cookeep/common/exception/ErrorCode.java
+++ b/src/main/java/com/cookeep/cookeep/common/exception/ErrorCode.java
@@ -40,6 +40,10 @@ public enum ErrorCode {
 	REFRIGERATOR_INVALID_QUERY(HttpStatus.BAD_REQUEST, "잘못된 쿼리 파라미터입니다.", "REFRIGERATOR-001"),
 	INVALID_SORT_TYPE(HttpStatus.BAD_REQUEST, "유효하지 않은 정렬 타입입니다.", "REFRIGERATOR-002"),
 	REFRIGERATOR_SEARCH_QUERY_REQUIRED(HttpStatus.BAD_REQUEST,"검색어를 입력해주세요.", "REFRIGERATOR-003"),
+	INVALID_PHONE_NUMBER(HttpStatus.BAD_REQUEST, "유효하지 않은 전화번호 형식입니다.", "SMS-001"),
+	INVALID_VERIFICATION_CODE(HttpStatus.BAD_REQUEST, "인증번호가 일치하지 않습니다.", "SMS-002"),
+	VERIFICATION_CODE_EXPIRED(HttpStatus.BAD_REQUEST, "인증번호가 만료되었습니다.", "SMS-003"),
+	VERIFICATION_NOT_COMPLETED(HttpStatus.BAD_REQUEST, "전화번호 인증이 완료되지 않았습니다.", "SMS-004"),
 
 	// 401 UNAUTHORIZED (인증 관련)
 	UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증에 실패했습니다.", "AUTH-001"),
@@ -66,9 +70,14 @@ public enum ErrorCode {
 	DUPLICATE_NICKNAME(HttpStatus.CONFLICT, "이미 사용 중인 닉네임입니다.", "USER-001"),
 	USER_PHONE_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 사용 중인 전화번호입니다.", "USER-002"),
 	USER_EMAIL_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 사용 중인 이메일입니다.", "USER-003"),
-	USER_EMAIL_REGISTERED_WITH_SOCIAL(HttpStatus.CONFLICT,"이미 소셜로 등록된 이메일입니다.", "USER-004"),
+	USER_EMAIL_REGISTERED_WITH_KAKAO(HttpStatus.CONFLICT,"이미 카카오로 가입된 이메일입니다.", "USER-004"),
+	USER_EMAIL_REGISTERED_WITH_GOOGLE(HttpStatus.CONFLICT,"이미 구글로 가입된 이메일입니다.", "USER-005"),
+	USER_EMAIL_REGISTERED_WITH_KAKAO_GOOGLE(HttpStatus.CONFLICT,"이미 카카오와 구글로 가입된 이메일입니다.", "USER-005"),
 	WEEKLY_GOAL_ALREADY_EXISTS(HttpStatus.CONFLICT, "이번 주 목표가 이미 설정되어 있습니다.", "WEEKLY_GOAL-001"),
 
+	// 429
+	SMS_RESEND_TOO_FAST(HttpStatus.TOO_MANY_REQUESTS, "인증번호 재전송 요청이 너무 빠릅니다. 잠시 후 다시 시도해주세요.ㄱ", "SMS-005"),
+	SMS_TOO_MANY_ATTEMPTS(HttpStatus.TOO_MANY_REQUESTS, "인증 시도 횟수를 초과하였습니다. 잠시 후 다시 시도해주세요.", "SMS-006"),
 
 	//500
 	FILE_UPLOAD_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "파일 업로드에 실패했습니다.", "FILE-001"),
@@ -78,6 +87,10 @@ public enum ErrorCode {
 	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부에서 에러가 발생하였습니다.", "COMMON-006"),
 	RECIPE_TITLE_PARSE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR,"레시피 제목 파싱 실패","RECIPE-020"),
 	INGREDIENTS_JSON_CONVERSION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR,"재료 JSON 변환에 실패했습니다.","RECIPE-021"),
+	SMS_PROVIDER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "SMS 서비스 오류가 발생했습니다.", "SMS-007"),
+	SMS_SEND_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "인증번호 발송 중 오류가 발생했습니다.", "SMS-008"),
+	USERAUTH_DOES_NOT_EXIST (HttpStatus.INTERNAL_SERVER_ERROR, "UserAuth 정보가 존재하지 않습니다.", "AUTH-003"),
+
 
 	// 503 SERVICE_UNAVAILABLE
 	NICKNAME_GENERATION_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE,"닉네임을 생성할 수 없습니다. 잠시 후 다시 시도해주세요.", "NICKNAME-001"),

--- a/src/main/java/com/cookeep/cookeep/domain/nickname/dao/NicknameActionRepository.java
+++ b/src/main/java/com/cookeep/cookeep/domain/nickname/dao/NicknameActionRepository.java
@@ -1,9 +1,14 @@
 package com.cookeep.cookeep.domain.nickname.dao;
 
+import java.util.List;
+
 import com.cookeep.cookeep.domain.nickname.entity.NicknameAction;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface NicknameActionRepository extends JpaRepository<NicknameAction, Long> {
+	@Query("select a.actionName from NicknameAction a")
+	List<String> findAllActionNames();
 }

--- a/src/main/java/com/cookeep/cookeep/domain/nickname/dao/NicknameFoodRepository.java
+++ b/src/main/java/com/cookeep/cookeep/domain/nickname/dao/NicknameFoodRepository.java
@@ -1,9 +1,14 @@
 package com.cookeep.cookeep.domain.nickname.dao;
 
+import java.util.List;
+
 import com.cookeep.cookeep.domain.nickname.entity.NicknameFood;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface NicknameFoodRepository extends JpaRepository<NicknameFood, Long> {
+	@Query("select f.foodName from NicknameFood f")
+	List<String> findAllFoodNames();
 }

--- a/src/main/java/com/cookeep/cookeep/domain/user/application/AuthService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/user/application/AuthService.java
@@ -6,6 +6,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -47,6 +48,7 @@ public class AuthService {
 	private final JwtTokenProvider jwtTokenProvider;
 	private final UserReader userReader;
 	private final PasswordEncoder passwordEncoder;
+	private final NicknameGenerator nicknameGenerator;
 
 	// 액세스 토큰이 만료되었을 경우 리프레쉬 토큰으로 액세스 토큰 갱신
 	@Transactional
@@ -110,6 +112,9 @@ public class AuthService {
 		return new TokenPair(accessToken, refreshToken);
 	}
 
+	// 닉네임 제약 위반 시 재시도 횟수를 제한하기 위한 값 (무한 반복 방지)
+	private static final int MAX_TRIES = 30;
+
 	// 카카오 로그인
 	@Transactional
 	public KakaoLoginResponseDTO kakaoLogin(String code, String redirectUri) {
@@ -126,14 +131,11 @@ public class AuthService {
 		// 신규 유저일 경우 User, UserAuth값을 새롭게 생성함
 		UserAuth userAuth = existingUserAuth
 			.orElseGet(() -> {
-				// User 값 새롭게 생성
-				User newUser = userRepository.save(User.builder()
-					.email(email)
-					.build());
+				User user = createKakaoUser(email);
 
 				return userAuthRepository.save(
 					UserAuth.builder()
-						.user(newUser)
+						.user(user)
 						.provider(KAKAO)
 						.providerUserId(kakaoId)
 						.build());
@@ -163,6 +165,33 @@ public class AuthService {
 		);
 	}
 
+	private User createKakaoUser(String email) {
+
+		for (int i = 0; i < MAX_TRIES; i++) {
+			String nickname = nicknameGenerator.generateRandomNickname();
+
+			try {
+				return userRepository.saveAndFlush(User.builder()
+					.email(email)
+					.nickname(nickname)
+					.build());
+			} catch (DataIntegrityViolationException e) {
+				// 닉네임 관련 제약 위반인 경우에만 재시도
+				if (shouldRetryNickname(e)) {
+					log.debug("Nickname conflict during kakao signup. try={}/{}", i + 1, MAX_TRIES);
+					continue;
+				}
+				// 그 외 제약 위반은 에러 발생
+				log.error("Signup failed due to integrity violation (non-nickname).", e);
+				throw e;
+			}
+		}
+
+		log.warn("Failed to generate unique nickname after {} tries (kakao signup).", MAX_TRIES);
+		throw new AppException(ErrorCode.NICKNAME_GENERATION_UNAVAILABLE);
+	}
+
+
 	@Transactional
 	public SignUpResponseDTO signUp(SignupRequestDTO signupRequestDTO) {
 
@@ -183,12 +212,39 @@ public class AuthService {
 
 		Boolean marketingConsent = signupRequestDTO.marketingConsent();
 
-		User user = userRepository.save(User.builder()
-			.phoneNumber(phoneNumber)
-			.email(email)
-			.password(encodedPassword)
-			.marketingConsent(marketingConsent)
-			.build());
+		User user = null;
+
+		for (int i = 0; i < MAX_TRIES; i++) {
+
+			String nickname = nicknameGenerator.generateRandomNickname();
+
+			try {
+				user = userRepository.saveAndFlush(User.builder()
+					.phoneNumber(phoneNumber)
+					.email(email)
+					.password(encodedPassword)
+					.marketingConsent(marketingConsent)
+					.nickname(nickname)
+					.build());
+
+				break; // 중복 없이 저장 성공한 경우
+			} catch (DataIntegrityViolationException e) {
+				// 닉네임 관련 제약 위반일 경우에만 재시도
+				if (shouldRetryNickname(e)) {
+					log.debug("Nickname conflict during signup. try={}/{}", i + 1, MAX_TRIES);
+					continue;
+				}
+				// 그 외 제약 위반은 에러 발생
+				log.error("Signup failed due to integrity violation (non-nickname).", e);
+				throw e;
+			}
+		}
+
+		if (user == null) {
+			// MAX_TRIES를 초과해서 실패하는 경우
+			log.error("Failed to generate unique nickname after {} tries.", MAX_TRIES);
+			throw new AppException(ErrorCode.NICKNAME_GENERATION_UNAVAILABLE);
+		}
 
 		// 액세스 토큰, 리프레쉬 토큰 발급
 		TokenPair tokenPair = issueTokensAndUpsertSession(user);
@@ -202,6 +258,20 @@ public class AuthService {
 		return new SignUpResponseDTO(
 			user.getUserId(), tokenPair.accessToken(), tokenPair.refreshToken()
 		);
+	}
+
+	private boolean shouldRetryNickname(DataIntegrityViolationException e) {
+		// DataIntegrityViolationException 중 닉네임 관련 제약 위반인지 식별
+		Throwable t = e;
+		while (t != null) { // 예외 체인 내에서 DB 에러 메세지를 탐색
+			String message = t.getMessage();
+			if (message != null && message.contains("nickname")) {
+				// 닉네임 관련 제약 위반으로 판단
+				return true;
+			}
+			t = t.getCause();
+		}
+		return false;
 	}
 
 	private void checkEmail(String email) {

--- a/src/main/java/com/cookeep/cookeep/domain/user/application/AuthService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/user/application/AuthService.java
@@ -3,8 +3,12 @@ package com.cookeep.cookeep.domain.user.application;
 import static com.cookeep.cookeep.domain.user.entity.Provider.*;
 
 import java.time.LocalDateTime;
+import java.util.EnumSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -276,23 +280,35 @@ public class AuthService {
 
 	private void checkEmail(String email) {
 		User user = userRepository.findByEmail(email).orElse(null);
-		if (user == null) return;
+		if (user == null) return; // 중복된 이메일이 아닐 경우 null 반환
 
 		List<UserAuth> auths = userAuthRepository.findAllByUser(user);
 		if (auths.isEmpty()) {
-			throw new IllegalStateException("UserAuth가 존재하지 않는 User입니다. 서버에 문의해주세요.");
+			throw new AppException(ErrorCode.USERAUTH_DOES_NOT_EXIST);
 		}
 
-		boolean hasLocal = auths.stream()
-			.anyMatch(a -> a.getProvider() == Provider.LOCAL);
+		// 어떤 provider로 가입된 이메일인지 판별하기 위해
+		EnumSet<Provider> providerSet = auths.stream()
+			.map(UserAuth::getProvider)
+			.collect(Collectors.toCollection(() -> EnumSet.noneOf(Provider.class)));
 
-		if (hasLocal) {
-			// LOCAL 사용자로 이미 등록된 이메일일 경우
+		// LOCAL 가입자인 경우
+		// LOCAL+KAKAO, LOCAL+GOOGLE은 불가능하므로 LOCAL인 경우는 단독으로 처리
+		if (providerSet.contains(Provider.LOCAL)) {
 			throw new AppException(ErrorCode.USER_EMAIL_ALREADY_EXISTS);
 		}
 
-		// LOCAL이 아니라 소셜로만 가입된 이메일일 경우
-		throw new AppException(ErrorCode.USER_EMAIL_REGISTERED_WITH_SOCIAL);
+		// 소셜 가입자인 경우 이메일도 함께 반환해야 하므로 ErrorCode 매핑만 함
+		Map<Set<Provider>, ErrorCode> socialProviderErrorMap = Map.of(
+			EnumSet.of(Provider.KAKAO), ErrorCode.USER_EMAIL_REGISTERED_WITH_KAKAO,
+			EnumSet.of(Provider.GOOGLE), ErrorCode.USER_EMAIL_REGISTERED_WITH_GOOGLE,
+			EnumSet.of(Provider.KAKAO, Provider.GOOGLE), ErrorCode.USER_EMAIL_REGISTERED_WITH_KAKAO_GOOGLE
+		);
+
+		ErrorCode errorCode = socialProviderErrorMap.get(providerSet);
+		if (errorCode != null) {
+			throw new AppException(errorCode);
+		}
 	}
 
 	@Transactional

--- a/src/main/java/com/cookeep/cookeep/domain/user/application/NicknameGenerator.java
+++ b/src/main/java/com/cookeep/cookeep/domain/user/application/NicknameGenerator.java
@@ -1,0 +1,50 @@
+package com.cookeep.cookeep.domain.user.application;
+
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+
+import org.springframework.stereotype.Service;
+
+import com.cookeep.cookeep.common.exception.AppException;
+import com.cookeep.cookeep.common.exception.ErrorCode;
+import com.cookeep.cookeep.domain.nickname.dao.NicknameActionRepository;
+import com.cookeep.cookeep.domain.nickname.dao.NicknameFoodRepository;
+
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class NicknameGenerator {
+	private final NicknameActionRepository nicknameActionRepository;
+	private final NicknameFoodRepository nicknameFoodRepository;
+
+	private List<String> actions;
+	private List<String> foods;
+
+	@PostConstruct // 서버 시작 시 NicknameGenerator 빈이 초기화된 직후에 한 번 실행
+		// 회원가입 시점에 seed 누락으로 인한 오류를 방지하기 위해
+		// 서버 시작 단계에서 닉네임 seed 데이터를 검증 및 로딩하도록 하였음
+	void loadNicknameList() {
+		actions = nicknameActionRepository.findAllActionNames();
+		foods = nicknameFoodRepository.findAllFoodNames();
+		if (actions.isEmpty() || foods.isEmpty()) {
+			log.debug("[ERROR] Nickname seed empty: actions=" + actions.size() + ", foods=" + foods.size());
+			throw new AppException(ErrorCode.NICKNAME_GENERATION_UNAVAILABLE);
+		}
+	}
+
+	String generateRandomNickname() {
+		// 웹 서버는 멀티 스레드 환경이므로
+		// 멀티 스레드 환경에서 Random의 동기화 비용을 피하기 위해 ThreadLocalRandom을 사용함
+		int actionIndex = ThreadLocalRandom.current().nextInt(actions.size());
+		int foodIndex   = ThreadLocalRandom.current().nextInt(foods.size());
+
+		String action = actions.get(actionIndex);
+		String food   = foods.get(foodIndex);
+
+		return action + " " + food;
+	}
+}

--- a/src/main/java/com/cookeep/cookeep/domain/user/entity/User.java
+++ b/src/main/java/com/cookeep/cookeep/domain/user/entity/User.java
@@ -29,9 +29,7 @@ public class User extends BaseEntity {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long userId;
 
-	// 닉네임 처리는 추후 값 전달받은 후에 업데이트할 예정
-	//@Column(length = 10, nullable = false, unique = true)
-	@Column(length = 10, unique = true, nullable = true)
+	@Column(length = 10, nullable = false, unique = true)
 	private String nickname;
 
 	// 소셜 로그인은 전화번호를 수집하지 않으므로 nullable


### PR DESCRIPTION
# Related Issue
#63 
</br></br>
# Description 

## 회원가입 시 랜덤 닉네임 자동 생성 기능 추가
- 신규 회원가입 시 랜덤 닉네임을 자동으로 부여하도록 구현
- NicknameGenerator를 별도 컴포넌트로 분리하여 닉네임 생성 책임을 분리하였음
- 서버 시작 시 seed 데이터(action, food)를 로딩하고, 누락 시 예외 발생하도록 처리
  - 회원가입 시점에서 seed 누락으로 인한 오류를 방지하기 위함
- 닉네임 UNIQUE 제약 충돌 발생 시 최대 30회까지 재시도하도록 로직 추가
  - 닉네임 관련 제약 위반인지 식별하여 재시도 여부 판단
  - 무한 반복 방지를 위해 임의로 30회로 제한하였음
- 멀티 스레드 환경에서 Random의 동기화 비용을 피하기 위해 ThreadLocalRandom 사용
</br>

## User.nickname 제약 수정
- nickname 컬럼을 `nullable = false, unique = true`로 변경
- 모든 사용자에 대해 닉네임이 필수로 생성함
</br>

## 소셜 로그인 신규 사용자 생성 구조 정리
- 카카오 로그인 시 신규 User 생성 로직을 별도 메서드로 분리
</br>

## 회원가입 이메일 중복 시 응답 수정
- 소셜로 이미 가입된 이메일일 경우 가입된 Provider에 따라 ErrorCode 분기 처리

</br></br>
# Changes
- NicknameGenerator 추가
- NicknameActionRepository / NicknameFoodRepository 쿼리 메서드 추가
- AuthService 닉네임 생성 및 재시도 로직 추가
- AuthService 이메일 중복 체크 로직 개선
- 카카오 신규 회원 생성 로직 분리
- User.nickname 컬럼 제약 수정 (nullable → false)
- ErrorCode 추가