### PR TITLE
feat: 마이쿠킵 주간 리포트 기능 구현

### DIFF
--- a/src/main/java/com/cookeep/cookeep/api/controller/MyCookeepController.java
+++ b/src/main/java/com/cookeep/cookeep/api/controller/MyCookeepController.java
@@ -1,11 +1,13 @@
 package com.cookeep.cookeep.api.controller;
 
 import com.cookeep.cookeep.api.dto.request.WeeklyGoalRequestDto;
+import com.cookeep.cookeep.api.dto.response.ConsumptionReportResponseDto;
 import com.cookeep.cookeep.api.dto.response.MyProfileResponseDto;
 import com.cookeep.cookeep.common.dto.DataResponse;
 import com.cookeep.cookeep.common.exception.ErrorCode;
 import com.cookeep.cookeep.config.ApiErrorCodeExamples;
 import com.cookeep.cookeep.security.UserPrincipal;
+import com.cookeep.cookeep.domain.mycookeep.application.ConsumptionReportService;
 import com.cookeep.cookeep.domain.mycookeep.application.MyCookeepService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -27,6 +29,7 @@ import org.springframework.web.bind.annotation.*;
 public class MyCookeepController {
 
     private final MyCookeepService myCookeepService;
+    private final ConsumptionReportService consumptionReportService;
 
     @Operation(summary = "마이쿠킵 프로필 조회", description = "닉네임, 프로필 식물 이미지, 가입 일수, 현재 키우는 식물 이름, 이번 주 목표를 조회합니다.")
     @ApiErrorCodeExamples({
@@ -57,6 +60,37 @@ public class MyCookeepController {
         Long userId = principal.userId();
         MyProfileResponseDto response = myCookeepService.getProfile(userId);
 
+        return ResponseEntity.ok(DataResponse.from(response));
+    }
+
+    @Operation(summary = "주간 소비 리포트 조회", description = "이번 주 전체 식재료 소비율과 유통기한 임박 식재료 소비율을 조회합니다.")
+    @ApiErrorCodeExamples({
+            ErrorCode.UNAUTHORIZED,
+            ErrorCode.USER_NOT_FOUND,
+            ErrorCode.INTERNAL_SERVER_ERROR
+    })
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "소비 리포트 조회 성공",
+                    content = @Content(schema = @Schema(implementation = ConsumptionReportResponseDto.class))),
+            @ApiResponse(responseCode = "401", description = """
+                인증 실패입니다. 다음 오류가 발생할 수 있습니다:
+                - UNAUTHORIZED: 인증 정보가 없거나 유효하지 않습니다.
+                """, content = @Content),
+            @ApiResponse(responseCode = "404", description = """
+                리소스를 찾을 수 없습니다. 다음 오류가 발생할 수 있습니다:
+                - USER_NOT_FOUND: 존재하지 않는 사용자입니다.
+                """, content = @Content),
+            @ApiResponse(responseCode = "500", description = """
+                서버 오류입니다. 다음 오류가 발생할 수 있습니다:
+                - INTERNAL_SERVER_ERROR: 서버 내부 오류가 발생했습니다.
+                """, content = @Content)
+    })
+    @GetMapping("/consumption-report")
+    public ResponseEntity<DataResponse<ConsumptionReportResponseDto>> getConsumptionReport(
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        Long userId = principal.userId();
+        ConsumptionReportResponseDto response = consumptionReportService.getReport(userId);
         return ResponseEntity.ok(DataResponse.from(response));
     }
 

--- a/src/main/java/com/cookeep/cookeep/api/dto/response/ConsumptionReportResponseDto.java
+++ b/src/main/java/com/cookeep/cookeep/api/dto/response/ConsumptionReportResponseDto.java
@@ -1,0 +1,34 @@
+package com.cookeep.cookeep.api.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Schema(
+        name = "ConsumptionReportResponse",
+        description = "주간 식재료 소비 달성 현황 응답 DTO"
+)
+@Getter
+@Builder
+@AllArgsConstructor
+public class ConsumptionReportResponseDto {
+
+    @Schema(description = "전체 식재료 수 (왼쪽 그래프 분모)", example = "20")
+    private int totalIngredientCount;
+
+    @Schema(description = "소비된 식재료 수 (왼쪽 그래프 분자)", example = "13")
+    private int consumedIngredientCount;
+
+    @Schema(description = "전체 소비율 (%, 0~100)", example = "65")
+    private int consumptionRate;
+
+    @Schema(description = "폐기 임박 식재료 수 (오른쪽 그래프 분모)", example = "5")
+    private int nearExpiryIngredientCount;
+
+    @Schema(description = "소비된 임박 식재료 수 (오른쪽 그래프 분자)", example = "5")
+    private int consumedNearExpiryCount;
+
+    @Schema(description = "임박 식재료 소비율 (%, 0~100)", example = "100")
+    private int nearExpiryConsumptionRate;
+}

--- a/src/main/java/com/cookeep/cookeep/domain/ingredient/useringredient/application/ConsumeIngredientService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/ingredient/useringredient/application/ConsumeIngredientService.java
@@ -8,6 +8,7 @@ import com.cookeep.cookeep.domain.cookie.application.CookieService;
 import com.cookeep.cookeep.domain.cookie.entity.CookieLog;
 import com.cookeep.cookeep.domain.ingredient.useringredient.dao.UserIngredientRepository;
 import com.cookeep.cookeep.domain.ingredient.useringredient.entity.UserIngredient;
+import com.cookeep.cookeep.domain.mycookeep.application.ConsumptionReportService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -25,6 +26,7 @@ public class ConsumeIngredientService {
 
     private final UserIngredientRepository userIngredientRepository;
     private final CookieService cookieService;
+    private final ConsumptionReportService consumptionReportService;
 
     // 식재료 섭취 완료
     @Transactional
@@ -62,7 +64,10 @@ public class ConsumeIngredientService {
             grantedTypes.add(dailyType);
         }
 
-        // 4. 재료 삭제
+        // 4. 주간 소비 리포트 기록 (삭제 전에 호출해야 leftDays 읽기 가능)
+        consumptionReportService.markConsumed(userId, userIngredients);
+
+        // 5. 재료 삭제
         userIngredientRepository.deleteAll(userIngredients);
 
         log.info("User {} consumed {} ingredients via manual action. Reward granted: {}, points: {}",

--- a/src/main/java/com/cookeep/cookeep/domain/ingredient/useringredient/application/UserIngredientScheduler.java
+++ b/src/main/java/com/cookeep/cookeep/domain/ingredient/useringredient/application/UserIngredientScheduler.java
@@ -2,12 +2,16 @@ package com.cookeep.cookeep.domain.ingredient.useringredient.application;
 
 import com.cookeep.cookeep.domain.ingredient.useringredient.dao.UserIngredientRepository;
 import com.cookeep.cookeep.domain.ingredient.useringredient.entity.UserIngredient;
+import com.cookeep.cookeep.domain.mycookeep.application.ConsumptionReportService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.temporal.TemporalAdjusters;
 import java.util.List;
 
 // 자정에 모든 식재료 leftDays 필드 업데이트
@@ -17,6 +21,7 @@ import java.util.List;
 public class UserIngredientScheduler {
 
     private final UserIngredientRepository userIngredientRepository;
+    private final ConsumptionReportService consumptionReportService;
 
     /**
      * 매일 자정(00:00)에 모든 식재료의 남은 일수(leftDays) 업데이트
@@ -35,6 +40,18 @@ public class UserIngredientScheduler {
 
             // 각 식재료의 leftDays 업데이트
             allIngredients.forEach(UserIngredient::updateLeftDays);
+
+            // 새로 임박된 식재료의 주간 로그 업데이트 (leftDays <= 3)
+            LocalDate weekStart = LocalDate.now()
+                    .with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY));
+            List<Long> nearExpiryIds = allIngredients.stream()
+                    .filter(ui -> ui.getLeftDays() <= ConsumptionReportService.NEAR_EXPIRY_THRESHOLD)
+                    .map(UserIngredient::getIngredientId)
+                    .toList();
+            if (!nearExpiryIds.isEmpty()) {
+                consumptionReportService.updateNearExpiryFlags(nearExpiryIds, weekStart);
+                log.info("Updated near-expiry flags for {} ingredients", nearExpiryIds.size());
+            }
 
             log.info("=== Successfully updated leftDays for {} ingredients ===", allIngredients.size());
 

--- a/src/main/java/com/cookeep/cookeep/domain/ingredient/useringredient/application/UserIngredientService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/ingredient/useringredient/application/UserIngredientService.java
@@ -12,6 +12,7 @@ import com.cookeep.cookeep.domain.ingredient.defaultingredient.dao.DefaultIngred
 import com.cookeep.cookeep.domain.ingredient.defaultingredient.entity.DefaultIngredient;
 import com.cookeep.cookeep.domain.ingredient.useringredient.dao.UserIngredientRepository;
 import com.cookeep.cookeep.domain.ingredient.useringredient.entity.UserIngredient;
+import com.cookeep.cookeep.domain.mycookeep.application.ConsumptionReportService;
 import com.cookeep.cookeep.domain.user.dao.UserRepository;
 import com.cookeep.cookeep.domain.user.entity.User;
 import lombok.RequiredArgsConstructor;
@@ -29,6 +30,7 @@ public class UserIngredientService {
     private final DefaultIngredientRepository defaultIngredientRepository;
     private final CustomIngredientRepository customIngredientRepository;
     private final UserRepository userRepository;
+    private final ConsumptionReportService consumptionReportService;
     private static final String DEFAULT_IMAGE =
             "https://cookeep-images.s3.ap-northeast-2.amazonaws.com/ingredients/0a0cc3bd-1ade-46ed-897e-ba89ec09b7c0.png";
 
@@ -96,6 +98,9 @@ public class UserIngredientService {
                 .build();
 
         UserIngredient saved = userIngredientRepository.save(userIngredient);
+
+        // 주간 소비 리포트용 로그 생성
+        consumptionReportService.createLogForNewIngredient(user, saved);
 
         return UserIngredientCreateResponseDto.of(saved, ingredientName, imageUrl);
     }

--- a/src/main/java/com/cookeep/cookeep/domain/ingredient/useringredient/dao/UserIngredientRepository.java
+++ b/src/main/java/com/cookeep/cookeep/domain/ingredient/useringredient/dao/UserIngredientRepository.java
@@ -43,6 +43,9 @@ public interface UserIngredientRepository extends JpaRepository<UserIngredient, 
             Long userId
     );
 
+    // 사용자 전체 식재료 조회 (주간 소비 리포트용)
+    List<UserIngredient> findAllByUser_UserId(Long userId);
+
     // --- 냉장고탭 ---
     // 홈화면 카테고리별 조회
     @Query("SELECT ui FROM UserIngredient ui WHERE ui.user.userId = :userId AND ui.storage = :storage ORDER BY ui.leftDays ASC")

--- a/src/main/java/com/cookeep/cookeep/domain/mycookeep/application/ConsumptionReportService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/mycookeep/application/ConsumptionReportService.java
@@ -1,0 +1,163 @@
+package com.cookeep.cookeep.domain.mycookeep.application;
+
+import com.cookeep.cookeep.api.dto.response.ConsumptionReportResponseDto;
+import com.cookeep.cookeep.domain.ingredient.useringredient.dao.UserIngredientRepository;
+import com.cookeep.cookeep.domain.ingredient.useringredient.entity.UserIngredient;
+import com.cookeep.cookeep.domain.mycookeep.dao.WeeklyIngredientLogRepository;
+import com.cookeep.cookeep.domain.mycookeep.entity.WeeklyIngredientLog;
+import com.cookeep.cookeep.domain.user.application.UserReader;
+import com.cookeep.cookeep.domain.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.temporal.TemporalAdjusters;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ConsumptionReportService {
+
+    private final WeeklyIngredientLogRepository weeklyIngredientLogRepository;
+    private final UserIngredientRepository userIngredientRepository;
+    private final UserReader userReader;
+
+    public static final int NEAR_EXPIRY_THRESHOLD = 3;
+
+    @Transactional
+    public ConsumptionReportResponseDto getReport(Long userId) {
+        User user = userReader.readById(userId);
+        LocalDate weekStart = getCurrentWeekStart();
+
+        ensureWeeklyLogsExist(user, weekStart);
+
+        int total = weeklyIngredientLogRepository
+                .countTotalByUserAndWeek(userId, weekStart);
+        int consumed = weeklyIngredientLogRepository
+                .countConsumedByUserAndWeek(userId, weekStart);
+        int nearExpiry = weeklyIngredientLogRepository
+                .countNearExpiryByUserAndWeek(userId, weekStart);
+        int consumedNearExpiry = weeklyIngredientLogRepository
+                .countConsumedNearExpiryByUserAndWeek(userId, weekStart);
+
+        int consumptionRate = total == 0 ? 0 : consumed * 100 / total;
+        int nearExpiryRate = nearExpiry == 0 ? 0 : consumedNearExpiry * 100 / nearExpiry;
+
+        return ConsumptionReportResponseDto.builder()
+                .totalIngredientCount(total)
+                .consumedIngredientCount(consumed)
+                .consumptionRate(consumptionRate)
+                .nearExpiryIngredientCount(nearExpiry)
+                .consumedNearExpiryCount(consumedNearExpiry)
+                .nearExpiryConsumptionRate(nearExpiryRate)
+                .build();
+    }
+
+    @Transactional
+    public void createLogForNewIngredient(User user, UserIngredient ingredient) {
+        LocalDate weekStart = getCurrentWeekStart();
+        boolean nearExpiry = ingredient.getLeftDays() <= NEAR_EXPIRY_THRESHOLD;
+
+        WeeklyIngredientLog logEntry = WeeklyIngredientLog.builder()
+                .user(user)
+                .weekStartDate(weekStart)
+                .userIngredientId(ingredient.getIngredientId())
+                .everNearExpiry(nearExpiry)
+                .build();
+
+        weeklyIngredientLogRepository.save(logEntry);
+    }
+
+    @Transactional
+    public void markConsumed(Long userId, List<UserIngredient> ingredients) {
+        LocalDate weekStart = getCurrentWeekStart();
+        List<Long> ingredientIds = ingredients.stream()
+                .map(UserIngredient::getIngredientId)
+                .toList();
+
+        List<WeeklyIngredientLog> logs = weeklyIngredientLogRepository
+                .findAllByUser_UserIdAndWeekStartDateAndUserIngredientIdIn(
+                        userId, weekStart, ingredientIds);
+
+        Map<Long, WeeklyIngredientLog> logMap = logs.stream()
+                .collect(Collectors.toMap(
+                        WeeklyIngredientLog::getUserIngredientId,
+                        Function.identity()));
+
+        for (UserIngredient ui : ingredients) {
+            WeeklyIngredientLog logEntry = logMap.get(ui.getIngredientId());
+            boolean isNearExpiry = ui.getLeftDays() <= NEAR_EXPIRY_THRESHOLD;
+
+            if (logEntry != null) {
+                logEntry.markConsumed(isNearExpiry);
+            } else {
+                log.info("Creating ad-hoc consumption log for ingredient {}",
+                        ui.getIngredientId());
+                WeeklyIngredientLog newLog = WeeklyIngredientLog.builder()
+                        .user(ui.getUser())
+                        .weekStartDate(weekStart)
+                        .userIngredientId(ui.getIngredientId())
+                        .everNearExpiry(isNearExpiry)
+                        .build();
+                newLog.markConsumed(isNearExpiry);
+                weeklyIngredientLogRepository.save(newLog);
+            }
+        }
+    }
+
+    @Transactional
+    public void updateNearExpiryFlags(List<Long> nearExpiryIngredientIds,
+                                       LocalDate weekStart) {
+        if (nearExpiryIngredientIds.isEmpty()) return;
+
+        List<WeeklyIngredientLog> logs = weeklyIngredientLogRepository
+                .findNotYetNearExpiryByWeekAndIngredientIds(
+                        weekStart, nearExpiryIngredientIds);
+
+        for (WeeklyIngredientLog logEntry : logs) {
+            logEntry.markEverNearExpiry();
+        }
+    }
+
+    @Transactional
+    public void createWeeklySnapshot(User user, List<UserIngredient> ingredients,
+                                      LocalDate weekStart) {
+        List<WeeklyIngredientLog> logs = ingredients.stream()
+                .map(ui -> WeeklyIngredientLog.builder()
+                        .user(user)
+                        .weekStartDate(weekStart)
+                        .userIngredientId(ui.getIngredientId())
+                        .everNearExpiry(ui.getLeftDays() <= NEAR_EXPIRY_THRESHOLD)
+                        .build())
+                .toList();
+
+        weeklyIngredientLogRepository.saveAll(logs);
+    }
+
+    private void ensureWeeklyLogsExist(User user, LocalDate weekStart) {
+        boolean exists = weeklyIngredientLogRepository
+                .existsByUser_UserIdAndWeekStartDate(user.getUserId(), weekStart);
+
+        if (!exists) {
+            log.info("No weekly logs found for user {} week {}, creating lazily",
+                    user.getUserId(), weekStart);
+            List<UserIngredient> currentIngredients =
+                    userIngredientRepository.findAllByUser_UserId(user.getUserId());
+            if (!currentIngredients.isEmpty()) {
+                createWeeklySnapshot(user, currentIngredients, weekStart);
+            }
+        }
+    }
+
+    private LocalDate getCurrentWeekStart() {
+        return LocalDate.now().with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY));
+    }
+}

--- a/src/main/java/com/cookeep/cookeep/domain/mycookeep/application/WeeklyIngredientLogScheduler.java
+++ b/src/main/java/com/cookeep/cookeep/domain/mycookeep/application/WeeklyIngredientLogScheduler.java
@@ -1,0 +1,59 @@
+package com.cookeep.cookeep.domain.mycookeep.application;
+
+import com.cookeep.cookeep.domain.ingredient.useringredient.dao.UserIngredientRepository;
+import com.cookeep.cookeep.domain.ingredient.useringredient.entity.UserIngredient;
+import com.cookeep.cookeep.domain.user.dao.UserRepository;
+import com.cookeep.cookeep.domain.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.temporal.TemporalAdjusters;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class WeeklyIngredientLogScheduler {
+
+    private final UserRepository userRepository;
+    private final UserIngredientRepository userIngredientRepository;
+    private final ConsumptionReportService consumptionReportService;
+
+    /**
+     * 매주 월요일 00:00:05에 모든 사용자의 현재 식재료 스냅샷을 생성한다.
+     * 기존 leftDays 스케줄러(00:00:00)보다 5초 뒤에 실행하여 leftDays가 먼저 갱신되도록 한다.
+     */
+    @Scheduled(cron = "5 0 0 * * MON", zone = "Asia/Seoul")
+    @Transactional
+    public void createWeeklySnapshots() {
+        log.info("=== Starting weekly ingredient log snapshot ===");
+        LocalDate weekStart = LocalDate.now()
+                .with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY));
+
+        try {
+            List<User> allUsers = userRepository.findAll();
+            int totalCount = 0;
+
+            for (User user : allUsers) {
+                List<UserIngredient> ingredients =
+                        userIngredientRepository.findAllByUser_UserId(user.getUserId());
+
+                if (!ingredients.isEmpty()) {
+                    consumptionReportService
+                            .createWeeklySnapshot(user, ingredients, weekStart);
+                    totalCount += ingredients.size();
+                }
+            }
+
+            log.info("=== Created weekly snapshots: {} logs for {} users ===",
+                    totalCount, allUsers.size());
+        } catch (Exception e) {
+            log.error("=== Error creating weekly snapshots ===", e);
+        }
+    }
+}

--- a/src/main/java/com/cookeep/cookeep/domain/mycookeep/dao/WeeklyIngredientLogRepository.java
+++ b/src/main/java/com/cookeep/cookeep/domain/mycookeep/dao/WeeklyIngredientLogRepository.java
@@ -1,0 +1,62 @@
+package com.cookeep.cookeep.domain.mycookeep.dao;
+
+import com.cookeep.cookeep.domain.mycookeep.entity.WeeklyIngredientLog;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+public interface WeeklyIngredientLogRepository extends JpaRepository<WeeklyIngredientLog, Long> {
+
+    boolean existsByUser_UserIdAndWeekStartDate(Long userId, LocalDate weekStartDate);
+
+    Optional<WeeklyIngredientLog> findByUser_UserIdAndWeekStartDateAndUserIngredientId(
+            Long userId, LocalDate weekStartDate, Long userIngredientId);
+
+    List<WeeklyIngredientLog> findAllByUser_UserIdAndWeekStartDateAndUserIngredientIdIn(
+            Long userId, LocalDate weekStartDate, List<Long> userIngredientIds);
+
+    @Query("""
+        SELECT wil FROM WeeklyIngredientLog wil
+        WHERE wil.weekStartDate = :weekStart
+          AND wil.everNearExpiry = false
+          AND wil.userIngredientId IN :ingredientIds
+    """)
+    List<WeeklyIngredientLog> findNotYetNearExpiryByWeekAndIngredientIds(
+            @Param("weekStart") LocalDate weekStart,
+            @Param("ingredientIds") List<Long> ingredientIds);
+
+    @Query("""
+        SELECT COUNT(wil) FROM WeeklyIngredientLog wil
+        WHERE wil.user.userId = :userId AND wil.weekStartDate = :weekStart
+    """)
+    int countTotalByUserAndWeek(@Param("userId") Long userId,
+                                @Param("weekStart") LocalDate weekStart);
+
+    @Query("""
+        SELECT COUNT(wil) FROM WeeklyIngredientLog wil
+        WHERE wil.user.userId = :userId AND wil.weekStartDate = :weekStart
+          AND wil.consumed = true
+    """)
+    int countConsumedByUserAndWeek(@Param("userId") Long userId,
+                                   @Param("weekStart") LocalDate weekStart);
+
+    @Query("""
+        SELECT COUNT(wil) FROM WeeklyIngredientLog wil
+        WHERE wil.user.userId = :userId AND wil.weekStartDate = :weekStart
+          AND wil.everNearExpiry = true
+    """)
+    int countNearExpiryByUserAndWeek(@Param("userId") Long userId,
+                                     @Param("weekStart") LocalDate weekStart);
+
+    @Query("""
+        SELECT COUNT(wil) FROM WeeklyIngredientLog wil
+        WHERE wil.user.userId = :userId AND wil.weekStartDate = :weekStart
+          AND wil.nearExpiryWhenConsumed = true
+    """)
+    int countConsumedNearExpiryByUserAndWeek(@Param("userId") Long userId,
+                                             @Param("weekStart") LocalDate weekStart);
+}

--- a/src/main/java/com/cookeep/cookeep/domain/mycookeep/entity/WeeklyIngredientLog.java
+++ b/src/main/java/com/cookeep/cookeep/domain/mycookeep/entity/WeeklyIngredientLog.java
@@ -1,0 +1,67 @@
+package com.cookeep.cookeep.domain.mycookeep.entity;
+
+import com.cookeep.cookeep.common.entity.BaseEntity;
+import com.cookeep.cookeep.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Entity
+@Table(name = "weekly_ingredient_logs",
+        uniqueConstraints = @UniqueConstraint(
+                columnNames = {"user_id", "week_start_date", "user_ingredient_id"}
+        ))
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class WeeklyIngredientLog extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(name = "week_start_date", nullable = false)
+    private LocalDate weekStartDate;
+
+    @Column(name = "user_ingredient_id", nullable = false)
+    private Long userIngredientId;
+
+    @Column(name = "ever_near_expiry", nullable = false)
+    private boolean everNearExpiry;
+
+    @Column(nullable = false)
+    private boolean consumed;
+
+    @Column(name = "near_expiry_when_consumed", nullable = false)
+    private boolean nearExpiryWhenConsumed;
+
+    @Builder
+    public WeeklyIngredientLog(User user, LocalDate weekStartDate,
+                                Long userIngredientId, boolean everNearExpiry) {
+        this.user = user;
+        this.weekStartDate = weekStartDate;
+        this.userIngredientId = userIngredientId;
+        this.everNearExpiry = everNearExpiry;
+        this.consumed = false;
+        this.nearExpiryWhenConsumed = false;
+    }
+
+    public void markEverNearExpiry() {
+        this.everNearExpiry = true;
+    }
+
+    public void markConsumed(boolean isNearExpiry) {
+        this.consumed = true;
+        if (isNearExpiry) {
+            this.nearExpiryWhenConsumed = true;
+            this.everNearExpiry = true;
+        }
+    }
+}

--- a/src/main/java/com/cookeep/cookeep/domain/recipe/application/AiRecipeService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/recipe/application/AiRecipeService.java
@@ -19,6 +19,7 @@ import com.cookeep.cookeep.domain.ingredient.defaultingredient.dao.DefaultIngred
 import com.cookeep.cookeep.domain.ingredient.defaultingredient.entity.DefaultIngredient;
 import com.cookeep.cookeep.domain.ingredient.useringredient.dao.UserIngredientRepository;
 import com.cookeep.cookeep.domain.ingredient.useringredient.entity.UserIngredient;
+import com.cookeep.cookeep.domain.mycookeep.application.ConsumptionReportService;
 import com.cookeep.cookeep.domain.recipe.dao.AiMessageRepository;
 import com.cookeep.cookeep.domain.recipe.dao.AiRecipeRepository;
 import com.cookeep.cookeep.domain.recipe.dao.AiSessionRepository;
@@ -59,6 +60,7 @@ public class AiRecipeService {
     private final DailyCookieGrantRepository dailyCookieGrantRepository;
     private final CookieService cookieService;
     private final YoutubeSearchService youtubeSearchService;
+    private final ConsumptionReportService consumptionReportService;
 
     // sessionId 유무에 따라 신규/재요청 로직 분기
     public AiRecipeResponseDto generateRecipe(Long userId, AiRecipeRequestDto request) {
@@ -621,6 +623,9 @@ public class AiRecipeService {
             log.warn("재료 차감 생략 - 유효한 재료 없음: userId={}", userId);
             return;
         }
+
+        // 주간 소비 리포트 기록 (차감/삭제 전에 호출해야 leftDays 읽기 가능)
+        consumptionReportService.markConsumed(userId, targets);
 
         for (UserIngredient ui : targets) {
             int currentQty = ui.getQuantity();


### PR DESCRIPTION
# Related Issue
#105 

# Description
- 마이쿠킵의 '리포트' 탭 내에 있는 '나의 식재료 소비 달성 현황' 두 개의 원형 그래프 데이터,
 이번 주 `전체 식재료 소비율`(왼쪽 그래프)과 `유통기한 임박 식재료 소비율`(오른쪽 그래프)을 조회하는 API를 구현했습니다.

- 현재 코드에는 소비 이력 추적 테이블이 없어서 (소비 시 식재료가 차감/삭제만 됨) 새로운 추적 테이블이 필요했고, 이에 WeeklyIngredientLog 테이블을 설계했습니다. (이벤트 발생시마다 스냅샷을 찍어 기록하고 데이터를 갱신하는 테이블)

### WeeklyIngredientLog 테이블
 
필드 | 설명
-- | --
user_id (FK) | 사용자
week_start_date | 해당 주 월요일 날짜
user_ingredient_id | 식재료 ID (삭제 후에도 보관)
ever_near_expiry | 해당 주에 한 번이라도 leftDays ≤ 3이었는지
consumed | 해당 주에 소비되었는지
near_expiry_when_consumed | 소비 시점에 leftDays ≤ 3이었는지


<!-- notionvc: 841289a1-fcd0-4ac2-af91-e4a503a1e8e6 -->

-  한 주 기준: 월요일 00:00:00 ~ 일요일 23:59:59
 - 폐기 임박 기준: `leftDays` <= 3
 - 카운트 기준: `UserIngredient` 행(row) 단위 (수량이 아닌 종류 수)
 - 부분 소비(AI 레시피로 수량 -1)도 소비로 카운트

- **데이터 갱신 시점** (5가지 이벤트):
    ```
     1. 월요일 00:00:05 스케줄러 → 전체 사용자의 현재 식재료 스냅샷 생성
     2. 식재료 등록 시 → 신규 스냅샷 레코드 생성
     3. 매일 00:00 스케줄러 → leftDays 갱신 후, 새로 임박된 식재료의 everNearExpiry 업데이트
     4. AI 레시피 채택 시 → consumed = true + 임박이면 nearExpiryWhenConsumed = true
     5. 직접 섭취 완료 시 → 4번과 동일
    ```

- 예시 데이터

id | user_ingredient_id | ever_near_expiry | consumed | near_expiry_when_consumed
-- | -- | -- | -- | --
1 | 당근 | false | true | false
2 | 우유 | true | true | true
3 | 양파 | false | false | false
4 | 계란 | true | false | false
5 | 두부 | true | true | true


<!-- notionvc: 1b8a61a4-43db-45c7-be00-16ad9d16bf3e -->

**왼쪽 그래프 (전체 소비율)**

분모 = COUNT(*) = 5  (전체 행 수 = 이번 주에 존재했던 모든 식재료)
분자 = COUNT(consumed = true) = 3  (당근, 우유, 두부)
비율 = 3/5 × 100 = `60%`

**오른쪽 그래프 (폐기 임박 소비율)**

분모 = COUNT(ever_near_expiry = true) = 3  (우유, 계란, 두부 — 주 중 한 번이라도 leftDays ≤ 3이었던 것)
분자 = COUNT(near_expiry_when_consumed = true) = 2  (우유, 두부 — 임박 상태에서 실제 소비된 것)
비율 = 2/3 × 100 = `66%`

# Changes

### 신규 파일

파일 | 역할
-- | --
domain/mycookeep/entity/`WeeklyIngredientLog`.java | 주간 식재료 스냅샷 엔티티
domain/mycookeep/dao/`WeeklyIngredientLogRepository`.java | 스냅샷 Repository (집계 쿼리 4개 포함)
domain/mycookeep/application/`ConsumptionReportService`.java | 핵심 비즈니스 로직 서비스
domain/mycookeep/application/`WeeklyIngredientLogScheduler`.java | 매주 월요일 스냅샷 스케줄러
api/dto/response/`ConsumptionReportResponseDto`.java | API 응답 DTO


<!-- notionvc: 35307ef2-f563-4ff3-b12e-fd92d27196a1 -->

### 수정 파일

파일 | 변경 내용
-- | --
`UserIngredientRepository`.java | findAllByUser_UserId() 메서드 추가
`UserIngredientService`.java | 식재료 등록 시 createLogForNewIngredient() 호출
`ConsumeIngredientService`.java | 직접 섭취 시 markConsumed() 호출 (삭제 전)
`AiRecipeService`.java | AI 레시피 채택 시 markConsumed() 호출 (차감 전)
`UserIngredientScheduler`.java | 매일 임박 상태 updateNearExpiryFlags() 호출
`MyCookeepController`.java | `GET` `/api/my-cookeep/consumption-report` 엔드포인트 추가


<!-- notionvc: 637a34d9-c492-4bc4-82f6-1ec43c463d6d -->