### PR TITLE
feat(s3): svg image 업로드 검증 로직 구현

### DIFF
--- a/src/main/java/com/cookeep/cookeep/common/util/S3Service.java
+++ b/src/main/java/com/cookeep/cookeep/common/util/S3Service.java
@@ -1,5 +1,7 @@
 package com.cookeep.cookeep.common.util;
 
+import java.nio.charset.StandardCharsets;
+import java.util.Set;
 import java.util.UUID;
 
 import org.springframework.beans.factory.annotation.Value;
@@ -32,13 +34,17 @@ public class S3Service {
 	public String upload(MultipartFile file, String folder) {
 		String originalFilename = file.getOriginalFilename();
 		String extension = extractExtension(originalFilename);
+
+		validateFile(file, extension, folder);
+
 		String key = folder + "/" + UUID.randomUUID() + "." + extension;
+		String contentType = resolveContentType(file, extension);
 
 		try {
 			PutObjectRequest request = PutObjectRequest.builder()
 				.bucket(bucket)
 				.key(key)
-				.contentType(file.getContentType())
+				.contentType(contentType)
 				.build();
 
 			s3Client.putObject(request, RequestBody.fromBytes(file.getBytes()));
@@ -72,4 +78,53 @@ public class S3Service {
 		String prefix = String.format("https://%s.s3.%s.amazonaws.com/", bucket, region);
 		return url.replace(prefix, "");
 	}
+
+	// --- svg용 ---
+	// SVG 허용 폴더: INGREDIENTS (아이콘 전용)
+	private static final Set<String> SVG_ALLOWED_FOLDERS = Set.of(
+			ImageFolder.INGREDIENTS.getFolderName()
+	);
+
+	private void validateSvgContent(MultipartFile file) {
+		try {
+			String svg = new String(file.getBytes(), StandardCharsets.UTF_8).toLowerCase();
+
+			if (svg.contains("<script")
+					|| svg.contains("onload=")
+					|| svg.contains("onclick=")
+					|| svg.contains("<foreignobject")) {
+				throw new AppException(ErrorCode.FILE_UPLOAD_ERROR);
+			}
+		} catch (Exception e) {
+			throw new AppException(ErrorCode.FILE_UPLOAD_ERROR);
+		}
+	}
+
+	private String resolveContentType(MultipartFile file, String extension) {
+		if ("svg".equalsIgnoreCase(extension)) {
+			return "image/svg+xml";
+		}
+		return file.getContentType();
+	}
+
+	private void validateFile(MultipartFile file, String extension, String folder) {
+		if ("svg".equalsIgnoreCase(extension)) {
+			validateSvgFolder(folder);
+			validateSvgContentType(file);
+			validateSvgContent(file);
+		}
+	}
+
+	private void validateSvgFolder(String folder) {
+		if (!SVG_ALLOWED_FOLDERS.contains(folder)) {
+			throw new AppException(ErrorCode.FILE_UPLOAD_ERROR);
+		}
+	}
+
+	private void validateSvgContentType(MultipartFile file) {
+		if (!"image/svg+xml".equalsIgnoreCase(file.getContentType())) {
+			throw new AppException(ErrorCode.FILE_UPLOAD_ERROR);
+		}
+	}
+
 }

--- a/src/main/resources/seed_ingredient.sql
+++ b/src/main/resources/seed_ingredient.sql
@@ -9,7 +9,7 @@ INSERT INTO default_ingredients
 (category, default_ingredient, default_unit, default_storage, default_expiration_days, ai_tip, image_url)
 VALUES
     -- 채소 (VEGETABLE)
-    ('VEGETABLE','상추','PIECE','FRIDGE',7,'키친타월로 감싸 밀봉 보관하면 수분이 유지돼요.','https://cookeep-images.s3.ap-northeast-2.amazonaws.com/ingredients/0a0cc3bd-1ade-46ed-897e-ba89ec09b7c0.png'),
+    ('VEGETABLE','상추','PIECE','FRIDGE',7,'키친타월로 감싸 밀봉 보관하면 수분이 유지돼요.','https://cookeep-images.s3.ap-northeast-2.amazonaws.com/ingredients/5af22114-d81c-4aa5-8914-fae6bfe8a379.svg'),
     ('VEGETABLE','깻잎','PIECE','FRIDGE',7,'세척하지 말고 보관했다가 사용 직전에 씻어주세요.','https://cookeep-images.s3.ap-northeast-2.amazonaws.com/ingredients/0a0cc3bd-1ade-46ed-897e-ba89ec09b7c0.png'),
     ('VEGETABLE','시금치','PIECE','FRIDGE',7,'숨이 잘 죽으니 공기를 최소화해 보관하세요.','https://cookeep-images.s3.ap-northeast-2.amazonaws.com/ingredients/0a0cc3bd-1ade-46ed-897e-ba89ec09b7c0.png'),
     ('VEGETABLE','청경채','PIECE','FRIDGE',7,'잎이 눌리지 않게 세워서 보관하면 좋아요.','https://cookeep-images.s3.ap-northeast-2.amazonaws.com/ingredients/0a0cc3bd-1ade-46ed-897e-ba89ec09b7c0.png),


### PR DESCRIPTION
# Issue
#88 

# Description
- INGREDIENTS 폴더에 업로드되는 아이콘 SVG 이미지를 안정적으로 지원하기 위해 S3 업로드 로직을 개선
- SVG 파일의 특성상 보안 이슈(XSS 등)가 발생할 수 있어, 아이콘 용도로만 제한적으로 허용하고 서버 단에서 최소한의 검증을 수행하도록 변경
- 기존 PNG/JPG 이미지 업로드 흐름에는 영향을 주지 않도록 설정

# Changes
- SVG 파일 업로드를 INGREDIENTS 폴더로 제한
- SVG 업로드 시 image/svg+xml content-type을 서버에서 강제 설정
- SVG 파일에 대해 <script>, 이벤트 핸들러(onload, onclick), <foreignObject> 포함 여부 검증 추가
- 업로드 전 파일 확장자 및 폴더 기반 검증 로직(validateFile) 추가
- SVG가 아닌 이미지 파일의 기존 업로드 로직은 그대로 유지

# Test Checklist
- [x] svg 형식 이미지 정상 동작 확인
- [x] 기타 형식 (png, jpg 등) 이미지 정상 동작 확인
- [x] 이미지 삭제 정상 동작 확인
- [x] rds 에서 이미지 Url svg 파일로 변경 완료