### PR TITLE
feat: 로그아웃 및 회원탈퇴 구현

### DIFF
--- a/src/main/java/com/cookeep/cookeep/api/controller/AuthController.java
+++ b/src/main/java/com/cookeep/cookeep/api/controller/AuthController.java
@@ -1,6 +1,7 @@
 package com.cookeep.cookeep.api.controller;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -19,6 +20,7 @@ import com.cookeep.cookeep.api.dto.response.SignUpResponseDTO;
 import com.cookeep.cookeep.api.dto.response.TokenRefreshResponseDTO;
 import com.cookeep.cookeep.common.dto.DataResponse;
 import com.cookeep.cookeep.domain.user.application.AuthService;
+import com.cookeep.cookeep.security.UserPrincipal;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -89,4 +91,20 @@ public class AuthController {
 		authService.resetPassword(resetPasswordRequestDTO);
 		return ResponseEntity.ok(DataResponse.ok());
 	}
+
+	@Operation(summary = "로그아웃 API", description = "현재 로그인한 사용자의 세션(RefreshToken)을 무효화합니다.")
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200", description = "로그아웃 성공"),
+		@ApiResponse(responseCode = "401", description = "회원 인증 실패, AccessToken이 없거나 유효하지 않음")
+	})
+	@PostMapping("/logout")
+	public ResponseEntity<DataResponse<Void>> logout(
+		@AuthenticationPrincipal UserPrincipal principal
+	) {
+		Long userId = principal.userId();
+		authService.logout(userId);
+		return ResponseEntity.ok(DataResponse.ok());
+	}
+
+
 }

--- a/src/main/java/com/cookeep/cookeep/api/controller/AuthController.java
+++ b/src/main/java/com/cookeep/cookeep/api/controller/AuthController.java
@@ -2,6 +2,7 @@ package com.cookeep.cookeep.api.controller;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -92,7 +93,7 @@ public class AuthController {
 		return ResponseEntity.ok(DataResponse.ok());
 	}
 
-	@Operation(summary = "로그아웃 API", description = "현재 로그인한 사용자의 세션(RefreshToken)을 무효화합니다.")
+	@Operation(summary = "로그아웃 API")
 	@ApiResponses(value = {
 		@ApiResponse(responseCode = "200", description = "로그아웃 성공"),
 		@ApiResponse(responseCode = "401", description = "회원 인증 실패, AccessToken이 없거나 유효하지 않음")
@@ -106,5 +107,18 @@ public class AuthController {
 		return ResponseEntity.ok(DataResponse.ok());
 	}
 
-
+	@Operation(summary = "회원 탈퇴 API", description = "현재 로그인한 사용자를 탈퇴 처리합니다.")
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200", description = "회원 탈퇴 성공"),
+		@ApiResponse(responseCode = "401", description = "회원 인증 실패, AccessToken이 없거나 유효하지 않음"),
+		@ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음")
+	})
+	@DeleteMapping("/withdraw")
+	public ResponseEntity<DataResponse<Void>> withdraw(
+		@AuthenticationPrincipal UserPrincipal principal
+	) {
+		Long userId = principal.userId();
+		authService.withdraw(userId);
+		return ResponseEntity.ok(DataResponse.ok());
+	}
 }

--- a/src/main/java/com/cookeep/cookeep/config/SecurityConfig.java
+++ b/src/main/java/com/cookeep/cookeep/config/SecurityConfig.java
@@ -64,12 +64,17 @@ public class SecurityConfig {
 				.requestMatchers(
 					// 아래 경로들은 로그인하지 않아도 접근 가능
 					// 나머지 경로는 모두 로그인해야 접근 가능함
-					"/api/auth/**",
 					"/swagger-ui/**",
 					"/v3/api-docs/**",
 					"/swagger-resources/**",
 					"/error"
 				).permitAll()
+
+				// auth 경로 중 로그아웃은 로그인한 사용자만 가능하도록 처리
+				.requestMatchers("/api/auth/logout").authenticated()
+
+				// 나머지 auth 경로는 로그인하지 않아도 접근 가능
+				.requestMatchers("/api/auth/**").permitAll()
 
 				.anyRequest().authenticated()
 			)

--- a/src/main/java/com/cookeep/cookeep/config/SecurityConfig.java
+++ b/src/main/java/com/cookeep/cookeep/config/SecurityConfig.java
@@ -70,8 +70,8 @@ public class SecurityConfig {
 					"/error"
 				).permitAll()
 
-				// auth 경로 중 로그아웃은 로그인한 사용자만 가능하도록 처리
-				.requestMatchers("/api/auth/logout").authenticated()
+				// auth 경로 중 로그아웃, 회원 탈퇴는 로그인한 사용자만 가능하도록 처리
+				.requestMatchers("/api/auth/logout", "/api/auth/withdraw").authenticated()
 
 				// 나머지 auth 경로는 로그인하지 않아도 접근 가능
 				.requestMatchers("/api/auth/**").permitAll()

--- a/src/main/java/com/cookeep/cookeep/domain/user/application/AuthService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/user/application/AuthService.java
@@ -414,4 +414,20 @@ public class AuthService {
 		// 로그아웃 시 refreshToken 저장된 userSession 폐기
 		userSessionRepository.deleteByUser_UserId(userId);
 	}
+
+	@Transactional
+	public void withdraw(Long userId) {
+		User user = userReader.readById(userId);
+
+		// 멱등성 보장을 위해 이미 탈퇴된 회원은 성공 처리
+		if (user.getUserStatus() == UserStatus.WITHDRAWN) {
+			userSessionRepository.deleteByUser_UserId(userId);
+			return;
+		}
+
+		user.withdraw();
+
+		// 탈퇴 시 refreshToken도 함께 무효화
+		userSessionRepository.deleteByUser_UserId(userId);
+	}
 }

--- a/src/main/java/com/cookeep/cookeep/domain/user/application/AuthService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/user/application/AuthService.java
@@ -408,4 +408,10 @@ public class AuthService {
 
 		user.updatePassword(encodedPassword);
 	}
+
+	@Transactional
+	public void logout(Long userId) {
+		// 로그아웃 시 refreshToken 저장된 userSession 폐기
+		userSessionRepository.deleteByUser_UserId(userId);
+	}
 }

--- a/src/main/java/com/cookeep/cookeep/domain/user/dao/UserSessionRepository.java
+++ b/src/main/java/com/cookeep/cookeep/domain/user/dao/UserSessionRepository.java
@@ -10,4 +10,8 @@ import com.cookeep.cookeep.domain.user.entity.UserSession;
 public interface UserSessionRepository extends JpaRepository<UserSession, Long> {
 	Optional<UserSession> findByUser_UserId(Long userId);
 	Optional<UserSession> findByUser(User user);
+
+	void deleteByUser_UserId(Long userId);
+
+	boolean existsByUser_UserId(Long userId);
 }

--- a/src/main/java/com/cookeep/cookeep/domain/user/entity/User.java
+++ b/src/main/java/com/cookeep/cookeep/domain/user/entity/User.java
@@ -141,4 +141,8 @@ public class User extends BaseEntity {
 		this.phoneNumber = phoneNumber;
 	}
 
+	public void withdraw() {
+		this.userStatus = UserStatus.WITHDRAWN;
+	}
+
 }


### PR DESCRIPTION
# Related Issue  
#110  
</br></br>

# Description  

## 로그아웃 API 구현

- `POST /api/auth/logout`
- `@AuthenticationPrincipal` 기반, 인증된 사용자만 접근 가능
- 로그아웃 시 해당 사용자의 `UserSession`을 삭제하여 refreshToken을 무효화함
- AccessToken은 stateless 구조이므로 별도 저장소에서 관리하지 않으며,  refreshToken을 폐기하는 방식으로 세션을 종료하도록 설계함.

</br></br>

## 회원 탈퇴 API 구현

- `DELETE /api/auth/withdraw`
- 로그인 사용자를 기준으로 탈퇴 처리
- `UserStatus`를 `WITHDRAWN`으로 변경하여 Soft Delete 방식으로 관리하였음

### 멱등성 처리

- 이미 `WITHDRAWN` 상태인 사용자가 다시 요청할 경우에도 예외 없이 성공 처리함
- 탈퇴 요청 시 항상 `UserSession`을 삭제하여 refreshToken을 함께 무효화
- 회원 탈퇴와 동시에 세션을 폐기함으로써 탈퇴 이후 refreshToken을 통한 재발급을 방지함

</br></br>

## SecurityConfig 설정 수정

- `/api/auth/logout`, `/api/auth/withdraw`는 로그인된 사용자만 접근 가능하도록 `.authenticated()` 설정
- 나머지 `/api/auth/**` 경로는 `permitAll()`을 유지함
- 로그아웃·탈퇴는 인증 이후에만 가능하도록 보안 설정을 분리하였음

</br></br>

# Changes

- 로그아웃 API 추가
- 회원 탈퇴 API 추가
- 탈퇴 시 refreshToken 무효화 처리
- `UserSessionRepository.deleteByUser_UserId` 메서드 추가
- SecurityConfig 경로 접근 권한 분리
