### PR TITLE
fix: 레시피 좋아요 API 엔드포인트 오타 수정

### DIFF
--- a/src/main/java/com/cookeep/cookeep/api/controller/RecipeLikeController.java
+++ b/src/main/java/com/cookeep/cookeep/api/controller/RecipeLikeController.java
@@ -43,7 +43,7 @@ public class RecipeLikeController {
 			@ApiResponse(responseCode = "401", description = "인증 실패", content = @Content),
 			@ApiResponse(responseCode = "404", description = "레시피를 찾을 수 없음", content = @Content)
 	})
-	@PostMapping("/{dailyRecipeId}/togle")
+	@PostMapping("/{dailyRecipeId}/toggle")
 	public ResponseEntity<DataResponse<RecipeLikeResponseDto>> toggleLike(
 		@AuthenticationPrincipal(expression = "userId") Long userId,
 		@Parameter(description = "데일리 레시피 ID", required = true)


### PR DESCRIPTION
# Related Issue
#119 

# Description
레시피 좋아요 토글(좋아요 등록/좋아요 취소) API 엔드포인트에 있던 오타 togle -> toggle로 수정완료했습니다.

# Changes
RecipeLikeController