### PR TITLE
feat: 쿠킵스 관련 일부 기능 개발

### DIFF
--- a/src/main/java/com/cookeep/cookeep/api/controller/CookeepsController.java
+++ b/src/main/java/com/cookeep/cookeep/api/controller/CookeepsController.java
@@ -1,0 +1,31 @@
+package com.cookeep.cookeep.api.controller;
+
+import com.cookeep.cookeep.api.dto.response.RankingResponseDto;
+import com.cookeep.cookeep.common.dto.DataResponse;
+import com.cookeep.cookeep.domain.cookeeps.application.CookeepsService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "쿠킵스", description = "쿠킵스(커뮤니티) 관련 API")
+@RestController
+@RequestMapping("/api/cookeeps")
+@RequiredArgsConstructor
+public class CookeepsController {
+
+	private final CookeepsService cookeepsService;
+
+	@Operation(summary = "이번 주 랭킹 조회", description = "이번 주 물주기 횟수 Top 3 유저와 좋아요 Top 3 레시피를 조회합니다.")
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200", description = "조회 성공")
+	})
+	@GetMapping("/ranking")
+	public DataResponse<RankingResponseDto> getRanking() {
+		return DataResponse.from(cookeepsService.getRanking());
+	}
+}

--- a/src/main/java/com/cookeep/cookeep/api/controller/MyCookeepController.java
+++ b/src/main/java/com/cookeep/cookeep/api/controller/MyCookeepController.java
@@ -28,7 +28,7 @@ public class MyCookeepController {
 
     private final MyCookeepService myCookeepService;
 
-    @Operation(summary = "마이쿠킵 프로필 조회", description = "닉네임, 프로필 식물 이미지, 가입 일수, 이번 주 목표를 조회합니다.")
+    @Operation(summary = "마이쿠킵 프로필 조회", description = "닉네임, 프로필 식물 이미지, 가입 일수, 현재 키우는 식물 이름, 이번 주 목표를 조회합니다.")
     @ApiErrorCodeExamples({
             ErrorCode.UNAUTHORIZED,
             ErrorCode.USER_NOT_FOUND,

--- a/src/main/java/com/cookeep/cookeep/api/controller/MyPlantController.java
+++ b/src/main/java/com/cookeep/cookeep/api/controller/MyPlantController.java
@@ -1,5 +1,6 @@
 package com.cookeep.cookeep.api.controller;
 
+import com.cookeep.cookeep.api.dto.response.GrowingPlantResponseDto;
 import com.cookeep.cookeep.api.dto.response.MyPlantResponseDto;
 import com.cookeep.cookeep.api.dto.response.RegisterPlantResponseDto;
 import com.cookeep.cookeep.common.dto.DataResponse;
@@ -31,6 +32,16 @@ public class MyPlantController {
     public DataResponse<List<MyPlantResponseDto>> getMyPlants(
             @AuthenticationPrincipal(expression = "userId") Long userId) {
         return DataResponse.from(userPlantService.getMyPlants(userId));
+    }
+
+    @Operation(summary = "현재 키우는 식물 조회", description = "쿠킵스 화면에서 현재 키우고 있는 식물 정보를 조회합니다. 키우는 식물이 없으면 data가 null입니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공")
+    })
+    @GetMapping("/growing-plant")
+    public DataResponse<GrowingPlantResponseDto> getGrowingPlant(
+            @AuthenticationPrincipal(expression = "userId") Long userId) {
+        return DataResponse.from(userPlantService.getGrowingPlant(userId));
     }
 
     @Operation(summary = "새로운 식물 등록", description = "기본 식물 ID를 경로에 전달하여 새로운 식물을 등록합니다.")

--- a/src/main/java/com/cookeep/cookeep/api/controller/RecipeLikeController.java
+++ b/src/main/java/com/cookeep/cookeep/api/controller/RecipeLikeController.java
@@ -29,8 +29,9 @@ public class RecipeLikeController {
 		description = "레시피에 좋아요를 추가하거나 취소합니다. 자신의 글에는 좋아요를 누를 수 없습니다."
 	)
 	@ApiErrorCodeExamples({
-		ErrorCode.UNAUTHORIZED,
-		ErrorCode.DAILY_RECIPE_NOT_FOUND
+			ErrorCode.UNAUTHORIZED,
+			ErrorCode.DAILY_RECIPE_NOT_FOUND,
+			ErrorCode.CANNOT_LIKE_OWN_RECIPE
 	})
 	@ApiResponses(value = {
 		@ApiResponse(responseCode = "200", description = "좋아요 토글 성공"),

--- a/src/main/java/com/cookeep/cookeep/api/controller/RecipeLikeController.java
+++ b/src/main/java/com/cookeep/cookeep/api/controller/RecipeLikeController.java
@@ -1,0 +1,89 @@
+package com.cookeep.cookeep.api.controller;
+
+import com.cookeep.cookeep.api.dto.response.RecipeLikeResponseDto;
+import com.cookeep.cookeep.common.dto.DataResponse;
+import com.cookeep.cookeep.common.exception.ErrorCode;
+import com.cookeep.cookeep.config.ApiErrorCodeExamples;
+import com.cookeep.cookeep.domain.dailyrecipe.application.RecipeLikeService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "레시피 좋아요", description = "레시피 좋아요 관련 API")
+@RestController
+@RequestMapping("/api/daily-recipes/{dailyRecipeId}/likes")
+@RequiredArgsConstructor
+public class RecipeLikeController {
+
+	private final RecipeLikeService recipeLikeService;
+
+	@Operation(
+		summary = "레시피 좋아요 토글",
+		description = "레시피에 좋아요를 추가하거나 취소합니다. 자신의 글에는 좋아요를 누를 수 없습니다."
+	)
+	@ApiErrorCodeExamples({
+		ErrorCode.UNAUTHORIZED,
+		ErrorCode.DAILY_RECIPE_NOT_FOUND
+	})
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200", description = "좋아요 토글 성공"),
+		@ApiResponse(responseCode = "401", description = "인증 실패", content = @Content),
+		@ApiResponse(responseCode = "403", description = "자신의 글에는 좋아요할 수 없음", content = @Content),
+		@ApiResponse(responseCode = "404", description = "레시피를 찾을 수 없음", content = @Content)
+	})
+	@PostMapping
+	public ResponseEntity<DataResponse<RecipeLikeResponseDto>> toggleLike(
+		@AuthenticationPrincipal(expression = "userId") Long userId,
+		@Parameter(description = "데일리 레시피 ID", required = true)
+		@PathVariable Long dailyRecipeId
+	) {
+		boolean isLiked = recipeLikeService.toggleLike(userId, dailyRecipeId);
+		long likeCount = recipeLikeService.getLikeCount(dailyRecipeId);
+
+		RecipeLikeResponseDto response = RecipeLikeResponseDto.from(
+			dailyRecipeId,
+			isLiked,
+			(int) likeCount
+		);
+
+		return ResponseEntity.ok(DataResponse.from(response));
+	}
+
+	@Operation(
+		summary = "레시피 좋아요 여부 조회",
+		description = "현재 사용자가 특정 레시피에 좋아요를 눌렀는지 확인합니다."
+	)
+	@ApiErrorCodeExamples({
+		ErrorCode.UNAUTHORIZED,
+		ErrorCode.DAILY_RECIPE_NOT_FOUND
+	})
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200", description = "좋아요 여부 조회 성공"),
+		@ApiResponse(responseCode = "401", description = "인증 실패", content = @Content),
+		@ApiResponse(responseCode = "404", description = "레시피를 찾을 수 없음", content = @Content)
+	})
+	@GetMapping("/check")
+	public ResponseEntity<DataResponse<RecipeLikeResponseDto>> checkLike(
+		@AuthenticationPrincipal(expression = "userId") Long userId,
+		@Parameter(description = "데일리 레시피 ID", required = true)
+		@PathVariable Long dailyRecipeId
+	) {
+		boolean isLiked = recipeLikeService.isLiked(userId, dailyRecipeId);
+		long likeCount = recipeLikeService.getLikeCount(dailyRecipeId);
+
+		RecipeLikeResponseDto response = RecipeLikeResponseDto.from(
+			dailyRecipeId,
+			isLiked,
+			(int) likeCount
+		);
+
+		return ResponseEntity.ok(DataResponse.from(response));
+	}
+}

--- a/src/main/java/com/cookeep/cookeep/api/dto/response/GrowingPlantResponseDto.java
+++ b/src/main/java/com/cookeep/cookeep/api/dto/response/GrowingPlantResponseDto.java
@@ -1,0 +1,27 @@
+package com.cookeep.cookeep.api.dto.response;
+
+import com.cookeep.cookeep.domain.plant.entity.PlantStatus;
+import com.cookeep.cookeep.domain.plant.entity.UserPlant;
+import com.cookeep.cookeep.domain.user.entity.User;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class GrowingPlantResponseDto {
+	private Long userPlantId;
+	private String plantName;
+	private Integer level;
+	private Integer wateringCnt;
+	private PlantStatus plantStatus;
+
+	public static GrowingPlantResponseDto from(UserPlant userPlant, User user) {
+		return GrowingPlantResponseDto.builder()
+			.userPlantId(userPlant.getUserPlantId())
+			.plantName(userPlant.getPlant().getPlantType().getDisplayName())
+			.level(userPlant.getLevel())
+			.wateringCnt(userPlant.getWaterCount())
+			.plantStatus(user.getPlantStatus())
+			.build();
+	}
+}

--- a/src/main/java/com/cookeep/cookeep/api/dto/response/RankingResponseDto.java
+++ b/src/main/java/com/cookeep/cookeep/api/dto/response/RankingResponseDto.java
@@ -22,6 +22,7 @@ public class RankingResponseDto {
 	@Getter
 	@Builder
 	public static class RecipeRankDto {
+		private Long dailyRecipeId;
 		private Integer rank;
 		private String title;
 		private Long likeCount;

--- a/src/main/java/com/cookeep/cookeep/api/dto/response/RankingResponseDto.java
+++ b/src/main/java/com/cookeep/cookeep/api/dto/response/RankingResponseDto.java
@@ -1,0 +1,30 @@
+package com.cookeep.cookeep.api.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class RankingResponseDto {
+	private List<WateringRankDto> wateringRanking;
+	private List<RecipeRankDto> recipeRanking;
+
+	@Getter
+	@Builder
+	public static class WateringRankDto {
+		private Integer rank;
+		private String nickname;
+		private String profileImageUrl;
+	}
+
+	@Getter
+	@Builder
+	public static class RecipeRankDto {
+		private Integer rank;
+		private String title;
+		private Long likeCount;
+		private String recipeImageUrl;
+	}
+}

--- a/src/main/java/com/cookeep/cookeep/api/dto/response/RecipeLikeResponseDto.java
+++ b/src/main/java/com/cookeep/cookeep/api/dto/response/RecipeLikeResponseDto.java
@@ -1,0 +1,20 @@
+package com.cookeep.cookeep.api.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class RecipeLikeResponseDto {
+	private Long dailyRecipeId;
+	private boolean isLiked; // true: 좋아요 추가, false: 좋아요 취소
+	private Integer likeCount; // 현재 좋아요 수
+
+	public static RecipeLikeResponseDto from(Long dailyRecipeId, boolean isLiked, Integer likeCount) {
+		return RecipeLikeResponseDto.builder()
+			.dailyRecipeId(dailyRecipeId)
+			.isLiked(isLiked)
+			.likeCount(likeCount)
+			.build();
+	}
+}

--- a/src/main/java/com/cookeep/cookeep/common/exception/ErrorCode.java
+++ b/src/main/java/com/cookeep/cookeep/common/exception/ErrorCode.java
@@ -59,6 +59,7 @@ public enum ErrorCode {
 	NOT_MY_PLANT(HttpStatus.FORBIDDEN, "해당 식물에 대한 권한이 없습니다.", "PLANT-001"),
 	AI_SESSION_FORBIDDEN(HttpStatus.FORBIDDEN, "본인의 대화 세션이 아닙니다.", "RECIPE-015"),
 	DAILY_RECIPE_FORBIDDEN(HttpStatus.FORBIDDEN, "본인의 레시피가 아닙니다.", "DAILY_RECIPE-001"),
+	CANNOT_LIKE_OWN_RECIPE(HttpStatus.FORBIDDEN, "자신의 레시피에는 좋아요를 누를 수 없습니다.", "DAILY_RECIPE-006"),
 
 	// 404 NOT FOUND
 	NOT_FOUND(HttpStatus.NOT_FOUND, "찾을 수 없습니다.", "COMMON-004"),

--- a/src/main/java/com/cookeep/cookeep/domain/cookeeps/application/CookeepsService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/cookeeps/application/CookeepsService.java
@@ -1,0 +1,93 @@
+package com.cookeep.cookeep.domain.cookeeps.application;
+
+import com.cookeep.cookeep.api.dto.response.RankingResponseDto;
+import com.cookeep.cookeep.api.dto.response.RankingResponseDto.RecipeRankDto;
+import com.cookeep.cookeep.api.dto.response.RankingResponseDto.WateringRankDto;
+import com.cookeep.cookeep.domain.dailyrecipe.dao.RecipeLikeRepository;
+import com.cookeep.cookeep.domain.dailyrecipe.entity.DailyRecipe;
+import com.cookeep.cookeep.domain.plant.dao.WateringLogRepository;
+import com.cookeep.cookeep.domain.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.temporal.TemporalAdjusters;
+import java.util.List;
+import java.util.stream.IntStream;
+
+@Service
+@RequiredArgsConstructor
+public class CookeepsService {
+
+	private final WateringLogRepository wateringLogRepository;
+	private final RecipeLikeRepository recipeLikeRepository;
+
+	@Transactional(readOnly = true)
+	public RankingResponseDto getRanking() {
+		LocalDateTime weekStart = LocalDate.now()
+			.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY))
+			.atStartOfDay();
+		LocalDateTime weekEnd = weekStart.plusDays(7);
+
+		List<WateringRankDto> wateringRanking = getWateringRanking(weekStart, weekEnd);
+		List<RecipeRankDto> recipeRanking = getRecipeRanking(weekStart, weekEnd);
+
+		return RankingResponseDto.builder()
+			.wateringRanking(wateringRanking)
+			.recipeRanking(recipeRanking)
+			.build();
+	}
+
+	private List<WateringRankDto> getWateringRanking(LocalDateTime weekStart, LocalDateTime weekEnd) {
+		// 1단계: 이번 주 물주기 상위 3명 조회
+		List<Object[]> results = wateringLogRepository.findTopWateringUsers(
+			weekStart, weekEnd, PageRequest.of(0, 3));
+		
+		// 2단계: 인덱스를 포함한 스트림 처리
+		return IntStream.range(0, results.size()) // 0부터 results 크기-1까지
+			.mapToObj(index -> {
+				Object[] row = results.get(index);
+				User user = (User) row[0]; // 유저 객체 추출
+
+				// 프로필 이미지 URL 가져오기
+				String profileImageUrl = user.getProfilePlant() != null
+					? user.getProfilePlant().getCurrentImageUrl()
+					: null;
+				
+				// DTO로 변환 (rank = 인덱스 + 1 → 1, 2, 3)
+				return WateringRankDto.builder()
+					.rank(index + 1)
+					.nickname(user.getNickname())
+					.profileImageUrl(profileImageUrl)
+					.build();
+			})
+			.toList();
+	}
+
+	private List<RecipeRankDto> getRecipeRanking(LocalDateTime weekStart, LocalDateTime weekEnd) {
+		// 1단계: 이번 주 좋아요 상위 3개 레시피 조회
+		List<Object[]> results = recipeLikeRepository.findTopLikedRecipes(
+			weekStart, weekEnd, PageRequest.of(0, 3));
+		
+		// 2단계: 인덱스를 포함한 스트림 처리
+		return IntStream.range(0, results.size())
+			.mapToObj(index -> {
+				Object[] row = results.get(index);
+				DailyRecipe recipe = (DailyRecipe) row[0]; // 레시피 객체 추출
+				Long likeCount = (Long) row[1]; // 좋아요 수 추출
+				
+				// DTO로 변환 (rank = 인덱스 + 1 → 1, 2, 3)
+				return RecipeRankDto.builder()
+					.rank(index + 1)
+					.title(recipe.getTitle())
+					.likeCount(likeCount)
+					.recipeImageUrl(recipe.getRecipeImageUrl())
+					.build();
+			})
+			.toList();
+	}
+}

--- a/src/main/java/com/cookeep/cookeep/domain/cookeeps/application/CookeepsService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/cookeeps/application/CookeepsService.java
@@ -82,11 +82,12 @@ public class CookeepsService {
 				
 				// DTO로 변환 (rank = 인덱스 + 1 → 1, 2, 3)
 				return RecipeRankDto.builder()
-					.rank(index + 1)
-					.title(recipe.getTitle())
-					.likeCount(likeCount)
-					.recipeImageUrl(recipe.getRecipeImageUrl())
-					.build();
+						.dailyRecipeId(recipe.getId())
+						.rank(index + 1)
+						.title(recipe.getTitle())
+						.likeCount(likeCount)
+						.recipeImageUrl(recipe.getRecipeImageUrl())
+						.build();
 			})
 			.toList();
 	}

--- a/src/main/java/com/cookeep/cookeep/domain/dailyrecipe/application/DailyRecipeService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/dailyrecipe/application/DailyRecipeService.java
@@ -14,11 +14,15 @@ import com.cookeep.cookeep.domain.user.entity.User;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.temporal.TemporalAdjusters;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;

--- a/src/main/java/com/cookeep/cookeep/domain/dailyrecipe/application/RecipeLikeService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/dailyrecipe/application/RecipeLikeService.java
@@ -1,0 +1,69 @@
+package com.cookeep.cookeep.domain.dailyrecipe.application;
+
+import com.cookeep.cookeep.common.exception.AppException;
+import com.cookeep.cookeep.common.exception.ErrorCode;
+import com.cookeep.cookeep.domain.dailyrecipe.dao.DailyRecipeRepository;
+import com.cookeep.cookeep.domain.dailyrecipe.dao.RecipeLikeRepository;
+import com.cookeep.cookeep.domain.dailyrecipe.entity.DailyRecipe;
+import com.cookeep.cookeep.domain.dailyrecipe.entity.RecipeLike;
+import com.cookeep.cookeep.domain.user.application.UserReader;
+import com.cookeep.cookeep.domain.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class RecipeLikeService {
+
+	private final RecipeLikeRepository recipeLikeRepository;
+	private final DailyRecipeRepository dailyRecipeRepository;
+	private final UserReader userReader;
+
+	// 좋아요 추가/삭제 토글
+	public boolean toggleLike(Long userId, Long dailyRecipeId) {
+		User user = userReader.readById(userId);
+		DailyRecipe dailyRecipe = dailyRecipeRepository.findById(dailyRecipeId)
+			.orElseThrow(() -> new AppException(ErrorCode.DAILY_RECIPE_NOT_FOUND));
+
+		// 자신의 글에 좋아요 불가
+		if (dailyRecipe.getUser().getUserId().equals(userId)) {
+			throw new AppException(ErrorCode.CANNOT_LIKE_OWN_RECIPE);
+		}
+
+		// 이미 좋아요를 눌렀으면 삭제
+		var existingLike = recipeLikeRepository.findByDailyRecipeAndUser(dailyRecipe, user);
+		if (existingLike.isPresent()) {
+			recipeLikeRepository.delete(existingLike.get());
+			dailyRecipe.decrementLikeCount();
+			return false; // 좋아요 취소
+		}
+
+		// 좋아요 추가
+		RecipeLike recipeLike = RecipeLike.builder()
+			.dailyRecipe(dailyRecipe)
+			.user(user)
+			.build();
+		recipeLikeRepository.save(recipeLike);
+		dailyRecipe.incrementLikeCount();
+		return true; // 좋아요 추가
+	}
+
+	// 특정 레시피의 좋아요 수 조회
+	@Transactional(readOnly = true)
+	public long getLikeCount(Long dailyRecipeId) {
+		DailyRecipe dailyRecipe = dailyRecipeRepository.findById(dailyRecipeId)
+			.orElseThrow(() -> new AppException(ErrorCode.DAILY_RECIPE_NOT_FOUND));
+		return recipeLikeRepository.countByDailyRecipe(dailyRecipe);
+	}
+
+	// 특정 사용자가 특정 레시피에 좋아요를 눌렀는지 확인
+	@Transactional(readOnly = true)
+	public boolean isLiked(Long userId, Long dailyRecipeId) {
+		User user = userReader.readById(userId);
+		DailyRecipe dailyRecipe = dailyRecipeRepository.findById(dailyRecipeId)
+			.orElseThrow(() -> new AppException(ErrorCode.DAILY_RECIPE_NOT_FOUND));
+		return recipeLikeRepository.existsByDailyRecipeAndUser(dailyRecipe, user);
+	}
+}

--- a/src/main/java/com/cookeep/cookeep/domain/dailyrecipe/dao/DailyRecipeRepository.java
+++ b/src/main/java/com/cookeep/cookeep/domain/dailyrecipe/dao/DailyRecipeRepository.java
@@ -3,6 +3,7 @@ package com.cookeep.cookeep.domain.dailyrecipe.dao;
 import com.cookeep.cookeep.domain.dailyrecipe.entity.DailyRecipe;
 import com.cookeep.cookeep.domain.recipe.entity.AiRecipe;
 import com.cookeep.cookeep.domain.user.entity.User;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;

--- a/src/main/java/com/cookeep/cookeep/domain/dailyrecipe/dao/RecipeLikeRepository.java
+++ b/src/main/java/com/cookeep/cookeep/domain/dailyrecipe/dao/RecipeLikeRepository.java
@@ -1,6 +1,8 @@
 package com.cookeep.cookeep.domain.dailyrecipe.dao;
 
 import com.cookeep.cookeep.domain.dailyrecipe.entity.RecipeLike;
+import com.cookeep.cookeep.domain.dailyrecipe.entity.DailyRecipe;
+import com.cookeep.cookeep.domain.user.entity.User;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -8,6 +10,7 @@ import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 public interface RecipeLikeRepository extends JpaRepository<RecipeLike, Long> {
 
@@ -20,4 +23,13 @@ public interface RecipeLikeRepository extends JpaRepository<RecipeLike, Long> {
 		@Param("weekStart") LocalDateTime weekStart,
 		@Param("weekEnd") LocalDateTime weekEnd,
 		Pageable pageable);
+
+	// 특정 사용자가 특정 레시피에 좋아요를 눌렀는지 확인
+	Optional<RecipeLike> findByDailyRecipeAndUser(DailyRecipe dailyRecipe, User user);
+
+	// 특정 레시피의 좋아요 수
+	long countByDailyRecipe(DailyRecipe dailyRecipe);
+
+	// 특정 사용자가 특정 레시피에 좋아요를 눌렀는지 boolean으로 확인
+	boolean existsByDailyRecipeAndUser(DailyRecipe dailyRecipe, User user);
 }

--- a/src/main/java/com/cookeep/cookeep/domain/dailyrecipe/dao/RecipeLikeRepository.java
+++ b/src/main/java/com/cookeep/cookeep/domain/dailyrecipe/dao/RecipeLikeRepository.java
@@ -1,0 +1,23 @@
+package com.cookeep.cookeep.domain.dailyrecipe.dao;
+
+import com.cookeep.cookeep.domain.dailyrecipe.entity.RecipeLike;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface RecipeLikeRepository extends JpaRepository<RecipeLike, Long> {
+
+	// 이번 주 등록된 레시피 중 이번 주에 받은 좋아요 Top N 조회
+	@Query("SELECT rl.dailyRecipe, COUNT(rl) FROM RecipeLike rl " +
+		   "WHERE rl.dailyRecipe.createdAt >= :weekStart AND rl.dailyRecipe.createdAt < :weekEnd " +
+		   "AND rl.createdAt >= :weekStart AND rl.createdAt < :weekEnd " +
+		   "GROUP BY rl.dailyRecipe ORDER BY COUNT(rl) DESC")
+	List<Object[]> findTopLikedRecipes(
+		@Param("weekStart") LocalDateTime weekStart,
+		@Param("weekEnd") LocalDateTime weekEnd,
+		Pageable pageable);
+}

--- a/src/main/java/com/cookeep/cookeep/domain/dailyrecipe/entity/DailyRecipe.java
+++ b/src/main/java/com/cookeep/cookeep/domain/dailyrecipe/entity/DailyRecipe.java
@@ -61,4 +61,14 @@ public class DailyRecipe extends BaseEntity {
             this.description = description;
         }
     }
+
+    public void incrementLikeCount() {
+        this.likeCount++;
+    }
+
+    public void decrementLikeCount() {
+        if (this.likeCount > 0) {
+            this.likeCount--;
+        }
+    }
 }

--- a/src/main/java/com/cookeep/cookeep/domain/dailyrecipe/entity/RecipeLike.java
+++ b/src/main/java/com/cookeep/cookeep/domain/dailyrecipe/entity/RecipeLike.java
@@ -1,0 +1,30 @@
+package com.cookeep.cookeep.domain.dailyrecipe.entity;
+
+import com.cookeep.cookeep.common.entity.BaseEntity;
+import com.cookeep.cookeep.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "recipe_likes", uniqueConstraints = {
+	@UniqueConstraint(columnNames = {"daily_recipe_id", "user_id"})
+})
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RecipeLike extends BaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "recipe_like_id")
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "daily_recipe_id", nullable = false)
+	private DailyRecipe dailyRecipe;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_id", nullable = false)
+	private User user;
+}

--- a/src/main/java/com/cookeep/cookeep/domain/mycookeep/application/MyCookeepService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/mycookeep/application/MyCookeepService.java
@@ -38,7 +38,8 @@ public class MyCookeepService {
 
         // 현재 키우는 식물(수확되지 않은, 얼지 않은 식물)의 이름 조회
         String growingPlantName = userPlantRepository
-            .findByUserAndIsHarvestedFalseAndIsFrozenFalse(user)
+            .findByUserAndIsHarvestedFalse(user)
+            .filter(plant -> !plant.getIsFrozen())
             .map(userPlant -> userPlant.getPlant().getPlantType().getDisplayName())
             .orElse(null);
 

--- a/src/main/java/com/cookeep/cookeep/domain/plant/application/UserPlantService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/plant/application/UserPlantService.java
@@ -1,5 +1,6 @@
 package com.cookeep.cookeep.domain.plant.application;
 
+import com.cookeep.cookeep.api.dto.response.GrowingPlantResponseDto;
 import com.cookeep.cookeep.api.dto.response.MyPlantResponseDto;
 import com.cookeep.cookeep.api.dto.response.RegisterPlantResponseDto;
 import com.cookeep.cookeep.common.exception.AppException;
@@ -13,6 +14,7 @@ import com.cookeep.cookeep.domain.plant.entity.Plant;
 import com.cookeep.cookeep.domain.plant.entity.PlantStatus;
 import com.cookeep.cookeep.domain.plant.entity.UserPlant;
 import com.cookeep.cookeep.domain.plant.entity.WateringLog;
+import com.cookeep.cookeep.domain.user.application.UserReader;
 import com.cookeep.cookeep.domain.user.dao.UserRepository;
 import com.cookeep.cookeep.domain.user.entity.User;
 import lombok.RequiredArgsConstructor;
@@ -33,6 +35,7 @@ public class UserPlantService {
     private final UserRepository userRepository;
     private final PlantRepository plantRepository;
     private final CookieService cookieService;
+    private final UserReader userReader;
 
     // 로그인/토큰 갱신 시 호출: 미접속 일수 기반 식물 상태 계산 및 성장 정지 처리
     @Transactional
@@ -49,8 +52,9 @@ public class UserPlantService {
 
         if (inactiveDays >= 14) {
             // 14일 이상 미접속: 키우는 식물 성장 정지 + FROZEN 상태
-            Optional<UserPlant> growingPlant = userPlantRepository.findByUserAndIsHarvestedFalseAndIsFrozenFalse(user);
-            growingPlant.ifPresent(UserPlant::freeze);
+            userPlantRepository.findByUserAndIsHarvestedFalse(user)
+                .filter(plant -> !plant.getIsFrozen())
+                .ifPresent(UserPlant::freeze);
             user.updatePlantStatus(PlantStatus.FROZEN);
         } else if (inactiveDays >= 7) {
             // 7~13일 미접속: WILTING 상태 (성장 정지는 하지 않음)
@@ -60,6 +64,16 @@ public class UserPlantService {
             boolean hasFrozenPlant = userPlantRepository.existsByUserAndIsFrozenTrue(user);
             user.updatePlantStatus(hasFrozenPlant ? PlantStatus.FROZEN : PlantStatus.NORMAL);
         }
+    }
+
+    // 쿠킵스 화면: 현재 키우는 식물 정보 조회
+    @Transactional(readOnly = true)
+    public GrowingPlantResponseDto getGrowingPlant(Long userId) {
+        User user = userReader.readById(userId);
+
+        return userPlantRepository.findByUserAndIsHarvestedFalse(user)
+                .map(plant -> GrowingPlantResponseDto.from(plant, user))
+                .orElse(null);
     }
 
     // 유저 보유 식물 목록 조회

--- a/src/main/java/com/cookeep/cookeep/domain/plant/dao/UserPlantRepository.java
+++ b/src/main/java/com/cookeep/cookeep/domain/plant/dao/UserPlantRepository.java
@@ -16,8 +16,9 @@ public interface UserPlantRepository extends JpaRepository<UserPlant, Long>{
     @EntityGraph(attributePaths = {"plant"})
     List<UserPlant> findAllByUser(User user);
 
-    // 현재 키우고 있는 식물 조회 (수확 완료되지 않고, 성장 정지되지 않은 식물)
-    Optional<UserPlant> findByUserAndIsHarvestedFalseAndIsFrozenFalse(User user);
+    // 현재 키우는 식물 조회 (성장 정지 여부 무관하게, 아직 수확 완료되지 않은 식물)
+    @EntityGraph(attributePaths = {"plant"})
+    Optional<UserPlant> findByUserAndIsHarvestedFalse(User user);
 
     // 성장 정지된 식물이 존재하는지 확인
     boolean existsByUserAndIsFrozenTrue(User user);

--- a/src/main/java/com/cookeep/cookeep/domain/plant/dao/WateringLogRepository.java
+++ b/src/main/java/com/cookeep/cookeep/domain/plant/dao/WateringLogRepository.java
@@ -1,10 +1,25 @@
 package com.cookeep.cookeep.domain.plant.dao;
 
 import com.cookeep.cookeep.domain.plant.entity.WateringLog;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
 
 @Repository
 public interface WateringLogRepository extends JpaRepository<WateringLog, Long> {
     boolean existsByUserUserId(Long userId);
+
+    // 이번 주 물주기 횟수 Top N 유저 조회
+    @Query("SELECT w.user, COUNT(w) FROM WateringLog w " +
+           "WHERE w.createdAt >= :weekStart AND w.createdAt < :weekEnd " +
+           "GROUP BY w.user ORDER BY COUNT(w) DESC")
+    List<Object[]> findTopWateringUsers(
+            @Param("weekStart") LocalDateTime weekStart,
+            @Param("weekEnd") LocalDateTime weekEnd,
+            Pageable pageable);
 }


### PR DESCRIPTION
# Related Issue
#80 

# Description
쿠킵스 관련 기능 중 다음 4가지 기능을 구현했습니다.

<img width="1057" height="228" alt="image" src="https://github.com/user-attachments/assets/8398ace5-bdcf-4bd1-a32e-a3708ad8879a" />

- 현재 키우는 식물 조회: 쿠킵스 화면에서 필요한 현재 키우고 있는 식물의 각종 정보를 조회(키우는 식물이 없으면 data가 null)
- 이번주 랭킹 조회: 이번 주 물주기 횟수 Top 3 유저와 '이번 주'에 등록된 레시피들 중 '이번 주'에 좋아요를 가장 많이 받은 Top 3 레시피를 조회합니다.
- 레시피 좋아요 토글: 레시피에 좋아요를 추가하거나 취소합니다. (자신의 글에는 좋아요를 누를 수 없습니다.)
- 레시피 좋아요 여부 조회: 현재 사용자가 특정 레시피에 좋아요를 눌렀는지 확인합니다. (프론트 측에서 상세화면 & 목록에서 버튼(하트)의 활성화 상태를 보여주기 위함

# Changes

### 1. 컨트롤러 레이어
- CookeepsController
이번 주 랭킹 조회 API (GET /api/cookeeps/ranking) 추가

- MyPlantController
현재 키우는 식물 정보 조회 API (GET /api/my-plants/growing-plant) 추가

- RecipeLikeController: 레시피 좋아요 관련 API 전용 컨트롤러 추가
레시피 좋아요 토글 (POST /api/daily-recipes/{id}/likes)
레시피 좋아요 여부 조회 (GET /api/daily-recipes/{id}/likes/check)

### 2. DTO (응답 데이터 모델)

API가 리턴하는 JSON 구조를 정의하는 클래스들입니다.

- GrowingPlantResponseDto — 현재 키우는 식물 정보 DTO

- RankingResponseDto — 랭킹 정보 DTO (물주기 Top3, 레시피 Top3)

- RecipeLikeResponseDto — 좋아요 토글/조회 응답 DTO

### 3. 서비스 및 도메인 로직

- CookeepsService: 이번 주 랭킹 조회 구현.
물주기 횟수 Top3 및 레시피 좋아요 Top3를 조회해 DTO로 조립

- RecipeLikeService
레시피 좋아요 토글 & 조회 로직 처리 

- UserPlantService
현재 키우는 식물 조회 로직 추가

- RecipeLikeRepository
좋아요 관련 DB 쿼리 제공

- UserPlantRepository, WateringLogRepository
사용자 식물/물주기 기록 조회.

### 4. 도메인/엔티티

- RecipeLike
레시피 좋아요 엔티티 추가(좋아요 데이터 저장)

### 5. 예외 처리 코드
CANNOT_LIKE_OWN_RECIPE: 자신의 레시피에는 좋아요 할 수 없음

# 참고사항
우선 지금까지 구현된 기능들 먼저 develop에 머지한 후, 아직 구현 안 된 나머지 기능들은 이 브랜치에서 마저 작업할 예정입니다!