### PR TITLE
Fix: 레시피 재료 차감 및 쿠키 지급 구현

### DIFF
--- a/src/main/java/com/cookeep/cookeep/api/controller/AiRecipeController.java
+++ b/src/main/java/com/cookeep/cookeep/api/controller/AiRecipeController.java
@@ -295,11 +295,16 @@ public class AiRecipeController {
             ErrorCode.UNAUTHORIZED,
             ErrorCode.AI_SESSION_NOT_FOUND,
             ErrorCode.AI_SESSION_FORBIDDEN,
-            ErrorCode.TITLE_INVALID_VALUE
+            ErrorCode.TITLE_INVALID_VALUE,
+            ErrorCode.TITLE_TOO_LONG
     })
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "세션 제목 수정 성공"),
-            @ApiResponse(responseCode = "400", description = "잘못된 요청 값 (빈 제목 등)", content = @Content),
+            @ApiResponse(responseCode = "400", description = """
+                    잘못된 요청입니다. 다음 오류가 발생할 수 있습니다:
+                    - TITLE_INVALID_VALUE: 세션 제목을 입력해주세요. (빈제목 불가)
+                    - TITLE_TOO_LONG: 세션 제목 최대 길이는 100자입니다.
+                    """, content = @Content),
             @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content),
             @ApiResponse(responseCode = "403", description = "본인의 대화 세션이 아님", content = @Content),
             @ApiResponse(responseCode = "404", description = "세션을 찾을 수 없음", content = @Content)

--- a/src/main/java/com/cookeep/cookeep/api/controller/AiRecipeController.java
+++ b/src/main/java/com/cookeep/cookeep/api/controller/AiRecipeController.java
@@ -261,7 +261,7 @@ public class AiRecipeController {
     }
 
     @Operation(
-            summary = "(MAIN07) AI 대화 세션 즐겨찾기 추가/삭제",
+            summary = "(MAIN07-1) AI 대화 세션 즐겨찾기 추가/삭제",
             description = "특정 세션의 즐겨찾기 상태를 변경합니다. (T -> F / F -> T)"
     )
     @ApiErrorCodeExamples({
@@ -288,7 +288,7 @@ public class AiRecipeController {
     }
 
     @Operation(
-            summary = "(MAIN08) AI 대화 세션 제목 수정",
+            summary = "(MAIN07-2) AI 대화 세션 제목 수정",
             description = "특정 AI 대화 세션의 제목을 수정합니다."
     )
     @ApiErrorCodeExamples({

--- a/src/main/java/com/cookeep/cookeep/common/exception/ErrorCode.java
+++ b/src/main/java/com/cookeep/cookeep/common/exception/ErrorCode.java
@@ -49,6 +49,7 @@ public enum ErrorCode {
 	INVALID_DELETE_REQUEST(HttpStatus.BAD_REQUEST, "삭제할 식재료를 입력해주세요.", "INGREDIENT_010"),
 	DAILY_RECIPE_UPDATE_FIELDS_REQUIRED(HttpStatus.BAD_REQUEST, "수정할 항목(제목 또는 한줄평)을 입력해주세요.", "DAILY_RECIPE-004"),
 	TITLE_INVALID_VALUE(HttpStatus.BAD_REQUEST, "레시피 제목을 입력해주세요.", "RECIPE-022"),
+	TITLE_TOO_LONG(HttpStatus.BAD_REQUEST, "레시피 제목은 최대 100글자입니다.", "RECIPE-023"),
 
 	// 401 UNAUTHORIZED (인증 관련)
 	UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증에 실패했습니다.", "AUTH-001"),

--- a/src/main/java/com/cookeep/cookeep/domain/cookie/dao/DailyCookieGrantRepository.java
+++ b/src/main/java/com/cookeep/cookeep/domain/cookie/dao/DailyCookieGrantRepository.java
@@ -16,11 +16,4 @@ public interface DailyCookieGrantRepository extends JpaRepository<DailyCookieGra
             LocalDate grantDate
     );
 
-    // 특정 유저의 특정 타입/날짜 지급 기록 조회
-    Optional<DailyCookieGrant> findByUser_UserIdAndGrantTypeAndGrantDate(
-            Long userId,
-            CookieLog.CookieLogType grantType,
-            LocalDate grantDate
-    );
-
 }

--- a/src/main/java/com/cookeep/cookeep/domain/recipe/application/AiRecipeService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/recipe/application/AiRecipeService.java
@@ -248,10 +248,10 @@ public class AiRecipeService {
             throw new AppException(ErrorCode.INTERNAL_SERVER_ERROR);
         }
 
-        // 9. 임박 재료(leftDays=0) 포함 세션이면 쿠키 지급 (하루 1회)
+        // 8. 임박 재료(leftDays=0) 포함 세션이면 쿠키 지급 (하루 1회)
         grantUrgentCookieRewardIfEligible(userId, ingredientIds);
 
-        // 8. 요청 재료 전체 수량 -1 (단위 무관, 0이 되면 삭제)
+        // 9. 요청 재료 전체 수량 -1 (단위 무관, 0이 되면 삭제)
         consumeIngredients(userId, ingredientIds);
 
         return AiRecipeAdoptResponseDto.builder()
@@ -398,17 +398,6 @@ public class AiRecipeService {
                             .build();
                 })
                 .collect(Collectors.toList());
-    }
-
-    // user_ingredients에서 단위 조회
-    private String getUserIngredientUnit(Long userId, String type, Long referenceId) {
-        Type ingredientType = Type.valueOf(type);
-
-        UserIngredient userIngredient = userIngredientRepository
-                .findByUserIdAndTypeAndReferenceId(userId, ingredientType, referenceId)
-                .orElseThrow(() -> new AppException(ErrorCode.INGREDIENT_NOT_FOUND));
-
-        return userIngredient.getUnit().name();
     }
 
     // AI 메시지에서 레시피 제목 추출
@@ -637,19 +626,6 @@ public class AiRecipeService {
                 userIngredientRepository.delete(ui);
                 log.info("재료 삭제(수량 0): ingredientId={}", ui.getIngredientId());
             }
-        }
-    }
-
-    // 임박 식재료 포함 레시피 채택 시 쿠키 3개 지급 (1일1회)
-    private void grantUrgentCookieReward(Long userId) {
-        CookieLog.CookieLogType urgentType = CookieLog.CookieLogType.BONUS_URGENT_INGREDIENT_USE;
-        boolean granted = cookieService.grantDailyCookie(userId, urgentType);
-
-        if (granted) {
-            log.info("임박 재료 쿠키 지급 완료: userId={}, amount={}",
-                    userId, urgentType.getDefaultAmount());
-        } else {
-            log.info("임박 재료 쿠키 오늘 이미 지급됨, 미지급: userId={}", userId);
         }
     }
 

--- a/src/main/java/com/cookeep/cookeep/domain/recipe/application/AiRecipeService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/recipe/application/AiRecipeService.java
@@ -347,10 +347,17 @@ public class AiRecipeService {
         aiSessionRepository.save(session);
     }
 
+    // 세션 제목 수정
     public void updateSessionTitle(Long userId, Long sessionId, String newTitle) {
 
+        // 빈 제목 방지
         if (newTitle == null || newTitle.isBlank()) {
             throw new AppException(ErrorCode.TITLE_INVALID_VALUE);
+        }
+
+        // 100자 이상 제목 방지
+        if (newTitle.trim().length() > 100) {
+            throw new AppException(ErrorCode.TITLE_TOO_LONG);
         }
 
         AiSession session = aiSessionRepository.findById(sessionId)

--- a/src/main/java/com/cookeep/cookeep/domain/recipe/application/AiRecipeService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/recipe/application/AiRecipeService.java
@@ -11,6 +11,7 @@ import com.cookeep.cookeep.domain.cookie.application.CookieService;
 import com.cookeep.cookeep.domain.cookie.dao.CookieLogRepository;
 import com.cookeep.cookeep.domain.cookie.dao.DailyCookieGrantRepository;
 import com.cookeep.cookeep.domain.cookie.entity.CookieLog;
+import com.cookeep.cookeep.domain.cookie.entity.DailyCookieGrant;
 import com.cookeep.cookeep.domain.ingredient.common.domain.Type;
 import com.cookeep.cookeep.domain.ingredient.customingredient.dao.CustomIngredientRepository;
 import com.cookeep.cookeep.domain.ingredient.customingredient.entity.CustomIngredient;
@@ -55,8 +56,6 @@ public class AiRecipeService {
     private final UserIngredientRepository userIngredientRepository;
     private final DefaultIngredientRepository defaultIngredientRepository;
     private final CustomIngredientRepository customIngredientRepository;
-    private final UserRepository userRepository;
-    private final CookieLogRepository cookieLogRepository;
     private final DailyCookieGrantRepository dailyCookieGrantRepository;
     private final CookieService cookieService;
     private final YoutubeSearchService youtubeSearchService;
@@ -586,24 +585,30 @@ public class AiRecipeService {
         List<UserIngredient> targets = userIngredientRepository
                 .findAllByIngredientIdInAndUser_UserId(ingredientIds, userId);
 
-        boolean hasUrgent = targets.stream()
-                .anyMatch(ui -> ui.getLeftDays() == 0);
-
-        if (!hasUrgent) {
-            log.info("임박 재료(leftDays=0) 없음, 쿠키 미지급: userId={}", userId);
+        if (targets.isEmpty()) {
             return;
         }
 
-        // BONUS_URGENT_INGREDIENT_USE: defaultAmount = 3, grantDailyCookie로 1일1회 보장
-        CookieLog.CookieLogType urgentType = CookieLog.CookieLogType.BONUS_URGENT_INGREDIENT_USE;
+        boolean hasUrgent = targets.stream()
+                .anyMatch(ui -> ui.getLeftDays() == URGENT);
+
+        if (!hasUrgent) {
+            return;
+        }
+
+        CookieLog.CookieLogType urgentType =
+                CookieLog.CookieLogType.BONUS_URGENT_INGREDIENT_USE;
+
+        // 1일 1회 제한 + DailyCookieGrant 자동 기록
         boolean granted = cookieService.grantDailyCookie(userId, urgentType);
 
         if (granted) {
-            log.info("임박 재료 쿠키 {}개 지급 완료: userId={}",
+            log.info("임박 재료 쿠키 {}개 지급 완료 - userId={}",
                     urgentType.getDefaultAmount(), userId);
         } else {
-            log.info("임박 재료 쿠키 오늘 이미 지급됨, 미지급: userId={}", userId);
+            log.info("임박 재료 쿠키 오늘 이미 지급됨 - userId={}", userId);
         }
+
     }
 
     // 재료 차감 로직. (단위 상관없이 무조건 -1)
@@ -664,7 +669,7 @@ public class AiRecipeService {
         var ingredients = response.getIngredients();
 
         List<String> allowedUnits = List.of(
-                "개", "팩", "봉지", "병", "묶음", "캔", "g", "ml", "tsp", "Tbsp"
+                "개", "팩", "봉지", "병", "묶음", "캔", "g", "ml", "티스푼", "테이블스푼"
         );
 
         // 1. additional_ingredients 검증

--- a/src/main/java/com/cookeep/cookeep/domain/recipe/application/AiRecipeService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/recipe/application/AiRecipeService.java
@@ -248,11 +248,11 @@ public class AiRecipeService {
             throw new AppException(ErrorCode.INTERNAL_SERVER_ERROR);
         }
 
-        // 8. 요청 재료 전체 수량 -1 (단위 무관, 0이 되면 삭제)
-        consumeIngredients(userId, ingredientIds);
-
         // 9. 임박 재료(leftDays=0) 포함 세션이면 쿠키 지급 (하루 1회)
         grantUrgentCookieRewardIfEligible(userId, ingredientIds);
+
+        // 8. 요청 재료 전체 수량 -1 (단위 무관, 0이 되면 삭제)
+        consumeIngredients(userId, ingredientIds);
 
         return AiRecipeAdoptResponseDto.builder()
                 .sessionId(session.getId())

--- a/src/main/java/com/cookeep/cookeep/domain/recipe/application/AiRecipeService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/recipe/application/AiRecipeService.java
@@ -238,7 +238,16 @@ public class AiRecipeService {
         session.complete();
 
         // 7. 세션의 ingredientIds 조회
-        List<Long> ingredientIds = session.getIngredientIds();
+        List<Long> ingredientIds;
+        try {
+            ingredientIds = objectMapper.readValue(
+                    session.getIngredientIdsJson(),
+                    new TypeReference<List<Long>>() {}
+            );
+        } catch (Exception e) {
+            log.error("❌ingredientIdsJson 파싱 실패", e);
+            throw new AppException(ErrorCode.INTERNAL_SERVER_ERROR);
+        }
 
         // 8. 요청 재료 전체 수량 -1 (단위 무관, 0이 되면 삭제)
         consumeIngredients(userId, ingredientIds);

--- a/src/main/java/com/cookeep/cookeep/domain/recipe/application/GeminiService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/recipe/application/GeminiService.java
@@ -178,13 +178,21 @@ public class GeminiService {
         4. additional_ingredients에는 레시피에 반드시 필요한 추가 재료만 포함하세요.
            - description 필드는 절대 생성하지 마세요.
            - description은 null로도 생성하지 말고, 아예 포함하지 마세요.
-        5. optional_ingredients에는 생략하거나 대체 가능한 재료만 포함하세요.
+        5. optional_ingredients에는 절대 새로운 재료를 생성하지 마세요.
+           - 반드시 user_ingredients 또는 additional_ingredients에 이미 존재하는 재료만 사용하세요.
+           - 위 두 목록에 없는 새로운 재료를 생성하는 것은 절대 금지합니다.
+           - optional_ingredients에 포함된 재료는 반드시 user_ingredients 또는 additional_ingredients 중 하나와 동일한 name을 가져야 합니다.
+
            - description 필드는 반드시 포함해야 합니다.
-           - description은 반드시 아래 두 형식 중 하나로 작성하세요:
+           - description은 반드시 아래 두 형식 중 하나로만 작성하세요:
+
              1) "이 재료는 [다른 재료]로 대체 가능합니다"
+               - [다른 재료]는 반드시 user_ingredients 또는 additional_ingredients에 존재하는 실제 재료명을 사용하세요.
+               - 존재하지 않는 재료명은 절대 사용하지 마세요.
+
              2) "이 재료는 생략 가능합니다"
-           - [다른 재료]에는 반드시 실제 식재료명을 명시하세요.
-           - 위 형식 외의 문장은 절대 생성하지 마세요.
+             
+            - 위 형식 외의 문장은 절대 생성하지 마세요.
         6. additional_ingredients와 optional_ingredients의 unit은 반드시 아래 목록 중 하나만 사용하세요:
            [개, 팩, 봉지, 병, 묶음, 캔, g, ml, 티스푼, 테이블스푼]
            - 위 목록에 없는 단위는 절대 사용하지 마세요.

--- a/src/main/java/com/cookeep/cookeep/domain/recipe/application/GeminiService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/recipe/application/GeminiService.java
@@ -186,7 +186,7 @@ public class GeminiService {
            - [다른 재료]에는 반드시 실제 식재료명을 명시하세요.
            - 위 형식 외의 문장은 절대 생성하지 마세요.
         6. additional_ingredients와 optional_ingredients의 unit은 반드시 아래 목록 중 하나만 사용하세요:
-           [개, 팩, 봉지, 병, 묶음, 캔, g, ml, tsp, Tbsp]
+           [개, 팩, 봉지, 병, 묶음, 캔, g, ml, 티스푼, 테이블스푼]
            - 위 목록에 없는 단위는 절대 사용하지 마세요.
            - 영어 단위(piece, cup 등)나 "적당량", "약간" 같은 표현은 금지합니다.
            - user_ingredients에는 해당 단위 제한을 적용하지 않습니다.


### PR DESCRIPTION
# Issue
#97 

# Description
- 레시피 채택 시 재료 차감 구현
- - 기존 문제: ingredientId를 DB가 아니라 JSON에서 조회해서 실제 DB의 재료 수량 변경이 안 됨
- - 해결: 실제 DB에서 아이디 조회하여 재료 수량 업데이트
- 유통기한 임박 식재료 포함 레시피 채택 시 쿠키 지급
- - 기존 문제: 재료 차감 후 쿠키 지급 로직 실행하여 쿠키 지급 안 됨 (임박 식재료가 db에서 이미 삭제되었기 때문에)
- - 해결: 쿠키 지급 먼저 수행 후 재료 차감 실행

# Changes
- Gemini 레시피 생성 규칙에 단위 수정
- 단위 검증 로직 수정
- 미사용 메서드 정리
- 레시피 채택 시 재료 차감 및 쿠키 지급 로직 수정
- 세션 제목 수정 시 길이 제한 에러처리 추가 TITLE_TOO_LONG

# Test Checklist
- [x] 레시피 생성 시 단위 생성 정상 동작 확인
- [x] 레시피 채택 시 해당 재료 모두 차감되는 거 확인 (모두 -1)
- [x] 유통기한 임박 재료 포함 레시피 채택 시 쿠키 지급 확인 및 1일 1회 지급까지 확인