### PR TITLE
feat: 회원정보 수정 구현

### DIFF
--- a/src/main/java/com/cookeep/cookeep/api/controller/NoticeController.java
+++ b/src/main/java/com/cookeep/cookeep/api/controller/NoticeController.java
@@ -1,0 +1,39 @@
+package com.cookeep.cookeep.api.controller;
+
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.cookeep.cookeep.api.dto.response.GetNoticeResponseDTO;
+import com.cookeep.cookeep.api.dto.response.UserProfileResponseDTO;
+import com.cookeep.cookeep.common.dto.DataResponse;
+import com.cookeep.cookeep.domain.notice.application.NoticeService;
+import com.cookeep.cookeep.security.UserPrincipal;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/notices")
+public class NoticeController {
+	private final NoticeService noticeService;
+
+	// 회원정보 조회
+	@Operation(summary = "회원정보 조회 API")
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200", description = "요청 성공"),
+		@ApiResponse(responseCode = "401", description = "회원 인증 실패 (AccessToken이 없거나 유효하지 않음)")
+	})
+	@GetMapping()
+	public ResponseEntity<DataResponse<List<GetNoticeResponseDTO>>> getNotices() {
+		return ResponseEntity.ok(DataResponse.from(noticeService.getNotices()));
+	}
+}

--- a/src/main/java/com/cookeep/cookeep/api/controller/UserInfoController.java
+++ b/src/main/java/com/cookeep/cookeep/api/controller/UserInfoController.java
@@ -2,6 +2,7 @@ package com.cookeep.cookeep.api.controller;
 
 import com.cookeep.cookeep.api.dto.request.NicknameUpdateRequestDto;
 import com.cookeep.cookeep.api.dto.request.UpdateEmailRequestDTO;
+import com.cookeep.cookeep.api.dto.request.UpdatePasswordRequestDTO;
 import com.cookeep.cookeep.api.dto.response.UserProfileResponseDTO;
 import com.cookeep.cookeep.common.dto.DataResponse;
 import com.cookeep.cookeep.common.exception.ErrorCode;
@@ -97,6 +98,24 @@ public class UserInfoController {
     ) {
         Long userId = principal.userId();
         userInfoService.updateMyEmail(userId, updateEmailRequestDTO);
+        return ResponseEntity.ok(DataResponse.ok());
+    }
+
+    // 비밀번호 변경
+    @Operation(summary = "비밀번호 변경 API")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "요청 성공"),
+        @ApiResponse(responseCode = "400", description = "요청 파라미터 오류(@Valid 검증 실패, 기존 비밀번호와 동일 등)"),
+        @ApiResponse(responseCode = "401", description = "회원 인증 실패, AccessToken이 없거나 유효하지 않음"),
+        @ApiResponse(responseCode = "403", description = "접근 권한 없음(소셜 로그인 유저는 비밀번호 변경 불가 등)")
+    })
+    @PostMapping("/password")
+    public ResponseEntity<DataResponse<Void>> updateMyPassword(
+        @AuthenticationPrincipal UserPrincipal principal,
+        @Valid @RequestBody UpdatePasswordRequestDTO updatePasswordRequestDTO
+    ) {
+        Long userId = principal.userId();
+        userInfoService.updateMyPassword(userId, updatePasswordRequestDTO);
         return ResponseEntity.ok(DataResponse.ok());
     }
 }

--- a/src/main/java/com/cookeep/cookeep/api/controller/UserInfoController.java
+++ b/src/main/java/com/cookeep/cookeep/api/controller/UserInfoController.java
@@ -2,6 +2,7 @@ package com.cookeep.cookeep.api.controller;
 
 import com.cookeep.cookeep.api.dto.request.NicknameUpdateRequestDto;
 import com.cookeep.cookeep.api.dto.request.UpdateEmailRequestDTO;
+import com.cookeep.cookeep.api.dto.request.UpdateMarketingPushDTO;
 import com.cookeep.cookeep.api.dto.request.UpdatePasswordRequestDTO;
 import com.cookeep.cookeep.api.dto.response.UserProfileResponseDTO;
 import com.cookeep.cookeep.common.dto.DataResponse;
@@ -116,6 +117,24 @@ public class UserInfoController {
     ) {
         Long userId = principal.userId();
         userInfoService.updateMyPassword(userId, updatePasswordRequestDTO);
+        return ResponseEntity.ok(DataResponse.ok());
+    }
+
+    // 알림설정 변경
+    @Operation(summary = "알림설정 변경 API")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "요청 성공"),
+        @ApiResponse(responseCode = "400", description = "요청 파라미터 오류(@Valid 검증 실패 등)"),
+        @ApiResponse(responseCode = "401", description = "회원 인증 실패, AccessToken이 없거나 유효하지 않음")
+    })
+    @PatchMapping("/marketing-push")
+    public ResponseEntity<DataResponse<Void>> updateMarketingPush(
+        @AuthenticationPrincipal UserPrincipal principal,
+        @Valid @RequestBody UpdateMarketingPushDTO updateMarketingPushDTO
+
+    ) {
+        Long userId = principal.userId();
+        userInfoService.updateMarketingPush(userId, updateMarketingPushDTO);
         return ResponseEntity.ok(DataResponse.ok());
     }
 }

--- a/src/main/java/com/cookeep/cookeep/api/controller/UserInfoController.java
+++ b/src/main/java/com/cookeep/cookeep/api/controller/UserInfoController.java
@@ -35,7 +35,7 @@ public class UserInfoController {
         @ApiResponse(responseCode = "401", description = "회원 인증 실패, AccessToken이 없거나 유효하지 않음"),
         @ApiResponse(responseCode = "403", description = "접근 권한 없음")
     })
-    @PostMapping("/auth/signup/send-code")
+    @PostMapping("/profile")
     public ResponseEntity<DataResponse<UserProfileResponseDTO>> getMyProfile(
         @AuthenticationPrincipal UserPrincipal principal
     ) {

--- a/src/main/java/com/cookeep/cookeep/api/controller/UserInfoController.java
+++ b/src/main/java/com/cookeep/cookeep/api/controller/UserInfoController.java
@@ -37,7 +37,7 @@ public class UserInfoController {
         @ApiResponse(responseCode = "401", description = "회원 인증 실패, AccessToken이 없거나 유효하지 않음"),
         @ApiResponse(responseCode = "403", description = "접근 권한 없음")
     })
-    @PostMapping("/profile")
+    @GetMapping("/profile")
     public ResponseEntity<DataResponse<UserProfileResponseDTO>> getMyProfile(
         @AuthenticationPrincipal UserPrincipal principal
     ) {
@@ -91,7 +91,7 @@ public class UserInfoController {
         @ApiResponse(responseCode = "403", description = "접근 권한 없음(소셜 로그인 유저는 이메일 변경 불가 등)"),
         @ApiResponse(responseCode = "409", description = "요청 충돌(이미 사용 중인 이메일 등)")
     })
-    @PostMapping("/email")
+    @PatchMapping("/email")
     public ResponseEntity<DataResponse<Void>> updateMyEmail(
         @AuthenticationPrincipal UserPrincipal principal,
         @Valid @RequestBody UpdateEmailRequestDTO updateEmailRequestDTO
@@ -109,7 +109,7 @@ public class UserInfoController {
         @ApiResponse(responseCode = "401", description = "회원 인증 실패, AccessToken이 없거나 유효하지 않음"),
         @ApiResponse(responseCode = "403", description = "접근 권한 없음(소셜 로그인 유저는 비밀번호 변경 불가 등)")
     })
-    @PostMapping("/password")
+    @PatchMapping("/password")
     public ResponseEntity<DataResponse<Void>> updateMyPassword(
         @AuthenticationPrincipal UserPrincipal principal,
         @Valid @RequestBody UpdatePasswordRequestDTO updatePasswordRequestDTO

--- a/src/main/java/com/cookeep/cookeep/api/controller/UserInfoController.java
+++ b/src/main/java/com/cookeep/cookeep/api/controller/UserInfoController.java
@@ -1,6 +1,7 @@
 package com.cookeep.cookeep.api.controller;
 
 import com.cookeep.cookeep.api.dto.request.NicknameUpdateRequestDto;
+import com.cookeep.cookeep.api.dto.request.UpdateEmailRequestDTO;
 import com.cookeep.cookeep.api.dto.response.UserProfileResponseDTO;
 import com.cookeep.cookeep.common.dto.DataResponse;
 import com.cookeep.cookeep.common.exception.ErrorCode;
@@ -77,6 +78,25 @@ public class UserInfoController {
     ) {
         userInfoService.updateNickname(userId, request);
 
+        return ResponseEntity.ok(DataResponse.ok());
+    }
+
+    // 이메일 변경
+    @Operation(summary = "이메일 변경 API")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "요청 성공"),
+        @ApiResponse(responseCode = "400", description = "요청 파라미터 오류(@Valid 검증 실패, 현재 이메일과 동일 등)"),
+        @ApiResponse(responseCode = "401", description = "회원 인증 실패, AccessToken이 없거나 유효하지 않음"),
+        @ApiResponse(responseCode = "403", description = "접근 권한 없음(소셜 로그인 유저는 이메일 변경 불가 등)"),
+        @ApiResponse(responseCode = "409", description = "요청 충돌(이미 사용 중인 이메일 등)")
+    })
+    @PostMapping("/email")
+    public ResponseEntity<DataResponse<Void>> updateMyEmail(
+        @AuthenticationPrincipal UserPrincipal principal,
+        @Valid @RequestBody UpdateEmailRequestDTO updateEmailRequestDTO
+    ) {
+        Long userId = principal.userId();
+        userInfoService.updateMyEmail(userId, updateEmailRequestDTO);
         return ResponseEntity.ok(DataResponse.ok());
     }
 }

--- a/src/main/java/com/cookeep/cookeep/api/controller/UserInfoController.java
+++ b/src/main/java/com/cookeep/cookeep/api/controller/UserInfoController.java
@@ -1,10 +1,13 @@
 package com.cookeep.cookeep.api.controller;
 
 import com.cookeep.cookeep.api.dto.request.NicknameUpdateRequestDto;
+import com.cookeep.cookeep.api.dto.response.UserProfileResponseDTO;
 import com.cookeep.cookeep.common.dto.DataResponse;
 import com.cookeep.cookeep.common.exception.ErrorCode;
 import com.cookeep.cookeep.config.ApiErrorCodeExamples;
 import com.cookeep.cookeep.domain.user.application.UserInfoService;
+import com.cookeep.cookeep.security.UserPrincipal;
+
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -23,6 +26,23 @@ import org.springframework.web.bind.annotation.*;
 public class UserInfoController {
 
     private final UserInfoService userInfoService;
+
+    // 회원정보 조회
+    @Operation(summary = "회원정보 조회 API")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "요청 성공"),
+        @ApiResponse(responseCode = "400", description = "요청 파라미터 오류"),
+        @ApiResponse(responseCode = "401", description = "회원 인증 실패, AccessToken이 없거나 유효하지 않음"),
+        @ApiResponse(responseCode = "403", description = "접근 권한 없음")
+    })
+    @PostMapping("/auth/signup/send-code")
+    public ResponseEntity<DataResponse<UserProfileResponseDTO>> getMyProfile(
+        @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        Long userId = principal.userId();
+        return ResponseEntity.ok(DataResponse.from(userInfoService.getMyProfile(userId)));
+    }
+
 
     @Operation(summary = "닉네임 수정", description = "사용자의 닉네임을 수정합니다.")
     @ApiErrorCodeExamples({

--- a/src/main/java/com/cookeep/cookeep/api/dto/request/UpdateEmailRequestDTO.java
+++ b/src/main/java/com/cookeep/cookeep/api/dto/request/UpdateEmailRequestDTO.java
@@ -1,0 +1,11 @@
+package com.cookeep.cookeep.api.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record UpdateEmailRequestDTO(
+	@NotBlank(message = "이메일은 필수 입력 값입니다.")
+	@Email(message = "이메일 주소를 다시 확인해주세요")
+	String email
+) {
+}

--- a/src/main/java/com/cookeep/cookeep/api/dto/request/UpdateMarketingPushDTO.java
+++ b/src/main/java/com/cookeep/cookeep/api/dto/request/UpdateMarketingPushDTO.java
@@ -1,0 +1,9 @@
+package com.cookeep.cookeep.api.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+
+public record UpdateMarketingPushDTO(
+	@NotNull(message = "푸쉬알림 동의 여부는 필수 입력 값입니다.")
+	Boolean marketingPush
+) {
+}

--- a/src/main/java/com/cookeep/cookeep/api/dto/request/UpdatePasswordRequestDTO.java
+++ b/src/main/java/com/cookeep/cookeep/api/dto/request/UpdatePasswordRequestDTO.java
@@ -1,0 +1,21 @@
+package com.cookeep.cookeep.api.dto.request;
+
+import com.cookeep.cookeep.api.dto.validator.PasswordMatch;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+@PasswordMatch
+public record UpdatePasswordRequestDTO(
+	// 영문, 숫자 포함 8자 이상 값
+	@NotBlank(message = "비밀번호는 필수 입력 값입니다.")
+	@Pattern(
+		regexp = "^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d]{8,}$",
+		message = "영문, 숫자 포함 8자 이상의 비밀번호를 사용해주세요"
+	)
+	String password,
+
+	@NotBlank(message = "비밀번호 확인은 필수 입력 값입니다.")
+	String passwordConfirm
+) {
+}

--- a/src/main/java/com/cookeep/cookeep/api/dto/response/GetNoticeResponseDTO.java
+++ b/src/main/java/com/cookeep/cookeep/api/dto/response/GetNoticeResponseDTO.java
@@ -1,0 +1,8 @@
+package com.cookeep.cookeep.api.dto.response;
+
+public record GetNoticeResponseDTO(
+	Long noticeId,
+	String title,
+	String content
+) {
+}

--- a/src/main/java/com/cookeep/cookeep/api/dto/response/UserProfileResponseDTO.java
+++ b/src/main/java/com/cookeep/cookeep/api/dto/response/UserProfileResponseDTO.java
@@ -1,0 +1,12 @@
+package com.cookeep.cookeep.api.dto.response;
+
+import com.cookeep.cookeep.domain.user.entity.Provider;
+
+public record UserProfileResponseDTO(
+	String Nickname,
+	String phoneNumber,
+	String email,
+	Provider authProvider,
+	Boolean marketingPush
+) {
+}

--- a/src/main/java/com/cookeep/cookeep/common/exception/ErrorCode.java
+++ b/src/main/java/com/cookeep/cookeep/common/exception/ErrorCode.java
@@ -51,6 +51,7 @@ public enum ErrorCode {
 	SAME_AS_PREVIOUS_PASSWORD(HttpStatus.BAD_REQUEST, "기존 등록된 비밀번호와 동일한 비밀번호입니다.", "AUTH-005"),
 	SAME_AS_CURRENT_PHONE_NUMBER(HttpStatus.BAD_REQUEST, "기존 등록된 전화번호와 동일한 전화번호입니다.", "USER-007"),
 	TITLE_INVALID_VALUE(HttpStatus.BAD_REQUEST, "레시피 제목을 입력해주세요.", "RECIPE-022"),
+	SAME_AS_CURRENT_EMAIL(HttpStatus.BAD_REQUEST, "기존 등록된 이메일과 동일한 이메일입니다.", "USER-008"),
 
 	// 401 UNAUTHORIZED (인증 관련)
 	UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증에 실패했습니다.", "AUTH-001"),
@@ -63,6 +64,8 @@ public enum ErrorCode {
 	AI_SESSION_FORBIDDEN(HttpStatus.FORBIDDEN, "본인의 대화 세션이 아닙니다.", "RECIPE-015"),
 	DAILY_RECIPE_FORBIDDEN(HttpStatus.FORBIDDEN, "본인의 레시피가 아닙니다.", "DAILY_RECIPE-001"),
 	CANNOT_LIKE_OWN_RECIPE(HttpStatus.FORBIDDEN, "자신의 레시피에는 좋아요를 누를 수 없습니다.", "DAILY_RECIPE-006"),
+	SOCIAL_USER_EMAIL_CHANGE_NOT_ALLOWED(HttpStatus.FORBIDDEN, "소셜 로그인 사용자는 이메일을 변경할 수 없습니다.", "USER-009"),
+
 
 	// 404 NOT FOUND
 	NOT_FOUND(HttpStatus.NOT_FOUND, "찾을 수 없습니다.", "COMMON-004"),

--- a/src/main/java/com/cookeep/cookeep/domain/notice/application/NoticeService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/notice/application/NoticeService.java
@@ -1,0 +1,26 @@
+package com.cookeep.cookeep.domain.notice.application;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import com.cookeep.cookeep.api.dto.response.GetNoticeResponseDTO;
+import com.cookeep.cookeep.domain.notice.dao.NoticeRepository;
+import com.cookeep.cookeep.domain.notice.entity.Notice;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class NoticeService {
+	private final NoticeRepository noticeRepository;
+
+	// 공지사항 조회
+	public List<GetNoticeResponseDTO> getNotices() {
+		return noticeRepository.findAllByOrderByCreatedAtDesc().stream()
+			.map(n -> new GetNoticeResponseDTO(n.getNoticeId(), n.getTitle(), n.getContent()))
+			.toList();
+	}
+}

--- a/src/main/java/com/cookeep/cookeep/domain/notice/dao/NoticeRepository.java
+++ b/src/main/java/com/cookeep/cookeep/domain/notice/dao/NoticeRepository.java
@@ -1,0 +1,13 @@
+package com.cookeep.cookeep.domain.notice.dao;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.cookeep.cookeep.domain.notice.entity.Notice;
+
+public interface NoticeRepository extends JpaRepository<Notice, Long> {
+
+	// 전체 공지를 최신순으로 조회함
+	List<Notice> findAllByOrderByCreatedAtDesc();
+}

--- a/src/main/java/com/cookeep/cookeep/domain/notice/entity/Notice.java
+++ b/src/main/java/com/cookeep/cookeep/domain/notice/entity/Notice.java
@@ -1,0 +1,38 @@
+package com.cookeep.cookeep.domain.notice.entity;
+
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import com.cookeep.cookeep.common.entity.BaseEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@EntityListeners(AuditingEntityListener.class)
+@Table(name = "notices")
+public class Notice extends BaseEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long noticeId;
+
+	@Column(nullable = false)
+	private String title;
+
+	@Column(nullable = false, columnDefinition = "TEXT")
+	private String content;
+
+}

--- a/src/main/java/com/cookeep/cookeep/domain/user/application/UserInfoService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/user/application/UserInfoService.java
@@ -3,9 +3,12 @@ package com.cookeep.cookeep.domain.user.application;
 import com.cookeep.cookeep.api.dto.request.NicknameUpdateRequestDto;
 import com.cookeep.cookeep.api.dto.request.SendCodeRequestDTO;
 import com.cookeep.cookeep.api.dto.request.VerifyCodeRequestDTO;
+import com.cookeep.cookeep.api.dto.response.UserProfileResponseDTO;
 import com.cookeep.cookeep.common.exception.AppException;
 import com.cookeep.cookeep.common.exception.ErrorCode;
+import com.cookeep.cookeep.domain.user.dao.UserAuthRepository;
 import com.cookeep.cookeep.domain.user.dao.UserRepository;
+import com.cookeep.cookeep.domain.user.entity.Provider;
 import com.cookeep.cookeep.domain.user.entity.User;
 import com.cookeep.cookeep.domain.verification.application.SmsVerificationService;
 import com.cookeep.cookeep.domain.verification.entity.VerificationPurpose;
@@ -22,6 +25,27 @@ public class UserInfoService {
     private final UserRepository userRepository;
     private final UserReader userReader;
     private final SmsVerificationService smsVerificationService;
+    private final UserAuthRepository userAuthRepository;
+
+    public UserProfileResponseDTO getMyProfile(Long userId) {
+        User user = userReader.readById(userId);
+
+        String nickname = user.getNickname();
+        String email = user.getEmail();
+        Provider provider = userAuthRepository.findProviderByUserId(userId);
+        Boolean marketingPush = user.getMarketingPush();
+
+        // 로컬 유저일 경우에만 존재, 소셜은 전화번호 없음
+        String phoneNumber = (provider == Provider.LOCAL)
+            ? user.getPhoneNumber()
+            : null;
+
+
+        return new UserProfileResponseDTO(
+            nickname, phoneNumber, email,
+            provider, marketingPush
+        );
+    }
 
     public void updateNickname(Long userId, NicknameUpdateRequestDto request) {
         if (userId == null) {

--- a/src/main/java/com/cookeep/cookeep/domain/user/application/UserInfoService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/user/application/UserInfoService.java
@@ -3,6 +3,7 @@ package com.cookeep.cookeep.domain.user.application;
 import com.cookeep.cookeep.api.dto.request.NicknameUpdateRequestDto;
 import com.cookeep.cookeep.api.dto.request.SendCodeRequestDTO;
 import com.cookeep.cookeep.api.dto.request.UpdateEmailRequestDTO;
+import com.cookeep.cookeep.api.dto.request.UpdatePasswordRequestDTO;
 import com.cookeep.cookeep.api.dto.request.VerifyCodeRequestDTO;
 import com.cookeep.cookeep.api.dto.response.UserProfileResponseDTO;
 import com.cookeep.cookeep.common.exception.AppException;
@@ -17,6 +18,7 @@ import com.cookeep.cookeep.domain.verification.entity.VerificationPurpose;
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.boot.web.error.Error;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -29,7 +31,9 @@ public class UserInfoService {
     private final UserReader userReader;
     private final SmsVerificationService smsVerificationService;
     private final UserAuthRepository userAuthRepository;
+    private final PasswordEncoder passwordEncoder;
 
+    // 회원 정보 조회
     public UserProfileResponseDTO getMyProfile(Long userId) {
         User user = userReader.readById(userId);
 
@@ -110,6 +114,7 @@ public class UserInfoService {
         user.updatePhoneNumber(newPhoneNumber);
     }
 
+    // 이메일 변경
     @Transactional
     public void updateMyEmail(Long userId, UpdateEmailRequestDTO updateEmailRequestDTO) {
 
@@ -136,5 +141,20 @@ public class UserInfoService {
         }
 
         user.updateEmail(newEmail);
+    }
+
+    // 비밀번호 변경
+    @Transactional
+    public void updateMyPassword(Long userId, UpdatePasswordRequestDTO updatePasswordRequestDTO) {
+        User user = userReader.readById(userId);
+
+        String encodedPassword = passwordEncoder.encode(updatePasswordRequestDTO.password());
+
+        // 기존에 등록되어 있던 비밀번호와 새로 들어온 비밀번호가 동일할 경우
+        if (passwordEncoder.matches(updatePasswordRequestDTO.password(), user.getPassword())) {
+            throw new AppException(ErrorCode.SAME_AS_PREVIOUS_PASSWORD);
+        }
+
+        user.updatePassword(encodedPassword);
     }
 }

--- a/src/main/java/com/cookeep/cookeep/domain/user/application/UserInfoService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/user/application/UserInfoService.java
@@ -2,6 +2,7 @@ package com.cookeep.cookeep.domain.user.application;
 
 import com.cookeep.cookeep.api.dto.request.NicknameUpdateRequestDto;
 import com.cookeep.cookeep.api.dto.request.SendCodeRequestDTO;
+import com.cookeep.cookeep.api.dto.request.UpdateEmailRequestDTO;
 import com.cookeep.cookeep.api.dto.request.VerifyCodeRequestDTO;
 import com.cookeep.cookeep.api.dto.response.UserProfileResponseDTO;
 import com.cookeep.cookeep.common.exception.AppException;
@@ -14,6 +15,8 @@ import com.cookeep.cookeep.domain.verification.application.SmsVerificationServic
 import com.cookeep.cookeep.domain.verification.entity.VerificationPurpose;
 
 import lombok.RequiredArgsConstructor;
+
+import org.springframework.boot.web.error.Error;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -105,5 +108,33 @@ public class UserInfoService {
         smsVerificationService.verifyCode(newPhoneNumber, VerificationPurpose.CHANGE_PHONE, code);
 
         user.updatePhoneNumber(newPhoneNumber);
+    }
+
+    @Transactional
+    public void updateMyEmail(Long userId, UpdateEmailRequestDTO updateEmailRequestDTO) {
+
+        Provider provider = userAuthRepository.findProviderByUserId(userId);
+
+        // 소셜 로그인은 이메일을 변경할 수 없음
+        if (provider != Provider.LOCAL) {
+            throw new AppException(ErrorCode.SOCIAL_USER_EMAIL_CHANGE_NOT_ALLOWED);
+        }
+
+        User user = userReader.readById(userId);
+        String newEmail = updateEmailRequestDTO.email();
+
+        String currentEmail = user.getEmail();
+
+        // 현재 등록된 이메일과 동일한 경우
+        if (newEmail.equals(currentEmail)) {
+            throw new AppException(ErrorCode.SAME_AS_CURRENT_EMAIL);
+        }
+
+        // 이미 등록된 이메일인지 확인
+        if (userRepository.existsByEmail(newEmail)) {
+            throw new AppException(ErrorCode.USER_EMAIL_ALREADY_EXISTS);
+        }
+
+        user.updateEmail(newEmail);
     }
 }

--- a/src/main/java/com/cookeep/cookeep/domain/user/application/UserInfoService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/user/application/UserInfoService.java
@@ -3,6 +3,7 @@ package com.cookeep.cookeep.domain.user.application;
 import com.cookeep.cookeep.api.dto.request.NicknameUpdateRequestDto;
 import com.cookeep.cookeep.api.dto.request.SendCodeRequestDTO;
 import com.cookeep.cookeep.api.dto.request.UpdateEmailRequestDTO;
+import com.cookeep.cookeep.api.dto.request.UpdateMarketingPushDTO;
 import com.cookeep.cookeep.api.dto.request.UpdatePasswordRequestDTO;
 import com.cookeep.cookeep.api.dto.request.VerifyCodeRequestDTO;
 import com.cookeep.cookeep.api.dto.response.UserProfileResponseDTO;
@@ -156,5 +157,17 @@ public class UserInfoService {
         }
 
         user.updatePassword(encodedPassword);
+    }
+
+    // 알림설정 변경
+    // 멱등성을 보장하기 위해 최종 상태를 명시적으로 가져옴
+    // 기존 DB에 저장된 상태와 동일할 경우 에러 발생 없이 그대로 업데이트되도록 처리하였음
+    @Transactional
+    public void updateMarketingPush(Long userId, UpdateMarketingPushDTO updateMarketingPushDTO) {
+        User user = userReader.readById(userId);
+
+        Boolean newMarketingPush = updateMarketingPushDTO.marketingPush();
+
+        user.updateMarketingPush(newMarketingPush);
     }
 }

--- a/src/main/java/com/cookeep/cookeep/domain/user/dao/UserAuthRepository.java
+++ b/src/main/java/com/cookeep/cookeep/domain/user/dao/UserAuthRepository.java
@@ -4,6 +4,8 @@ import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.cookeep.cookeep.domain.user.entity.Provider;
 import com.cookeep.cookeep.domain.user.entity.User;
@@ -13,4 +15,7 @@ public interface UserAuthRepository extends JpaRepository<UserAuth, Long> {
 	Optional<UserAuth> findByProviderAndProviderUserId(Provider provider, String providerUserId);
 
 	List<UserAuth> findAllByUser(User user);
+
+	@Query("select ua.provider from UserAuth ua where ua.user.userId = :userId")
+	Provider findProviderByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/com/cookeep/cookeep/domain/user/dao/UserRepository.java
+++ b/src/main/java/com/cookeep/cookeep/domain/user/dao/UserRepository.java
@@ -29,4 +29,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     // 푸시 알림 동의한 사용자 조회
     @Query("SELECT u FROM User u WHERE u.marketingPush = true")
     List<User> findAllByMarketingPushTrue();
+
+    boolean existsByEmail(String email);
 }

--- a/src/main/java/com/cookeep/cookeep/domain/user/entity/User.java
+++ b/src/main/java/com/cookeep/cookeep/domain/user/entity/User.java
@@ -144,4 +144,8 @@ public class User extends BaseEntity {
 	public void updateEmail(String email) {
 		this.email = email;
 	}
+
+	public void updateMarketingPush(Boolean marketingPush) {
+		this.marketingPush = marketingPush;
+	}
 }

--- a/src/main/java/com/cookeep/cookeep/domain/user/entity/User.java
+++ b/src/main/java/com/cookeep/cookeep/domain/user/entity/User.java
@@ -141,4 +141,7 @@ public class User extends BaseEntity {
 		this.phoneNumber = phoneNumber;
 	}
 
+	public void updateEmail(String email) {
+		this.email = email;
+	}
 }


### PR DESCRIPTION
# Related Issue  
#101  
</br></br>

# Description  

## 마이페이지 회원정보/설정 API 구현

- 마이페이지 내 **프로필 조회, 계정 정보 수정, 알림 설정 변경** 기능 구현
- 모든 API는 `@AuthenticationPrincipal UserPrincipal` 기반, 인증된 사용자 기준으로만 동작함
- 공지사항 조회는 별도 Notice 도메인으로 분리하여 구현하였음

</br>

### 1. Profile 영역 – 회원 프로필 조회

- `GET /api/users/me/profile`
- `User` 기본 정보와 `UserAuth.provider`를 함께 조회하여 응답 DTO 구성
  - provider에 따라 프로필 조회 정책이 다르기 때문
- 인증 provider에 따라 노출 정보 분기
  - LOCAL 유저 → phoneNumber 포함
  - 소셜 로그인 유저 → phoneNumber는 null 반환

</br>

### 2. Account 영역 – 이메일 / 비밀번호 변경

#### 이메일 변경 정책 반영

- `PATCH /api/users/me/email`
- 이메일 변경은 **LOCAL 계정만 허용**
  - 소셜 로그인 계정은 provider 기반 식별 구조를 사용하므로 변경 불가
  - 소셜 로그인 계정이 시도하는 경우 `SOCIAL_USER_EMAIL_CHANGE_NOT_ALLOWED (USER-009)` 예외를 반환함
- 예외 처리
  - 기존 이메일과 동일한 경우 → `SAME_AS_CURRENT_EMAIL (USER-008)`
  - 이미 사용 중인 이메일 → `USER_EMAIL_ALREADY_EXISTS`

</br>

#### 비밀번호 변경

- `PATCH /api/users/me/password`
- `PasswordEncoder` 기반 암호화 저장
- 기존 비밀번호와 동일한 값 요청 시 `SAME_AS_PREVIOUS_PASSWORD` 예외를 반환함
- `@PasswordMatch` 커스텀 검증을 통해 password / passwordConfirm 일치 여부를 DTO에서 사전에 검증함

</br>

### 3. Settings 영역 – 알림 설정 변경

- `PATCH /api/users/me/marketing-push`
- `marketingPush` 값을 명시적으로 전달받아 최종 상태를 업데이트
- DB와 동일한 값을 재요청했을 경우에도 멱등적 요청 구조를 유지하기 위해 에러 없이 성공 처리함
  - 클라이언트 재시도, 중복 요청 상황 등 고려

</br></br>

## Notice 도메인 추가 – 공지사항 조회 API 구현

- `GET /api/notices`
- `createdAt` 기준 최신순 정렬
- `Notice`는 `BaseEntity`(JPA Auditing) 기반으로 생성 시간 관리
- 엔티티 → DTO 매핑을 서비스 레이어에서 수행하여 응답 구조 단순화
- 현재 공지사항 데이터가 많지 않으므로 전체 조회 방식으로 구현함

</br></br>

# Changes

### Profile
- 회원 프로필 조회 API 추가
- provider 기반 응답 정보 분기 처리

### Account
- 이메일 변경 API 추가 (LOCAL 계정만 허용 / 동일값·중복 검증)
- 비밀번호 변경 API 추가 (동일 비밀번호 방지 / PasswordMatch 적용)
- ErrorCode 추가 (`USER-008`, `USER-009`)

### Settings
- 알림 설정 변경 API 추가 (멱등 요청 허용)

### Notice
- Notice 엔티티 / 레포지토리 / 서비스 / 컨트롤러 추가
- 최신순 공지사항 조회 API 구현