### PR TITLE
Fix: delete recipe

### DIFF
--- a/src/main/java/com/cookeep/cookeep/api/controller/AiRecipeController.java
+++ b/src/main/java/com/cookeep/cookeep/api/controller/AiRecipeController.java
@@ -240,10 +240,12 @@ public class AiRecipeController {
     @ApiErrorCodeExamples({
             ErrorCode.UNAUTHORIZED,
             ErrorCode.AI_SESSION_NOT_FOUND,
-            ErrorCode.AI_SESSION_FORBIDDEN
+            ErrorCode.AI_SESSION_FORBIDDEN,
+            ErrorCode.RECIPE_DELETE_NOT_ALLOWED
     })
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "세션 삭제 성공"),
+            @ApiResponse(responseCode = "400", description = "데이터무결성 예외(데일리레시피)", content = @Content),
             @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content),
             @ApiResponse(responseCode = "403", description = "본인의 대화 세션이 아님", content = @Content),
             @ApiResponse(responseCode = "404", description = "세션을 찾을 수 없음", content = @Content)

--- a/src/main/java/com/cookeep/cookeep/common/exception/ErrorCode.java
+++ b/src/main/java/com/cookeep/cookeep/common/exception/ErrorCode.java
@@ -58,6 +58,7 @@ public enum ErrorCode {
 	VERIFICATION_NOT_VERIFIED(HttpStatus.BAD_REQUEST, "전화번호 인증이 완료되지 않았습니다.", "SMS-009"),
 	PASSWORD_MISMATCH(HttpStatus.BAD_REQUEST, "현재 비밀번호가 일치하지 않습니다.", "AUTH-006"),
 	REGISTERED_PHONE_NUMBER_MISMATCH(HttpStatus.BAD_REQUEST, "회원정보에 등록된 전화번호와 일치하지 않습니다.", "AUTH-008"),
+	RECIPE_DELETE_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "데일리레시피에 기록된 레시피는 삭제할 수 없습니다.", "RECIPE-024"),
 
 	// 401 UNAUTHORIZED (인증 관련)
 	UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증에 실패했습니다.", "AUTH-001"),

--- a/src/main/java/com/cookeep/cookeep/domain/dailyrecipe/dao/DailyRecipeRepository.java
+++ b/src/main/java/com/cookeep/cookeep/domain/dailyrecipe/dao/DailyRecipeRepository.java
@@ -44,4 +44,7 @@ public interface DailyRecipeRepository extends JpaRepository<DailyRecipe, Long> 
             @Param("start") LocalDateTime start,
             @Param("end") LocalDateTime end,
             Pageable pageable);
+
+    boolean existsByAiRecipe_Session_Id(Long sessionId);
+
 }

--- a/src/main/java/com/cookeep/cookeep/domain/recipe/application/AiRecipeService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/recipe/application/AiRecipeService.java
@@ -324,6 +324,7 @@ public class AiRecipeService {
 
         // 4. 세션 삭제
         aiSessionRepository.delete(session);
+
     }
 
     // (MAIN07) AI 대화 세션 즐겨찾기 추가/삭제

--- a/src/main/java/com/cookeep/cookeep/domain/recipe/application/AiRecipeService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/recipe/application/AiRecipeService.java
@@ -12,6 +12,7 @@ import com.cookeep.cookeep.domain.cookie.dao.CookieLogRepository;
 import com.cookeep.cookeep.domain.cookie.dao.DailyCookieGrantRepository;
 import com.cookeep.cookeep.domain.cookie.entity.CookieLog;
 import com.cookeep.cookeep.domain.cookie.entity.DailyCookieGrant;
+import com.cookeep.cookeep.domain.dailyrecipe.dao.DailyRecipeRepository;
 import com.cookeep.cookeep.domain.ingredient.common.domain.Type;
 import com.cookeep.cookeep.domain.ingredient.customingredient.dao.CustomIngredientRepository;
 import com.cookeep.cookeep.domain.ingredient.customingredient.entity.CustomIngredient;
@@ -60,10 +61,10 @@ public class AiRecipeService {
     private final UserIngredientRepository userIngredientRepository;
     private final DefaultIngredientRepository defaultIngredientRepository;
     private final CustomIngredientRepository customIngredientRepository;
-    private final DailyCookieGrantRepository dailyCookieGrantRepository;
     private final CookieService cookieService;
     private final YoutubeSearchService youtubeSearchService;
     private final ConsumptionReportService consumptionReportService;
+    private final DailyRecipeRepository dailyRecipeRepository;
 
     // sessionId 유무에 따라 신규/재요청 로직 분기
     public AiRecipeResponseDto generateRecipe(Long userId, AiRecipeRequestDto request) {
@@ -316,6 +317,11 @@ public class AiRecipeService {
         // 2. 본인 세션인지 확인
         if (!session.getUserId().equals(userId)) {
             throw new AppException(ErrorCode.AI_SESSION_FORBIDDEN);
+        }
+
+        // 데일리레시피 등록 여부 검사
+        if (dailyRecipeRepository.existsByAiRecipe_Session_Id(sessionId)) {
+            throw new AppException(ErrorCode.RECIPE_DELETE_NOT_ALLOWED);
         }
 
         // 3. 연관 레시피&메시지 삭제

--- a/src/main/java/com/cookeep/cookeep/domain/recipe/application/AiRecipeService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/recipe/application/AiRecipeService.java
@@ -727,19 +727,9 @@ public class AiRecipeService {
             // Gemini 응답을 JSON으로 변환
             ObjectNode root = objectMapper.valueToTree(response);
 
-            // 서치쿼리 제거
-            root.remove("youtube_search_queries");
-
             // 레시피 생성 결과 저장
             JsonNode refsNode = objectMapper.valueToTree(youtubeReferences);
             root.set("youtube_references", refsNode);
-
-            // 에러 방지
-            ArrayNode urlArray = objectMapper.createArrayNode();
-            for (YoutubeReferenceDto ref : youtubeReferences) {
-                urlArray.add(ref.getUrl());
-            }
-            root.set("youtube_search_queries", urlArray);
 
             String json = objectMapper.writeValueAsString(root);
 

--- a/src/main/java/com/cookeep/cookeep/domain/recipe/entity/AiSession.java
+++ b/src/main/java/com/cookeep/cookeep/domain/recipe/entity/AiSession.java
@@ -68,6 +68,9 @@ public class AiSession {
     @Builder.Default
     private Boolean hasUrgentIngredient = false;
 
+    @OneToMany(mappedBy = "session", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private List<AiRecipe> aiRecipes;
+
     // Domain Logic
     public void pin() {
         this.isPinned = true;


### PR DESCRIPTION
# Issue
#124 

# Descipriton
- 데일리레시피로 등록된 ai세션 삭제 방지
- DailyRecipeRepository에서 id 조회하여 검증
- 레시피 세션 상세조회 시 서치쿼리 조회되도록 수정

# Changes
- 에러코드 RECIPE_DELETE_NOT_ALLOWED 추가
- deleteSession에 데일리레시피 등록 여부 검증 로직 추가
- 레시피 상세 조회 시 서치쿼리 그대로 출력

# Test checklist
- [x] 데일리레시피 등록 시 RECIPE_DELETE_NOT_ALLOWED 에러 처리 확인
- [x] 데일리레시피 미등록 시 삭제 가능
- [x] 레시피 상세조회 시 서치 쿼리 조회 확인