### PR TITLE
Fix: gemini 응답 형식 수정 및 의존성을 주입 문제 해결

### DIFF
--- a/src/main/java/com/cookeep/cookeep/api/controller/AiRecipeController.java
+++ b/src/main/java/com/cookeep/cookeep/api/controller/AiRecipeController.java
@@ -92,7 +92,6 @@ public class AiRecipeController {
             summary = "(MAIN05-02)AI 레시피 재요청",
             description = "기존 세션의 식재료 및 조건을 기반으로 AI에게 레시피를 재요청합니다."
     )
-    @SecurityRequirements
     @ApiErrorCodeExamples({
             ErrorCode.RECIPE_SESSIONID_REQUIRED,
             ErrorCode.AI_SESSION_NOT_FOUND,
@@ -148,7 +147,6 @@ public class AiRecipeController {
             summary = "(MAIN05-03)AI 레시피 채택",
             description = "생성된 AI 레시피 중 하나를 최종 레시피로 채택하고 세션을 완료 처리합니다."
     )
-    @SecurityRequirements
     @ApiErrorCodeExamples({
             ErrorCode.AI_SESSION_NOT_FOUND,
             ErrorCode.SESSION_ALREADY_COMPLETED,
@@ -196,7 +194,6 @@ public class AiRecipeController {
             summary = "(MAIN06-1) AI 레시피 대화 세션 목록 조회",
             description = "사용자의 모든 AI 레시피 대화 세션 조회 (즐겨찾기 분리, 최신순 정렬)"
     )
-    @SecurityRequirements
     @ApiErrorCodeExamples({
             ErrorCode.UNAUTHORIZED
     })
@@ -214,7 +211,6 @@ public class AiRecipeController {
             summary = "(MAIN06-2)AI 레시피 대화 세션 상세 조회",
             description = "특정 세션의 모든 대화 내역 조회 (AI 응답만)"
     )
-    @SecurityRequirements
     @ApiErrorCodeExamples({
             ErrorCode.UNAUTHORIZED,
             ErrorCode.AI_SESSION_NOT_FOUND
@@ -240,7 +236,6 @@ public class AiRecipeController {
             summary = "(MAIN06-3)AI 레시피 대화 세션 삭제",
             description = "특정 세션과 관련 메시지 모두 삭제"
     )
-    @SecurityRequirements
     @ApiErrorCodeExamples({
             ErrorCode.UNAUTHORIZED,
             ErrorCode.AI_SESSION_NOT_FOUND,
@@ -268,7 +263,6 @@ public class AiRecipeController {
             summary = "(MAIN07) AI 대화 세션 즐겨찾기 추가/삭제",
             description = "특정 세션의 즐겨찾기 상태를 변경합니다. (T -> F / F -> T)"
     )
-    @SecurityRequirements
     @ApiErrorCodeExamples({
             ErrorCode.UNAUTHORIZED,
             ErrorCode.AI_SESSION_NOT_FOUND,

--- a/src/main/java/com/cookeep/cookeep/domain/recipe/application/AiRecipeService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/recipe/application/AiRecipeService.java
@@ -102,7 +102,11 @@ public class AiRecipeService {
         List<IngredientDetailDto> enrichedIngredients =
                 enrichIngredientsFromUserIngredients(userIngredients);
 
-        // 3. 세션 생성
+        // 3. 유통기한 임박 식재료 포함 여부 확인
+        boolean hasUrgent = userIngredients.stream()
+                .anyMatch(ui -> ui.getLeftDays() == 0);
+
+        // 4. 세션 생성
         AiSession session = AiSession.builder()
                 .userId(userId)
                 .difficulty(request.getDifficulty())
@@ -235,11 +239,13 @@ public class AiRecipeService {
         // 7. 세션 완료 처리
         session.complete();
 
-        // 8. 식재료 섭취 차감
-        List<Long> ingredientIds = session.getIngredientIds();
+        // 8. 요청 재료 전체 수량 -1 (단위 무관, 0이 되면 삭제)
+        consumeIngredients(userId, session.getIngredientIds());
 
-        // 9. 임박 식재료 리워드 처리
-        processUrgentIngredientReward(userId, ingredientIds);
+        // 9. 임박 재료(leftDays=0) 포함 세션이면 쿠키 지급 (하루 1회)
+        if (Boolean.TRUE.equals(session.getHasUrgentIngredient())) {
+            grantUrgentCookieReward(userId);
+        }
 
         return AiRecipeAdoptResponseDto.builder()
                 .sessionId(session.getId())
@@ -590,5 +596,46 @@ public class AiRecipeService {
         }
     }
 
+    // 재료 차감 로직. (단위 상관없이 무조건 -1)
+    private void consumeIngredients(Long userId, List<Long> ingredientIds) {
+        if (ingredientIds == null || ingredientIds.isEmpty()) {
+            log.info("재료 차감 생략 - ingredientIds 없음: userId={}", userId);
+            return;
+        }
 
+        List<UserIngredient> targets = userIngredientRepository
+                .findAllByIngredientIdInAndUser_UserId(ingredientIds, userId);
+
+        if (targets.isEmpty()) {
+            log.warn("재료 차감 생략 - 유효한 재료 없음: userId={}", userId);
+            return;
+        }
+
+        for (UserIngredient ui : targets) {
+            int currentQty = ui.getQuantity();
+            if (currentQty > 1) {
+                // 수량 -1
+                ui.updateQuantity(currentQty - 1);
+                log.info("재료 수량 차감: ingredientId={}, {} → {}",
+                        ui.getIngredientId(), currentQty, currentQty - 1);
+            } else {
+                // quantity == 1 → 0이 되므로 삭제
+                userIngredientRepository.delete(ui);
+                log.info("재료 삭제(수량 0): ingredientId={}", ui.getIngredientId());
+            }
+        }
+    }
+
+    // 임박 식재료 포함 레시피 채택 시 쿠키 3개 지급 (1일1회)
+    private void grantUrgentCookieReward(Long userId) {
+        CookieLog.CookieLogType urgentType = CookieLog.CookieLogType.BONUS_URGENT_INGREDIENT_USE;
+        boolean granted = cookieService.grantDailyCookie(userId, urgentType);
+
+        if (granted) {
+            log.info("임박 재료 쿠키 지급 완료: userId={}, amount={}",
+                    userId, urgentType.getDefaultAmount());
+        } else {
+            log.info("임박 재료 쿠키 오늘 이미 지급됨, 미지급: userId={}", userId);
+        }
+    }
 }

--- a/src/main/java/com/cookeep/cookeep/domain/recipe/application/AiRecipeService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/recipe/application/AiRecipeService.java
@@ -112,12 +112,12 @@ public class AiRecipeService {
                 .difficulty(request.getDifficulty())
                 .attemptNumber(1)
                 .isCompleted(false)
-                .userIngredientIds(writeIngredientsAsJson(enrichedIngredients))
+                .userIngredientIds(writeEnrichedIngredientsAsJson(enrichedIngredients))
                 .build();
         aiSessionRepository.save(session);
 
         // 입력한 재료 저장 (채택시 차감)
-        session.setIngredientIds(request.getIngredientIds());
+        session.setIngredientIdsJson(writeIngredientIdsAsJson(request.getIngredientIds()));
 
         // 메시지 db에 저장
         saveInitialUserMessage(session, request);
@@ -224,28 +224,27 @@ public class AiRecipeService {
             throw new AppException(ErrorCode.SESSION_ALREADY_COMPLETED);
         }
 
-        // 3. 마지막 AI 메시지 조회 (채택할 레시피)
-        AiMessage lastAiMessage = getLastAiMessage(session);
+        // 3. AI 메시지를 레시피로 파싱
+        GeminiRecipeResponseDto recipe =
+                parseAiMessageToRecipe(getLastAiMessage(session).getContent());
 
-        // 4. AI 메시지를 레시피로 파싱
-        GeminiRecipeResponseDto recipe = parseAiMessageToRecipe(lastAiMessage.getContent());
-
-        // 5. ai_recipes 테이블에 저장
+        // 4. ai_recipes 테이블에 저장
         AiRecipe savedRecipe = saveAdoptedRecipe(session, recipe, userId);
 
-        // 6. USER 채택 메시지 저장
+        // 5. USER 채택 메시지 저장
         saveSimpleUserMessage(session, MessageType.ADOPT_RECIPE);
 
-        // 7. 세션 완료 처리
+        // 6. 세션 완료 처리
         session.complete();
 
+        // 7. 세션의 ingredientIds 조회
+        List<Long> ingredientIds = session.getIngredientIds();
+
         // 8. 요청 재료 전체 수량 -1 (단위 무관, 0이 되면 삭제)
-        consumeIngredients(userId, session.getIngredientIds());
+        consumeIngredients(userId, ingredientIds);
 
         // 9. 임박 재료(leftDays=0) 포함 세션이면 쿠키 지급 (하루 1회)
-        if (Boolean.TRUE.equals(session.getHasUrgentIngredient())) {
-            grantUrgentCookieReward(userId);
-        }
+        grantUrgentCookieRewardIfEligible(userId, ingredientIds);
 
         return AiRecipeAdoptResponseDto.builder()
                 .sessionId(session.getId())
@@ -481,9 +480,17 @@ public class AiRecipeService {
     }
 
     // 재료 JSON 형식 변환
-    private String writeIngredientsAsJson(List<IngredientDetailDto> ingredients) {
+    private String writeIngredientIdsAsJson(List<Long> ingredientIds) {
         try {
-            return objectMapper.writeValueAsString(ingredients);
+            return objectMapper.writeValueAsString(ingredientIds);
+        } catch (Exception e) {
+            throw new AppException(ErrorCode.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    private String writeEnrichedIngredientsAsJson(List<IngredientDetailDto> enrichedIngredients) {
+        try {
+            return objectMapper.writeValueAsString(enrichedIngredients);
         } catch (Exception e) {
             throw new AppException(ErrorCode.INTERNAL_SERVER_ERROR);
         }
@@ -542,57 +549,32 @@ public class AiRecipeService {
     }
 
     // 임박 식재료 레시피 채택 시 리워드 지급
-    private void processUrgentIngredientReward(Long userId, List<Long> ingredientIds) {
+    private void grantUrgentCookieRewardIfEligible(Long userId, List<Long> ingredientIds) {
         if (ingredientIds == null || ingredientIds.isEmpty()) {
-            log.info("No ingredients provided for recipe adopt. Skipping reward processing.");
             return;
         }
 
-        // 1. 사용자의 실제 보유 재료 조회
-        List<UserIngredient> userIngredients =
-                userIngredientRepository.findAllByIngredientIdInAndUser_UserId(ingredientIds, userId);
+        // 세션에 요청된 재료 중 leftDays == 0인 항목이 있는지 확인
+        List<UserIngredient> targets = userIngredientRepository
+                .findAllByIngredientIdInAndUser_UserId(ingredientIds, userId);
 
-        if (userIngredients.isEmpty()) {
-            log.warn("유효한 재료 없음, 임박 리워드 생략: userId={}", userId);
-            return;
-        }
-
-        // 2. 임박 식재료 확인 (leftDays <= 0)
-        boolean hasUrgent = userIngredients.stream()
-                .anyMatch(ui -> ui.getLeftDays() <= URGENT);
+        boolean hasUrgent = targets.stream()
+                .anyMatch(ui -> ui.getLeftDays() == 0);
 
         if (!hasUrgent) {
-            log.info("임박 재료 없음, 임박 리워드 생략: userId={}", userId);
+            log.info("임박 재료(leftDays=0) 없음, 쿠키 미지급: userId={}", userId);
             return;
         }
 
-        // 3. 재료 중 첫 번째만 수량 -1
-        UserIngredient targetIngredient = userIngredients.get(0);
-        int newQuantity = targetIngredient.getQuantity() - 1;
-
-        if (newQuantity > 0) {
-            // 수량만 감소
-            targetIngredient.updateQuantity(newQuantity);
-            log.info("재료 수량 감소: ingredientId={}, {} → {}",
-                    targetIngredient.getIngredientId(),
-                    targetIngredient.getQuantity() + 1,
-                    newQuantity);
-        } else {
-            // 수량이 0이 되면 삭제
-            userIngredientRepository.delete(targetIngredient);
-            log.info("재료 삭제(수량 0): ingredientId={}",
-                    targetIngredient.getIngredientId());
-        }
-
-        // 4. 임박 식재료 리워드 지급 (하루 1회)
+        // BONUS_URGENT_INGREDIENT_USE: defaultAmount = 3, grantDailyCookie로 1일1회 보장
         CookieLog.CookieLogType urgentType = CookieLog.CookieLogType.BONUS_URGENT_INGREDIENT_USE;
         boolean granted = cookieService.grantDailyCookie(userId, urgentType);
 
         if (granted) {
-            log.info("임박 재료 리워드 지급: userId={}, amount={}",
-                    userId, urgentType.getDefaultAmount());
+            log.info("임박 재료 쿠키 {}개 지급 완료: userId={}",
+                    urgentType.getDefaultAmount(), userId);
         } else {
-            log.info("임박 재료 리워드 오늘 이미 지급됨: userId={}", userId);
+            log.info("임박 재료 쿠키 오늘 이미 지급됨, 미지급: userId={}", userId);
         }
     }
 
@@ -614,12 +596,11 @@ public class AiRecipeService {
         for (UserIngredient ui : targets) {
             int currentQty = ui.getQuantity();
             if (currentQty > 1) {
-                // 수량 -1
                 ui.updateQuantity(currentQty - 1);
                 log.info("재료 수량 차감: ingredientId={}, {} → {}",
                         ui.getIngredientId(), currentQty, currentQty - 1);
             } else {
-                // quantity == 1 → 0이 되므로 삭제
+                // quantity == 1이면 -1 = 0, 섭취 완료로 삭제
                 userIngredientRepository.delete(ui);
                 log.info("재료 삭제(수량 0): ingredientId={}", ui.getIngredientId());
             }

--- a/src/main/java/com/cookeep/cookeep/domain/recipe/application/GeminiService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/recipe/application/GeminiService.java
@@ -168,21 +168,21 @@ public class GeminiService {
         [난이도]
         %s
         
-                [규칙]
-                1. 제공된 재료의 단위를 반드시 사용하세요.
-                2. 각 재료의 적절한 수량(quantity)을 생성하세요.
-                   - 수량은 반드시 0보다 큰 양수여야 합니다. (0은 절대 불가)
-                   - 0.5, 1, 1.5, 2 등 소수점 첫 번째 자리까지 표현 가능합니다.
-                   - 예: 0은 불가, 최소 0.5 이상이어야 합니다.
-                3. user_ingredients에는 type, referenceId, name, quantity, unit을 모두 포함하세요.
-                4. 추가로 필요한 재료가 있다면 additional_ingredients에 포함하세요.
-                5. 생략 가능하거나 대체 가능한 재료는 optional_ingredients에 포함하세요.
-                6. youtube_search_queries에는 이 레시피를 유튜브에서 검색할 때 쓸 한국어 검색어를 1~3개 작성하세요.
-                   - 검색어는 실제로 유튜브에서 검색했을 때 관련 영상이 나올만한 구체적인 표현을 사용하세요.
-                   - 예: "김치볶음밥 만들기", "간단한 김치볶음밥 레시피", "볶음밥 황금레시피"
-                7. URL이나 링크는 절대 생성하지 마세요. 검색어만 제공하면 됩니다.
-                8. 반드시 JSON만 응답하세요. 설명 문구는 절대 포함하지 마세요.
-                9. steps는 간결하고 실용적인 요리 방법을 단계별로 작성하세요.
+        [규칙]
+        1. 제공된 재료의 단위를 반드시 사용하세요.
+        2. 각 재료의 적절한 수량(quantity)을 생성하세요.
+           - 수량은 반드시 0보다 큰 양수여야 합니다. (0은 절대 불가)
+           - 소수점 첫 번째 자리까지 표현 가능합니다. 예: 0.5, 1, 1.5, 2
+        3. user_ingredients에는 ingredientId, name, quantity, unit을 모두 포함하세요.
+           - ingredientId는 제공된 값을 그대로 사용하세요. 절대 임의로 변경하지 마세요.
+        4. 추가로 필요한 재료가 있다면 additional_ingredients에 포함하세요.
+        5. 생략하거나 대체 가능한 재료는 optional_ingredients에 포함하세요.
+        6. youtube_search_queries에는 이 레시피를 유튜브에서 검색할 때 쓸 한국어 검색어를 1~3개 작성하세요.
+           - 실제로 유튜브에서 검색했을 때 관련 영상이 나올만한 구체적인 표현을 사용하세요.
+           - 예: "김치볶음밥 만들기", "간단한 김치볶음밥 레시피"
+        7. URL이나 링크는 절대 생성하지 마세요. 검색어만 제공하면 됩니다.
+        8. 반드시 JSON만 응답하세요. 설명 문구는 절대 포함하지 마세요.
+        9. steps는 간결하고 실용적인 요리 방법을 단계별로 작성하세요.
         
         [응답 형식]
         {
@@ -190,10 +190,10 @@ public class GeminiService {
           "ingredients": {
             "user_ingredients": %s,
             "additional_ingredients": [
-              {"name": "간장", "quantity": 2, "unit": "GRAM"}
+              {"name": "간장", "quantity": 2.0, "unit": "GRAM"}
             ],
             "optional_ingredients": [
-              {"name": "참기름", "quantity": 1, "unit": "GRAM"}
+              {"name": "참기름", "quantity": 0.5, "unit": "GRAM"}
             ]
           },
           "steps": [

--- a/src/main/java/com/cookeep/cookeep/domain/recipe/entity/AiSession.java
+++ b/src/main/java/com/cookeep/cookeep/domain/recipe/entity/AiSession.java
@@ -63,6 +63,11 @@ public class AiSession {
     @Column(name = "ingredient_ids", columnDefinition = "JSON")
     private String ingredientIdsJson;
 
+    // 유저 요청 식재료에 D-0 식재료 포함 여부 (true -> 쿠키 3개 지급/1일1회)
+    @Column(name = "has_urgent_ingredient", nullable = false)
+    @Builder.Default
+    private Boolean hasUrgentIngredient = false;
+
     // Domain Logic
     public void pin() {
         this.isPinned = true;


### PR DESCRIPTION
# Issue
#66 

# Description
- 기존 요청 바디 형식을 수정하면서 레시피 생성 프롬프트의 type 필드가 없어 응답 생성 실패 오류(500) 발생
- AiSession 엔티티 내부 ObjectMapper 사용 구조로 인해, JPA Entity에서 의존성을 주입하려 하면서 NullPointerException이 발생
- JSON 직렬화 책임을 Service 계층으로 이동하고, AiSession 엔티티는 순수하게 데이터만 보관하도록 수정

# Changes
- GeminiService 프롬프트 형식 수정
- AiSession
- - ObjectMapper 필드 및 JSON 직렬화/역직렬화 로직 제거
- - ingredientIdsJson 필드는 String 타입으로만 유지
- - Entity를 순수 데이터 모델로 정리
- AiRecipeService
- - ObjectMapper를 사용하여 ingredientIds (List<Long>), userIngredientIds (List<IngredientDetailDto>)를 JSON 문자열로 변환
- - 변환된 JSON 문자열을 AiSession에 세팅하도록 변경
- - writeIngredientIdsAsJson, writeEnrichedIngredientsAsJson 메서드 추가

# Test Checklist
- 레시피 생성시 발생하던 500 오류 해결 (Gemini 응답 생성 실패 오류)

# 추가 전달 사항
- 원래 레시피 채택 시 쿠키 지급 및 재료 차감 로직 구현하면서 발견한 문제입니다
- 레시피 채택 관련 로직은 계속 구현이 안되고 있어 시간이 걸릴 것 같습니다. 참고로 제가 가진 계정 세 개의 크레딧을 다 써서 목요일에 다시 시도해야할 것 같아요..
- 현재 수정사항을 반영해야 프론트에서도 오류가 안 날 것 같아서 먼저 pr 올립니다