### PR TITLE
fix: VerificationController 내 ApiResponse 수정 및 보강

### DIFF
--- a/src/main/java/com/cookeep/cookeep/api/controller/VerificationController.java
+++ b/src/main/java/com/cookeep/cookeep/api/controller/VerificationController.java
@@ -32,10 +32,10 @@ public class VerificationController {
 	@Operation(summary = "회원가입 시 SMS 인증 요청 API")
 	@ApiResponses(value = {
 		@ApiResponse(responseCode = "200", description = "요청 성공"),
-		@ApiResponse(responseCode = "400", description = "요청 파라미터 오류"),
+		@ApiResponse(responseCode = "400", description = "요청 파라미터 오류 (@Valid 검증 실패)"),
 		@ApiResponse(responseCode = "409", description = "이미 사용중인 전화번호"),
 		@ApiResponse(responseCode = "429", description = "인증 재요청이 너무 빠름"),
-		@ApiResponse(responseCode = "500", description = "SMS 발송 실패 (외부 서비스 오류)")
+		@ApiResponse(responseCode = "500", description = "서버 오류")
 	})
 	@PostMapping("/auth/signup/send-code")
 	public ResponseEntity<DataResponse<Void>> sendSignupCode(
@@ -49,10 +49,10 @@ public class VerificationController {
 	@Operation(summary = "회원가입 시 SMS 인증 확인 API")
 	@ApiResponses(value = {
 		@ApiResponse(responseCode = "200", description = "확인 성공"),
-		@ApiResponse(responseCode = "400", description = "요청 파라미터 오류"),
+		@ApiResponse(responseCode = "400", description = "요청 오류 (형식 오류 또는 인증 실패)"),
 		@ApiResponse(responseCode = "404", description = "인증 요청 내역이 없음"),
-		@ApiResponse(responseCode = "409", description = "인증번호 불일치 또는 만료됨"),
-		@ApiResponse(responseCode = "429", description = "인증 시도 횟수 초과")
+		@ApiResponse(responseCode = "429", description = "인증 시도 횟수 초과"),
+		@ApiResponse(responseCode = "500", description = "서버 오류")
 	})
 	@PostMapping("/auth/signup/verify-code")
 	public ResponseEntity<DataResponse<Void>> verifySignupCode(
@@ -66,10 +66,10 @@ public class VerificationController {
 	@Operation(summary = "비밀번호 찾기 시 SMS 인증 요청 API")
 	@ApiResponses(value = {
 		@ApiResponse(responseCode = "200", description = "요청 성공"),
-		@ApiResponse(responseCode = "400", description = "요청 파라미터 오류"),
-		@ApiResponse(responseCode = "409", description = "가입된 번호가 없음"),
+		@ApiResponse(responseCode = "400", description = "요청 파라미터 오류 (@Valid 검증 실패)"),
+		@ApiResponse(responseCode = "404", description = "가입된 번호가 없음"),
 		@ApiResponse(responseCode = "429", description = "인증 재요청이 너무 빠름"),
-		@ApiResponse(responseCode = "500", description = "SMS 발송 실패 (외부 서비스 오류)")
+		@ApiResponse(responseCode = "500", description = "서버 오류")
 	})
 	@PostMapping("/auth/password/send-code")
 	public ResponseEntity<DataResponse<Void>> sendPasswordResetCode(
@@ -83,10 +83,10 @@ public class VerificationController {
 	@Operation(summary = "비밀번호 찾기 시 SMS 인증 확인 API")
 	@ApiResponses(value = {
 		@ApiResponse(responseCode = "200", description = "확인 성공"),
-		@ApiResponse(responseCode = "400", description = "요청 파라미터 오류"),
+		@ApiResponse(responseCode = "400", description = "요청 오류 (형식 오류 또는 인증 실패)"),
 		@ApiResponse(responseCode = "404", description = "인증 요청 내역이 없음"),
-		@ApiResponse(responseCode = "409", description = "인증번호 불일치 또는 만료됨"),
-		@ApiResponse(responseCode = "429", description = "인증 시도 횟수 초과")
+		@ApiResponse(responseCode = "429", description = "인증 시도 횟수 초과"),
+		@ApiResponse(responseCode = "500", description = "서버 오류")
 	})
 	@PostMapping("/auth/password/verify-code")
 	public ResponseEntity<DataResponse<Void>> verifyPasswordResetCode(
@@ -100,12 +100,13 @@ public class VerificationController {
 	@Operation(summary = "전화번호 변경 시 SMS 인증 요청 API")
 	@ApiResponses(value = {
 		@ApiResponse(responseCode = "200", description = "요청 성공"),
-		@ApiResponse(responseCode = "400", description = "요청 파라미터 오류"),
+		@ApiResponse(responseCode = "400", description = "요청 오류 (형식 오류 또는 인증 실패)"),
 		@ApiResponse(responseCode = "401", description = "회원 인증 실패, AccessToken이 없거나 유효하지 않음"),
 		@ApiResponse(responseCode = "403", description = "접근 권한 없음"),
-		@ApiResponse(responseCode = "409", description = "이미 사용 중인 번호임"),
+		@ApiResponse(responseCode = "404", description = "인증 요청 내역이 없음"),
+		@ApiResponse(responseCode = "409", description = "이미 사용 중인 전화번호"),
 		@ApiResponse(responseCode = "429", description = "인증 재요청이 너무 빠름"),
-		@ApiResponse(responseCode = "500", description = "SMS 발송 실패 (외부 서비스 오류)")
+		@ApiResponse(responseCode = "500", description = "서버 오류")
 	})
 	@PostMapping("/users/me/phone/send-code")
 	public ResponseEntity<DataResponse<Void>> sendChangePhoneCode(
@@ -121,12 +122,12 @@ public class VerificationController {
 	@Operation(summary = "전화번호 변경 시 SMS 인증 확인 API")
 	@ApiResponses(value = {
 		@ApiResponse(responseCode = "200", description = "확인 성공"),
-		@ApiResponse(responseCode = "400", description = "요청 파라미터 오류"),
+		@ApiResponse(responseCode = "400", description = "요청 파라미터 오류 (인증번호 불일치 또는 만료됨 등)"),
 		@ApiResponse(responseCode = "401", description = "회원 인증 실패, AccessToken이 없거나 유효하지 않음"),
 		@ApiResponse(responseCode = "403", description = "접근 권한 없음"),
 		@ApiResponse(responseCode = "404", description = "인증 요청 내역이 없음"),
-		@ApiResponse(responseCode = "409", description = "인증번호 불일치 또는 만료됨"),
-		@ApiResponse(responseCode = "429", description = "인증 시도 횟수 초과")
+		@ApiResponse(responseCode = "429", description = "인증 시도 횟수 초과"),
+		@ApiResponse(responseCode = "500", description = "서버 오류")
 	})
 	@PostMapping("/users/me/phone/verify-code")
 	public ResponseEntity<DataResponse<Void>> verifyChangePhoneCode(

--- a/src/main/java/com/cookeep/cookeep/common/exception/ErrorCode.java
+++ b/src/main/java/com/cookeep/cookeep/common/exception/ErrorCode.java
@@ -43,7 +43,7 @@ public enum ErrorCode {
 	INVALID_PHONE_NUMBER(HttpStatus.BAD_REQUEST, "유효하지 않은 전화번호 형식입니다.", "SMS-001"),
 	INVALID_VERIFICATION_CODE(HttpStatus.BAD_REQUEST, "인증번호가 일치하지 않습니다.", "SMS-002"),
 	VERIFICATION_CODE_EXPIRED(HttpStatus.BAD_REQUEST, "인증번호가 만료되었습니다.", "SMS-003"),
-	VERIFICATION_NOT_COMPLETED(HttpStatus.BAD_REQUEST, "전화번호 인증을 실패했습니다.", "SMS-004"),
+	// VERIFICATION_NOT_COMPLETED(HttpStatus.BAD_REQUEST, "전화번호 인증을 실패했습니다.", "SMS-004"),
 	INVALID_QUANTITY(HttpStatus.BAD_REQUEST, "식재료 수량은 0 이상이어야 합니다.", "INGREDIENT_008"),
 	MEMO_TOO_LONG(HttpStatus.BAD_REQUEST, "식재료 메모는 최대 100자까지 입력 가능합니다.", "INGREDIENT_009"),
 	INVALID_DELETE_REQUEST(HttpStatus.BAD_REQUEST, "삭제할 식재료를 입력해주세요.", "INGREDIENT_010"),
@@ -55,6 +55,8 @@ public enum ErrorCode {
 	TITLE_TOO_LONG(HttpStatus.BAD_REQUEST, "레시피 제목은 최대 100글자입니다.", "RECIPE-023"),
 	CANNOT_LIKE_OWN_RECIPE(HttpStatus.BAD_REQUEST, "자신의 레시피에는 좋아요를 누를 수 없습니다.", "DAILY_RECIPE-006"),
 	CANNOT_BOOKMARK_OWN_RECIPE(HttpStatus.BAD_REQUEST, "자신의 레시피에는 북마크를 누를 수 없습니다.", "DAILY_RECIPE-007"),
+	VERIFICATION_NOT_VERIFIED(HttpStatus.BAD_REQUEST, "전화번호 인증이 완료되지 않았습니다.", "SMS-009"),
+
 
 	// 401 UNAUTHORIZED (인증 관련)
 	UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증에 실패했습니다.", "AUTH-001"),
@@ -79,6 +81,7 @@ public enum ErrorCode {
 	AI_RECIPE_TITLE_MISSING(HttpStatus.NOT_FOUND, "AI 응답에 레시피 제목이 존재하지 않습니다.", "RECIPE-019"),
 	AI_RECIPE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 AI 레시피를 찾을 수 없습니다.", "DAILY_RECIPE-002"),
 	DAILY_RECIPE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 데일리 레시피를 찾을 수 없습니다.", "DAILY_RECIPE-003"),
+	VERIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "인증 요청 내역이 없습니다.", "SMS-004"),
 
 	// 409
 	DUPLICATE_CUSTOM_INGREDIENT(HttpStatus.CONFLICT, "이미 등록된 식재료 입니다.", "INGREDIENT-007"),

--- a/src/main/java/com/cookeep/cookeep/domain/verification/application/SmsVerificationService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/verification/application/SmsVerificationService.java
@@ -69,7 +69,7 @@ public class SmsVerificationService {
 
 		SmsVerification verification = smsVerificationRepository
 			.findTopByPhoneAndPurposeOrderByCreatedAtDesc(phoneNumber, purpose)
-			.orElseThrow(() -> new AppException(ErrorCode.VERIFICATION_NOT_COMPLETED));
+			.orElseThrow(() -> new AppException(ErrorCode.VERIFICATION_NOT_FOUND));
 
 		// 이미 인증이 완료된 경우
 		if (verification.isVerified()) {
@@ -116,14 +116,14 @@ public class SmsVerificationService {
 	@Transactional(readOnly = true)
 	public void assertVerified(String phoneNumber, VerificationPurpose purpose) {
 
-		// 번호 내 인증을 찾을 수 없는 경우
+		// 인증 요청 내역이 없는 경우
 		SmsVerification verification = smsVerificationRepository
 			.findTopByPhoneAndPurposeOrderByCreatedAtDesc(phoneNumber, purpose)
-			.orElseThrow(() -> new AppException(ErrorCode.VERIFICATION_NOT_COMPLETED));
+			.orElseThrow(() -> new AppException(ErrorCode.VERIFICATION_NOT_FOUND));
 
-		// 기존 인증이 만료되지 않은 경우
+		// 아직 인증이 완료되지 않은 경우
 		if (!verification.isVerified()) {
-			throw new AppException(ErrorCode.VERIFICATION_NOT_COMPLETED);
+			throw new AppException(ErrorCode.VERIFICATION_NOT_VERIFIED);
 		}
 
 		// 인증이 만료된 경우 (5분 초과 시 만료)


### PR DESCRIPTION
# Related Issue  
#114 
</br></br>

# Description  

## VerificationController ApiResponse 정리

- SMS 인증 관련 API의 Swagger 응답 정의를 실제 예외 처리 로직과 맞도록 수정하였음

- 인증 확인 API에서 `409` 응답 제거  
  - 인증번호 불일치/만료는 요청 오류에 해당하므로 400으로 처리됨
 
- `@ApiResponse` 설명 보강
  - `@Valid` 검증 실패 명시
  - 500 응답을 "서버 오류"로 통일

- 비밀번호 찾기 시 SMS 인증 요청 API 내 409 예외를 404로 변경

</br>

## ErrorCode 분리
- 기존 `VERIFICATION_NOT_COMPLETED` 분리
  - 인증 요청 내역이 없는 경우 → `VERIFICATION_NOT_FOUND (404)`
  - 인증 요청은 존재하지만 완료되지 않은 경우 → `VERIFICATION_NOT_VERIFIED (400)`

- `SmsVerificationService` 내 관련 에러 처리 수정

</br></br>

# Changes

- VerificationController `@ApiResponses` 수정
- 409 응답 제거
- ErrorCode 세분화 (`VERIFICATION_NOT_FOUND`, `VERIFICATION_NOT_VERIFIED`)
- SmsVerificationService 예외 처리 수정

