### PR TITLE
feat: 비밀번호 변경 시 비밀번호 확인 

### DIFF
--- a/src/main/java/com/cookeep/cookeep/api/controller/NoticeController.java
+++ b/src/main/java/com/cookeep/cookeep/api/controller/NoticeController.java
@@ -26,8 +26,8 @@ import lombok.RequiredArgsConstructor;
 public class NoticeController {
 	private final NoticeService noticeService;
 
-	// 회원정보 조회
-	@Operation(summary = "회원정보 조회 API")
+	// 공지사항 조회
+	@Operation(summary = "공지사항 조회 API")
 	@ApiResponses(value = {
 		@ApiResponse(responseCode = "200", description = "요청 성공"),
 		@ApiResponse(responseCode = "401", description = "회원 인증 실패 (AccessToken이 없거나 유효하지 않음)")

--- a/src/main/java/com/cookeep/cookeep/api/controller/UserInfoController.java
+++ b/src/main/java/com/cookeep/cookeep/api/controller/UserInfoController.java
@@ -107,9 +107,10 @@ public class UserInfoController {
     @Operation(summary =  "비밀번호 확인 API")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "요청 성공"),
-        @ApiResponse(responseCode = "400", description = "요청 파라미터 오류(@Valid 검증 실패 등)"),
+        @ApiResponse(responseCode = "400", description = "요청 파라미터 오류(@Valid 검증 실패, 비밀번호 불일치)"),
         @ApiResponse(responseCode = "401", description = "회원 인증 실패, AccessToken이 없거나 유효하지 않음"),
-        @ApiResponse(responseCode = "403", description = "접근 권한 없음")
+        @ApiResponse(responseCode = "403", description = "접근 권한 없음"),
+        @ApiResponse(responseCode = "423", description = "비밀번호 검증 시도 가능 횟수 초과")
     })
     @PostMapping("/password/verify")
     public ResponseEntity<DataResponse<Void>> verifyMyPassword(

--- a/src/main/java/com/cookeep/cookeep/api/controller/UserInfoController.java
+++ b/src/main/java/com/cookeep/cookeep/api/controller/UserInfoController.java
@@ -4,6 +4,7 @@ import com.cookeep.cookeep.api.dto.request.NicknameUpdateRequestDto;
 import com.cookeep.cookeep.api.dto.request.UpdateEmailRequestDTO;
 import com.cookeep.cookeep.api.dto.request.UpdateMarketingPushDTO;
 import com.cookeep.cookeep.api.dto.request.UpdatePasswordRequestDTO;
+import com.cookeep.cookeep.api.dto.request.VerifyPasswordRequestDTO;
 import com.cookeep.cookeep.api.dto.response.UserProfileResponseDTO;
 import com.cookeep.cookeep.common.dto.DataResponse;
 import com.cookeep.cookeep.common.exception.ErrorCode;
@@ -101,6 +102,25 @@ public class UserInfoController {
         userInfoService.updateMyEmail(userId, updateEmailRequestDTO);
         return ResponseEntity.ok(DataResponse.ok());
     }
+
+    // 비밀번호 확인
+    @Operation(summary =  "비밀번호 확인 API")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "요청 성공"),
+        @ApiResponse(responseCode = "400", description = "요청 파라미터 오류(@Valid 검증 실패 등)"),
+        @ApiResponse(responseCode = "401", description = "회원 인증 실패, AccessToken이 없거나 유효하지 않음"),
+        @ApiResponse(responseCode = "403", description = "접근 권한 없음")
+    })
+    @PostMapping("/password/verify")
+    public ResponseEntity<DataResponse<Void>> verifyMyPassword(
+        @AuthenticationPrincipal UserPrincipal principal,
+        @Valid @RequestBody VerifyPasswordRequestDTO verifyPasswordRequestDTO
+    ) {
+        Long userId = principal.userId();
+        userInfoService.verifyMyPassword(userId, verifyPasswordRequestDTO);
+        return ResponseEntity.ok(DataResponse.ok());
+    }
+
 
     // 비밀번호 변경
     @Operation(summary = "비밀번호 변경 API")

--- a/src/main/java/com/cookeep/cookeep/api/controller/VerificationController.java
+++ b/src/main/java/com/cookeep/cookeep/api/controller/VerificationController.java
@@ -157,4 +157,25 @@ public class VerificationController {
 		userInfoService.sendPasswordVerificationCode(userId, sendCodeRequestDTO);
 		return ResponseEntity.ok(DataResponse.ok());
 	}
+
+	// 비밀번호 검증 실패 시 전화번호 인증 확인
+	@Operation(summary = "비밀번호 검증 실패 시 전화번호 인증 확인 API")
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200", description = "확인 성공"),
+		@ApiResponse(responseCode = "400", description = "요청 오류 (형식 오류 또는 인증 실패, 전화번호 불일치)"),
+		@ApiResponse(responseCode = "401", description = "회원 인증 실패, AccessToken이 없거나 유효하지 않음"),
+		@ApiResponse(responseCode = "403", description = "접근 권한 없음"),
+		@ApiResponse(responseCode = "404", description = "인증 요청 내역이 없음"),
+		@ApiResponse(responseCode = "429", description = "인증 시도 횟수 초과"),
+		@ApiResponse(responseCode = "500", description = "서버 오류")
+	})
+	@PostMapping("/users/me/password/verify-code")
+	public ResponseEntity<DataResponse<Void>> verifyPasswordVerificationCode(
+		@AuthenticationPrincipal UserPrincipal principal,
+		@Valid @RequestBody VerifyCodeRequestDTO verifyCodeRequestDTO
+	) {
+		Long userId = principal.userId();
+		userInfoService.verifyPasswordVerificationCode(userId, verifyCodeRequestDTO);
+		return ResponseEntity.ok(DataResponse.ok());
+	}
 }

--- a/src/main/java/com/cookeep/cookeep/api/controller/VerificationController.java
+++ b/src/main/java/com/cookeep/cookeep/api/controller/VerificationController.java
@@ -137,4 +137,24 @@ public class VerificationController {
 		userInfoService.verifyChangePhoneCode(userId, verifyCodeRequestDTO);
 		return ResponseEntity.ok(DataResponse.ok());
 	}
+
+	// 비밀번호 검증 실패 시 전화번호 인증 요청
+	@Operation(summary = "비밀번호 검증 실패 시 전화번호 인증 요청 API")
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200", description = "요청 성공"),
+		@ApiResponse(responseCode = "400", description = "요청 오류 (@Valid 검증 실패, 전화번호 불일치)"),
+		@ApiResponse(responseCode = "401", description = "회원 인증 실패, AccessToken이 없거나 유효하지 않음"),
+		@ApiResponse(responseCode = "403", description = "접근 권한 없음"),
+		@ApiResponse(responseCode = "429", description = "인증 재요청이 너무 빠름"),
+		@ApiResponse(responseCode = "500", description = "서버 오류")
+	})
+	@PostMapping("/users/me/password/send-code")
+	public ResponseEntity<DataResponse<Void>> sendPasswordVerificationCode(
+		@AuthenticationPrincipal UserPrincipal principal,
+		@Valid @RequestBody SendCodeRequestDTO sendCodeRequestDTO
+	) {
+		Long userId = principal.userId();
+		userInfoService.sendPasswordVerificationCode(userId, sendCodeRequestDTO);
+		return ResponseEntity.ok(DataResponse.ok());
+	}
 }

--- a/src/main/java/com/cookeep/cookeep/api/dto/request/VerifyPasswordRequestDTO.java
+++ b/src/main/java/com/cookeep/cookeep/api/dto/request/VerifyPasswordRequestDTO.java
@@ -1,0 +1,15 @@
+package com.cookeep.cookeep.api.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+public record VerifyPasswordRequestDTO(
+	// 현재 비밀번호
+	@NotBlank(message = "비밀번호는 필수 입력 값입니다.")
+	@Pattern(
+		regexp = "^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d]{8,}$",
+		message = "영문, 숫자 포함 8자 이상의 비밀번호를 사용해주세요"
+	)
+	String password
+) {
+}

--- a/src/main/java/com/cookeep/cookeep/common/dto/ErrorResponse.java
+++ b/src/main/java/com/cookeep/cookeep/common/dto/ErrorResponse.java
@@ -52,4 +52,17 @@ public class ErrorResponse extends BaseResponse {
 			errorCode.getHttpStatus()
 		);
 	}
+
+	// 추가 에러 정보(시도 횟수 등)를 포함한 ErrorResponse 생성 메서드
+	public static ErrorResponse ofWithErrors(ErrorCode errorCode, Map<String, String> errors, HttpServletRequest request) {
+		return new ErrorResponse(
+			errorCode.getCode(),
+			errorCode.getMessage(),
+			request.getMethod(),
+			request.getRequestURI(),
+			errors,
+			errorCode.getHttpStatus()
+		);
+	}
+
 }

--- a/src/main/java/com/cookeep/cookeep/common/exception/AppException.java
+++ b/src/main/java/com/cookeep/cookeep/common/exception/AppException.java
@@ -1,14 +1,24 @@
 package com.cookeep.cookeep.common.exception;
 
+import java.util.Map;
+
 import lombok.Getter;
 
 @Getter
 public class AppException extends RuntimeException {
 
 	private final ErrorCode errorCode;
+	private final Map<String, String> errors;
 
 	public AppException(ErrorCode errorCode) {
 		super(errorCode.getMessage());
 		this.errorCode = errorCode;
+		this.errors = null;
+	}
+
+	public AppException(ErrorCode errorCode, Map<String, String> errors) {
+		super(errorCode.getMessage());
+		this.errorCode = errorCode;
+		this.errors = errors;
 	}
 }

--- a/src/main/java/com/cookeep/cookeep/common/exception/ErrorCode.java
+++ b/src/main/java/com/cookeep/cookeep/common/exception/ErrorCode.java
@@ -57,6 +57,7 @@ public enum ErrorCode {
 	CANNOT_BOOKMARK_OWN_RECIPE(HttpStatus.BAD_REQUEST, "자신의 레시피에는 북마크를 누를 수 없습니다.", "DAILY_RECIPE-007"),
 	VERIFICATION_NOT_VERIFIED(HttpStatus.BAD_REQUEST, "전화번호 인증이 완료되지 않았습니다.", "SMS-009"),
 	PASSWORD_MISMATCH(HttpStatus.BAD_REQUEST, "현재 비밀번호가 일치하지 않습니다.", "AUTH-006"),
+	REGISTERED_PHONE_NUMBER_MISMATCH(HttpStatus.BAD_REQUEST, "회원정보에 등록된 전화번호와 일치하지 않습니다.", "AUTH-008"),
 
 	// 401 UNAUTHORIZED (인증 관련)
 	UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증에 실패했습니다.", "AUTH-001"),

--- a/src/main/java/com/cookeep/cookeep/common/exception/ErrorCode.java
+++ b/src/main/java/com/cookeep/cookeep/common/exception/ErrorCode.java
@@ -56,7 +56,7 @@ public enum ErrorCode {
 	CANNOT_LIKE_OWN_RECIPE(HttpStatus.BAD_REQUEST, "자신의 레시피에는 좋아요를 누를 수 없습니다.", "DAILY_RECIPE-006"),
 	CANNOT_BOOKMARK_OWN_RECIPE(HttpStatus.BAD_REQUEST, "자신의 레시피에는 북마크를 누를 수 없습니다.", "DAILY_RECIPE-007"),
 	VERIFICATION_NOT_VERIFIED(HttpStatus.BAD_REQUEST, "전화번호 인증이 완료되지 않았습니다.", "SMS-009"),
-
+	PASSWORD_MISMATCH(HttpStatus.BAD_REQUEST, "현재 비밀번호가 일치하지 않습니다.", "AUTH-006"),
 
 	// 401 UNAUTHORIZED (인증 관련)
 	UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증에 실패했습니다.", "AUTH-001"),
@@ -93,6 +93,10 @@ public enum ErrorCode {
 	USER_EMAIL_REGISTERED_WITH_KAKAO_GOOGLE(HttpStatus.CONFLICT,"이미 카카오와 구글로 가입된 이메일입니다.", "USER-006"),
 	WEEKLY_GOAL_ALREADY_EXISTS(HttpStatus.CONFLICT, "이번 주 목표가 이미 설정되어 있습니다.", "WEEKLY_GOAL-001"),
 	DAILY_RECIPE_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 데일리 레시피로 등록된 AI 레시피입니다.", "DAILY_RECIPE-005"),
+
+	// 423
+	PASSWORD_VERIFICATION_LOCKED(HttpStatus.LOCKED, "비밀번호 입력 횟수를 초과했습니다. 본인인증 후 다시 시도해주세요.", "AUTH-007"),
+
 	// 429
 	SMS_RESEND_TOO_FAST(HttpStatus.TOO_MANY_REQUESTS, "인증번호 재전송 요청이 너무 빠릅니다. 잠시 후 다시 시도해주세요.", "SMS-005"),
 	SMS_TOO_MANY_ATTEMPTS(HttpStatus.TOO_MANY_REQUESTS, "인증 시도 횟수를 초과하였습니다. 잠시 후 다시 시도해주세요.", "SMS-006"),

--- a/src/main/java/com/cookeep/cookeep/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/cookeep/cookeep/common/exception/GlobalExceptionHandler.java
@@ -27,11 +27,16 @@ public class GlobalExceptionHandler {
 	public ResponseEntity<ErrorResponse> handleAppCustomException(AppException e, HttpServletRequest request) {
 		log.error("AppException 발생: {}", e.getErrorCode().getMessage());
 		log.error("에러가 발생한 지점 {}, {}", request.getMethod(), request.getRequestURI());
-		ErrorResponse errorResponse = ErrorResponse.of(e.getErrorCode(), request);
+
+		ErrorResponse errorResponse = (e.getErrors() == null)
+			? ErrorResponse.of(e.getErrorCode(), request)
+			: ErrorResponse.ofWithErrors(e.getErrorCode(), e.getErrors(), request);
+
 		return ResponseEntity
 			.status(e.getErrorCode().getHttpStatus())
 			.body(errorResponse);
 	}
+
 
 	// JWT 토큰 관련 예외 처리
 	// - JwtException: io.jsonwebtoken 라이브러리의 모든 JWT 예외

--- a/src/main/java/com/cookeep/cookeep/domain/user/application/UserInfoService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/user/application/UserInfoService.java
@@ -195,6 +195,19 @@ public class UserInfoService {
         );
     }
 
+    // 비밀번호 검증 실패 시 전화번호 인증 요청
+    public void sendPasswordVerificationCode(Long userId, SendCodeRequestDTO sendCodeRequestDTO) {
+        User user = userReader.readById(userId);
+        String phoneNumber = sendCodeRequestDTO.phoneNumber();
+
+        // 현재 등록된 전화번호와 동일하지 않은 경우
+        if (!phoneNumber.equals(user.getPhoneNumber())) {
+            throw new AppException(ErrorCode.REGISTERED_PHONE_NUMBER_MISMATCH);
+        }
+
+        smsVerificationService.sendCode(phoneNumber, VerificationPurpose.PASSWORD_VERIFICATION);
+    }
+
     // 비밀번호 변경
     @Transactional
     public void updateMyPassword(Long userId, UpdatePasswordRequestDTO updatePasswordRequestDTO) {

--- a/src/main/java/com/cookeep/cookeep/domain/user/application/UserInfoService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/user/application/UserInfoService.java
@@ -1,11 +1,15 @@
 package com.cookeep.cookeep.domain.user.application;
 
+import java.util.Map;
+import java.util.Optional;
+
 import com.cookeep.cookeep.api.dto.request.NicknameUpdateRequestDto;
 import com.cookeep.cookeep.api.dto.request.SendCodeRequestDTO;
 import com.cookeep.cookeep.api.dto.request.UpdateEmailRequestDTO;
 import com.cookeep.cookeep.api.dto.request.UpdateMarketingPushDTO;
 import com.cookeep.cookeep.api.dto.request.UpdatePasswordRequestDTO;
 import com.cookeep.cookeep.api.dto.request.VerifyCodeRequestDTO;
+import com.cookeep.cookeep.api.dto.request.VerifyPasswordRequestDTO;
 import com.cookeep.cookeep.api.dto.response.UserProfileResponseDTO;
 import com.cookeep.cookeep.common.exception.AppException;
 import com.cookeep.cookeep.common.exception.ErrorCode;
@@ -13,16 +17,19 @@ import com.cookeep.cookeep.domain.user.dao.UserAuthRepository;
 import com.cookeep.cookeep.domain.user.dao.UserRepository;
 import com.cookeep.cookeep.domain.user.entity.Provider;
 import com.cookeep.cookeep.domain.user.entity.User;
+import com.cookeep.cookeep.domain.user.entity.UserStatus;
 import com.cookeep.cookeep.domain.verification.application.SmsVerificationService;
 import com.cookeep.cookeep.domain.verification.entity.VerificationPurpose;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 import org.springframework.boot.web.error.Error;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -33,6 +40,9 @@ public class UserInfoService {
     private final SmsVerificationService smsVerificationService;
     private final UserAuthRepository userAuthRepository;
     private final PasswordEncoder passwordEncoder;
+
+    // 비밀번호 입력 최대 시도 횟수
+    private static final int MAX_ATTEMPTS = 5;
 
     // 회원 정보 조회
     public UserProfileResponseDTO getMyProfile(Long userId) {
@@ -142,6 +152,45 @@ public class UserInfoService {
         }
 
         user.updateEmail(newEmail);
+    }
+
+    // 비밀번호 확인
+    @Transactional
+    public void verifyMyPassword(Long userId, VerifyPasswordRequestDTO verifyPasswordRequestDTO) {
+        User user = userReader.readById(userId);
+
+        if (passwordEncoder.matches(verifyPasswordRequestDTO.password(), user.getPassword())) {
+            // 기존 비밀번호와 일치할 경우 passwordCnt 초기화
+            user.updatePasswordCnt(0);
+            return;
+        }
+
+        // null일 경우 0으로 세팅 후 +1, 값이 있을 경우 해당 값을 가져오고 + 1
+        int passwordCnt = Optional.ofNullable(user.getPasswordCnt()).orElse(0) + 1;
+
+        // 5회 틀릴 경우 LOCK
+        // 동시/중복 요청 고려하여 >=로 판별
+        if (passwordCnt >= MAX_ATTEMPTS) {
+            user.updatePasswordCnt(MAX_ATTEMPTS);
+            user.updateUserStatus(UserStatus.LOCK);
+            log.warn("Password verification locked. userId={}", userId);
+            throw new AppException(
+                ErrorCode.PASSWORD_VERIFICATION_LOCKED,
+                Map.of(
+                    "failedCount", String.valueOf(MAX_ATTEMPTS),
+                    "maxCount", String.valueOf(MAX_ATTEMPTS)
+                )
+            );
+        } else {
+            user.updatePasswordCnt(passwordCnt);
+            throw new AppException(
+                ErrorCode.PASSWORD_MISMATCH,
+                Map.of(
+                    "failedCount", String.valueOf(passwordCnt),
+                    "maxCount", String.valueOf(MAX_ATTEMPTS)
+                )
+            );
+        }
     }
 
     // 비밀번호 변경

--- a/src/main/java/com/cookeep/cookeep/domain/user/application/UserInfoService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/user/application/UserInfoService.java
@@ -155,7 +155,8 @@ public class UserInfoService {
     }
 
     // 비밀번호 확인
-    @Transactional
+    // 비밀번호 검증 실패 횟수를 예외 발생 시에도 누적시키기 위해 rollback 제외하였음
+    @Transactional(noRollbackFor = AppException.class)
     public void verifyMyPassword(Long userId, VerifyPasswordRequestDTO verifyPasswordRequestDTO) {
         User user = userReader.readById(userId);
 

--- a/src/main/java/com/cookeep/cookeep/domain/user/application/UserInfoService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/user/application/UserInfoService.java
@@ -169,12 +169,14 @@ public class UserInfoService {
         // null일 경우 0으로 세팅 후 +1, 값이 있을 경우 해당 값을 가져오고 + 1
         int passwordCnt = Optional.ofNullable(user.getPasswordCnt()).orElse(0) + 1;
 
-        // 5회 틀릴 경우 LOCK
+        // 5회 틀릴 경우
         // 동시/중복 요청 고려하여 >=로 판별
         if (passwordCnt >= MAX_ATTEMPTS) {
             user.updatePasswordCnt(MAX_ATTEMPTS);
-            user.updateUserStatus(UserStatus.LOCK);
-            log.warn("Password verification locked. userId={}", userId);
+
+            // 비밀번호 변경 플로우 내 LOCK 정책은 보류하였음
+            // user.updateUserStatus(UserStatus.LOCK);
+            // log.warn("Password verification locked. userId={}", userId);
             throw new AppException(
                 ErrorCode.PASSWORD_VERIFICATION_LOCKED,
                 Map.of(
@@ -182,16 +184,15 @@ public class UserInfoService {
                     "maxCount", String.valueOf(MAX_ATTEMPTS)
                 )
             );
-        } else {
-            user.updatePasswordCnt(passwordCnt);
-            throw new AppException(
-                ErrorCode.PASSWORD_MISMATCH,
-                Map.of(
-                    "failedCount", String.valueOf(passwordCnt),
-                    "maxCount", String.valueOf(MAX_ATTEMPTS)
-                )
-            );
         }
+        user.updatePasswordCnt(passwordCnt);
+        throw new AppException(
+            ErrorCode.PASSWORD_MISMATCH,
+            Map.of(
+                "failedCount", String.valueOf(passwordCnt),
+                "maxCount", String.valueOf(MAX_ATTEMPTS)
+            )
+        );
     }
 
     // 비밀번호 변경

--- a/src/main/java/com/cookeep/cookeep/domain/user/application/UserInfoService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/user/application/UserInfoService.java
@@ -208,6 +208,23 @@ public class UserInfoService {
         smsVerificationService.sendCode(phoneNumber, VerificationPurpose.PASSWORD_VERIFICATION);
     }
 
+    // 비밀번호 검증 실패 시 전화번호 인증 확인
+    @Transactional
+    public void verifyPasswordVerificationCode(Long userId, VerifyCodeRequestDTO verifyCodeRequestDTO) {
+        User user = userReader.readById(userId);
+        String phoneNumber = verifyCodeRequestDTO.phoneNumber();
+        String code = verifyCodeRequestDTO.code();
+
+        // 현재 등록된 전화번호와 동일하지 않은 경우
+        if (!phoneNumber.equals(user.getPhoneNumber())) {
+            throw new AppException(ErrorCode.REGISTERED_PHONE_NUMBER_MISMATCH);
+        }
+
+        smsVerificationService.verifyCode(phoneNumber, VerificationPurpose.PASSWORD_VERIFICATION, code);
+
+        user.updatePasswordCnt(0);
+    }
+
     // 비밀번호 변경
     @Transactional
     public void updateMyPassword(Long userId, UpdatePasswordRequestDTO updatePasswordRequestDTO) {

--- a/src/main/java/com/cookeep/cookeep/domain/user/entity/User.java
+++ b/src/main/java/com/cookeep/cookeep/domain/user/entity/User.java
@@ -154,4 +154,12 @@ public class User extends BaseEntity {
 	public void updateMarketingPush(Boolean marketingPush) {
 		this.marketingPush = marketingPush;
 	}
+
+	public void updatePasswordCnt(Integer passwordCnt) {
+		this.passwordCnt = passwordCnt;
+	}
+
+	public void updateUserStatus(UserStatus userStatus) {
+		this.userStatus = userStatus;
+	}
 }

--- a/src/main/java/com/cookeep/cookeep/domain/verification/entity/VerificationPurpose.java
+++ b/src/main/java/com/cookeep/cookeep/domain/verification/entity/VerificationPurpose.java
@@ -3,5 +3,6 @@ package com.cookeep.cookeep.domain.verification.entity;
 public enum VerificationPurpose {
 	SIGNUP, // 회원가입
 	RESET_PASSWORD, // 비밀번호 찾기 - 비밀번호 리셋
-	CHANGE_PHONE // 전화번호 변경
+	CHANGE_PHONE, // 전화번호 변경
+	PASSWORD_VERIFICATION // 비밀번호 변경 - 비밀번호 5회 오류 시 본인 인증
 }


### PR DESCRIPTION
# Related Issue  
#122  
</br></br>

# Description  

## ErrorResponse / AppException 확장 (custom errors 지원)

- 비밀번호 검증 실패 횟수 등 추가 정보를 응답에 포함하기 위해, `AppException`과 `ErrorResponse`를 확장하였음

  - `AppException`에 `Map<String, String> errors` 필드 추가
  - `ErrorResponse.ofWithErrors()` 추가
  - `GlobalExceptionHandler`에서 errors 존재 여부에 따라 응답 생성 분기

- 비밀번호 검증 실패 시 `failedCount`, `maxCount`를 함께 전달할 수 있도록 함

</br>

## 비밀번호 확인 API 구현
- 비밀번호 변경 시 현재 비밀번호를 입력받아 일치하는지 검증하는 API
- `POST /api/users/me/password/verify`
- 비밀번호 불일치 시 `passwordCnt`를 누적하여 재시도 횟수를 관리함

</br>

### 비밀번호 검증 재시도 제한

- 최대 5회(`MAX_ATTEMPTS = 5`)까지 실패 횟수 누적
- 5회 오류 시 `PASSWORD_VERIFICATION_LOCKED (423)` 반환, 전화번호 인증으로 넘어감

</br></br>

## 비밀번호 검증 실패 시 전화번호 인증(PASSWORD_VERIFICATION) 추가
### 전화번호 인증 요청

- `POST /api/users/me/password/send-code`
- 입력된 전화번호가 회원 정보의 전화번호와 일치하는 경우에만 인증 요청 허용
  - 불일치 시 `REGISTERED_PHONE_NUMBER_MISMATCH` 반환

</br>

### 전화번호 인증 확인

- `POST /api/users/me/password/verify-code`
- 인증번호 검증 성공 시 `passwordCnt`를 0으로 초기화하여 재시도 가능 상태로 전환

</br></br>

# Changes

- 비밀번호 확인 API 추가 (`/api/users/me/password/verify`)
- 비밀번호 검증 재시도 제한(최대 5회) 및 423 응답 추가
- 비밀번호 검증 실패 시 본인인증용 SMS 요청/확인 API 추가
  - `/api/users/me/password/send-code`
  - `/api/users/me/password/verify-code`
- ErrorResponse / AppException / GlobalExceptionHandler custom errors 지원
- ErrorCode 추가 (`AUTH-006`, `AUTH-007`, `AUTH-008`)
- 비밀번호 변경 플로우 내 LOCK(UserStatus 변경) 정책은 보류하였음
