### PR TITLE
hotfix: 중복된 ErrorCode 제거

### DIFF
--- a/src/main/java/com/cookeep/cookeep/common/exception/ErrorCode.java
+++ b/src/main/java/com/cookeep/cookeep/common/exception/ErrorCode.java
@@ -66,7 +66,6 @@ public enum ErrorCode {
 	NOT_MY_PLANT(HttpStatus.FORBIDDEN, "해당 식물에 대한 권한이 없습니다.", "PLANT-001"),
 	AI_SESSION_FORBIDDEN(HttpStatus.FORBIDDEN, "본인의 대화 세션이 아닙니다.", "RECIPE-015"),
 	DAILY_RECIPE_FORBIDDEN(HttpStatus.FORBIDDEN, "본인의 레시피가 아닙니다.", "DAILY_RECIPE-001"),
-	CANNOT_LIKE_OWN_RECIPE(HttpStatus.FORBIDDEN, "자신의 레시피에는 좋아요를 누를 수 없습니다.", "DAILY_RECIPE-006"),
 	SOCIAL_USER_EMAIL_CHANGE_NOT_ALLOWED(HttpStatus.FORBIDDEN, "소셜 로그인 사용자는 이메일을 변경할 수 없습니다.", "USER-009"),
 
 	// 404 NOT FOUND


### PR DESCRIPTION
# Related Issue  
#112 
</br></br>

# Description  
머지 과정에서 중복된 ErrorCode를 제거하였습니다.
</br></br>

# Changes
`CANNOT_LIKE_OWN_RECIPE(HttpStatus.FORBIDDEN, "자신의 레시피에는 좋아요를 누를 수 없습니다.", "DAILY_RECIPE-006")` 제거