### PR TITLE
fix: 마이쿠킵 프로필에 현재 키우는 식물의 이름을 응답값에 추가

### DIFF
--- a/src/main/java/com/cookeep/cookeep/api/dto/response/MyProfileResponseDto.java
+++ b/src/main/java/com/cookeep/cookeep/api/dto/response/MyProfileResponseDto.java
@@ -14,6 +14,7 @@ import java.time.temporal.ChronoUnit;
 public class MyProfileResponseDto {
     private String nickname;
     private String profilePlantImageUrl;
+    private String growingPlantName;
     private Long daysSinceJoined;
     private WeeklyGoalDto weeklyGoal;
 
@@ -35,7 +36,7 @@ public class MyProfileResponseDto {
         }
     }
 
-    public static MyProfileResponseDto of(User user, WeeklyGoal weeklyGoal) {
+    public static MyProfileResponseDto of(User user, WeeklyGoal weeklyGoal, String growingPlantName) {
         String profileImageUrl = null;
         if (user.getProfilePlant() != null) {
             profileImageUrl = user.getProfilePlant().getCurrentImageUrl();
@@ -47,10 +48,11 @@ public class MyProfileResponseDto {
         ) + 1; // 가입 당일을 1일로 계산
 
         return MyProfileResponseDto.builder()
-                .nickname(user.getNickname())
-                .profilePlantImageUrl(profileImageUrl)
-                .daysSinceJoined(daysSinceJoined)
-                .weeklyGoal(weeklyGoal != null ? WeeklyGoalDto.from(weeklyGoal) : null)
-                .build();
+            .nickname(user.getNickname())
+            .profilePlantImageUrl(profileImageUrl)
+            .growingPlantName(growingPlantName)
+            .daysSinceJoined(daysSinceJoined)
+            .weeklyGoal(weeklyGoal != null ? WeeklyGoalDto.from(weeklyGoal) : null)
+            .build();
     }
 }

--- a/src/main/java/com/cookeep/cookeep/domain/mycookeep/application/MyCookeepService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/mycookeep/application/MyCookeepService.java
@@ -8,6 +8,7 @@ import com.cookeep.cookeep.domain.onboarding.dao.WeeklyGoalRepository;
 import com.cookeep.cookeep.domain.onboarding.entity.WeeklyGoal;
 import com.cookeep.cookeep.domain.user.application.UserReader;
 import com.cookeep.cookeep.domain.user.entity.User;
+import com.cookeep.cookeep.domain.plant.dao.UserPlantRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -23,6 +24,7 @@ public class MyCookeepService {
 
     private final UserReader userReader;
     private final WeeklyGoalRepository weeklyGoalRepository;
+    private final UserPlantRepository userPlantRepository;
 
     @Transactional(readOnly = true)
     public MyProfileResponseDto getProfile(Long userId) {
@@ -34,7 +36,13 @@ public class MyCookeepService {
                 .findFirstByUserAndWeekStartDateOrderByCreatedAtDesc(user, currentWeekStart)
                 .orElse(null);
 
-        return MyProfileResponseDto.of(user, weeklyGoal);
+        // 현재 키우는 식물(수확되지 않은, 얼지 않은 식물)의 이름 조회
+        String growingPlantName = userPlantRepository
+            .findByUserAndIsHarvestedFalseAndIsFrozenFalse(user)
+            .map(userPlant -> userPlant.getPlant().getPlantType().getDisplayName())
+            .orElse(null);
+
+        return MyProfileResponseDto.of(user, weeklyGoal, growingPlantName);
     }
 
     public void setWeeklyGoal(Long userId, WeeklyGoalRequestDto request) {


### PR DESCRIPTION
# Related Issue
CLOSE #84 


# Description
마이쿠킵 탭 진입 시 불러오는 프로필에 현재 키우는 식물의 이름을 함께 반환합니다.

```json
{
  "status": "OK",
  "timestamp": "2026-02-10 22:09:05",
  "data": {
    "daysSinceJoined": 3,
    "growingPlantName": "강낭콩",
    "nickname": "댕굴",
    "profilePlantImageUrl": "https://s3.aws.../common_seed.png",
    "weeklyGoal": {
      "achieved": false,
      "currentCount": 0,
      "goalActionType": "RECIPE_LIKE",
      "targetCount": 2
    }
  }
}
```
⬆️ 위와 같이

# Changes

- MyProfileResponseDto에 growingPlantName 필드 추가 및 빌더/팩토리 메서드 업데이트

- MyCookeepService에서 UserPlantRepository 주입 후, 
[isHarvested = false] 및 [isFrozen = false]인 **현재 키우는 식물**의 이름(한글 표시명)을 조회하여 DTO에 전달하도록 변경