### PR TITLE
fix: folderName의 camelCase 요청 값 변환 지원

### DIFF
--- a/src/main/java/com/cookeep/cookeep/common/util/ImageFolder.java
+++ b/src/main/java/com/cookeep/cookeep/common/util/ImageFolder.java
@@ -1,5 +1,6 @@
 package com.cookeep.cookeep.common.util;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -11,4 +12,14 @@ public enum ImageFolder {
 	INGREDIENTS("ingredients");
 
 	private final String folderName;
+
+	@JsonCreator
+	public static ImageFolder fromValue(String value) {
+		for (ImageFolder folder : ImageFolder.values()) {
+			if (folder.folderName.equals(value)) {
+				return folder;
+			}
+		}
+		throw new IllegalArgumentException("Invalid ImageFolder value: " + value);
+	}
 }

--- a/src/main/java/com/cookeep/cookeep/common/util/ImageFolder.java
+++ b/src/main/java/com/cookeep/cookeep/common/util/ImageFolder.java
@@ -1,6 +1,5 @@
 package com.cookeep.cookeep.common.util;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -13,7 +12,6 @@ public enum ImageFolder {
 
 	private final String folderName;
 
-	@JsonCreator
 	public static ImageFolder fromValue(String value) {
 		for (ImageFolder folder : ImageFolder.values()) {
 			if (folder.folderName.equals(value)) {

--- a/src/main/java/com/cookeep/cookeep/config/WebMvcConfig.java
+++ b/src/main/java/com/cookeep/cookeep/config/WebMvcConfig.java
@@ -1,0 +1,24 @@
+package com.cookeep.cookeep.config;
+
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.format.FormatterRegistry;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import com.cookeep.cookeep.common.util.ImageFolder;
+
+@Component
+public class WebMvcConfig implements WebMvcConfigurer {
+
+	@Override
+	public void addFormatters(FormatterRegistry registry) {
+		registry.addConverter(new StringToImageFolderConverter());
+	}
+
+	public static class StringToImageFolderConverter implements Converter<String, ImageFolder> {
+		@Override
+		public ImageFolder convert(String source) {
+			return ImageFolder.fromValue(source);
+		}
+	}
+}


### PR DESCRIPTION
# Related Issue
CLOSE #89 

# Description
이미지 업로드시에, folder=recipeImages 같은 camelCase 요청 파라미터가 API에서 enum 변환 실패로 예외를 발생시키던 문제가 있었습니다.

Spring의 기본 enum 변환은 enum 상수명(RECIPE_IMAGES)만 인식하여 recipeImages로 전달된 값은 변환되지 않은 게 원인이었습니다.

# Changes
- `ImageFolder` enum - `fromValue(String)`메서드 추가 

      - FolderName의 값을 기반으로 enum 변환 지원
      
- `WebMvcConfig` 생성 (String -> ImageFolder 변환기 역할)

      -  ImageFolder.fromValue()를 이용하여 문자열을 enum으로 변환
      
- 이제 클라이언트는 `folder=recipeImages`, `folder=plants`, `folder=ingredients` 
  등의 camelCase 파라미터를 사용 가능

(프론트 측에서 대문자 넣어 요청해도 되긴 하지만 REST API 관례상 파라미터에는 camelCase를 넣는 게 맞고, 클라이언트가 내부 enum 상수명을 알아야 한다는 점에서 캡슐화 위반 등을 고려해 리팩토링했습니다!!)