### PR TITLE
fix: 이번주 랭킹 조회 시 식물 돌봄 랭킹에 물주기 횟수도 추가

### DIFF
--- a/src/main/java/com/cookeep/cookeep/api/dto/response/RankingResponseDto.java
+++ b/src/main/java/com/cookeep/cookeep/api/dto/response/RankingResponseDto.java
@@ -17,6 +17,7 @@ public class RankingResponseDto {
 		private Integer rank;
 		private String nickname;
 		private String profileImageUrl;
+		private Long wateringCount;
 	}
 
 	@Getter

--- a/src/main/java/com/cookeep/cookeep/domain/cookeeps/application/CookeepsService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/cookeeps/application/CookeepsService.java
@@ -62,17 +62,19 @@ public class CookeepsService {
 			.mapToObj(index -> {
 				Object[] row = results.get(index);
 				User user = (User) row[0]; // 유저 객체 추출
+				Long wateringCount = (Long) row[1]; // 물주기 횟수 추출
 
 				// 프로필 이미지 URL 가져오기
 				String profileImageUrl = user.getProfilePlant() != null
 					? user.getProfilePlant().getCurrentImageUrl()
 					: null;
-				
+
 				// DTO로 변환 (rank = 인덱스 + 1 → 1, 2, 3)
 				return WateringRankDto.builder()
 					.rank(index + 1)
 					.nickname(user.getNickname())
 					.profileImageUrl(profileImageUrl)
+					.wateringCount(wateringCount)
 					.build();
 			})
 			.toList();


### PR DESCRIPTION
# Related Issue
CLOSE #107 

# Description
쿠킵스 - 이번 주 실물 돌봄 랭킹 top 3 유저에 물주기 횟수도 함께 반환하도록 수정.

응답값 예시
```json
{
  "status": "OK",
  "timestamp": "2026-02-13 02:25:26",
  "data": {
    "recipeRanking": [
      {
        "dailyRecipeId": 2,
        "likeCount": 3,
        "rank": 1,
        "recipeImageUrl": "https://cookeep-images.s3.amazonaws.com/recipe-images/abc.jpg",
        "title": "간단 우유 크림 스파게티"
      },
      {
        "dailyRecipeId": 6,
        "likeCount": 2,
        "rank": 2,
        "recipeImageUrl": null,
        "title": "뉴제목"
      }
    ],
    "wateringRanking": [
      {
        "nickname": "댕굴",
        "profileImageUrl": "https://s3.aws.../bean_4.png",
        "rank": 1, // 1위
        "wateringCount": 18
      },
      {
        "nickname": "카카오현정",
        "profileImageUrl": "https://s3.aws.../bean_3.png",
        "rank": 2, // 2위
        "wateringCount": 3
      },
      {
        "nickname": "얼린 두부",
        "profileImageUrl": "https://s3.aws.../common_sprout.png",
        "rank": 3, // 3위
        "wateringCount": 1
      }
    ]
  }
}
```

# Changes
`RankingResponseDto` - `WateringRankDto`에 `wateringCount` 필드 추가    
```java                                                                                              
private Long wateringCount;
```
                                                                                                                                                                       
`CookeepsService` - `getWateringRanking()`에서 row[1](COUNT 결과)을 추출하여 DTO에 설정  
```java                                                                           
Long wateringCount = (Long) row[1]; // 물주기 횟수 추출
```

Repository 쿼리(findTopWateringUsers)는 이미 **SELECT w.user, COUNT(w)로 물주기 횟수를 조회하고 있었기** 때문에, 
쿼리 수정 없이 서비스와 DTO만 수정했습니다.

# 참고사항
프론트 연동 수정사항이라 보시는 대로 머지해주시면 감사하겠습니다!