### PR TITLE
fix: 똑같은 AI 레시피로 데일리 레시피 재기록 허용하도록 수정

### DIFF
--- a/src/main/java/com/cookeep/cookeep/api/controller/DailyRecipeController.java
+++ b/src/main/java/com/cookeep/cookeep/api/controller/DailyRecipeController.java
@@ -46,7 +46,7 @@ public class DailyRecipeController {
 
     @Operation(
             summary = "채택된 AI 레시피 목록 조회",
-            description = "데일리 레시피 등록을 위한 채택된 AI 레시피 목록 중 데일리 레시피 미등록 건만을 조회합니다."
+            description = "데일리 레시피 등록을 위해 유저가 채택한 AI 레시피 목록을 조회합니다."
     )
     @ApiErrorCodeExamples({
             ErrorCode.UNAUTHORIZED
@@ -100,15 +100,13 @@ public class DailyRecipeController {
     @ApiErrorCodeExamples({
             ErrorCode.UNAUTHORIZED,
             ErrorCode.AI_RECIPE_NOT_FOUND,
-            ErrorCode.DAILY_RECIPE_FORBIDDEN,
-            ErrorCode.DAILY_RECIPE_ALREADY_EXISTS
+            ErrorCode.DAILY_RECIPE_FORBIDDEN
     })
     @ApiResponses(value = {
             @ApiResponse(responseCode = "201", description = "데일리 레시피 등록 성공"),
             @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content),
             @ApiResponse(responseCode = "403", description = "본인의 AI 레시피가 아님", content = @Content),
-            @ApiResponse(responseCode = "404", description = "AI 레시피를 찾을 수 없음", content = @Content),
-            @ApiResponse(responseCode = "409", description = "이미 데일리 레시피로 등록된 AI 레시피", content = @Content)
+            @ApiResponse(responseCode = "404", description = "AI 레시피를 찾을 수 없음", content = @Content)
     })
     @PostMapping
     public ResponseEntity<DataResponse<DailyRecipeCreateResponseDto>> createDailyRecipe(

--- a/src/main/java/com/cookeep/cookeep/domain/dailyrecipe/application/DailyRecipeService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/dailyrecipe/application/DailyRecipeService.java
@@ -39,10 +39,10 @@ public class DailyRecipeService {
     private final UserReader userReader;
     private final ObjectMapper objectMapper;
 
-    // 채택된 AI 레시피 목록 조회 (데일리 레시피 미등록 건만)
+    // 채택된 AI 레시피 목록 조회
     @Transactional(readOnly = true)
     public List<AiRecipe> getAdoptedAiRecipes(Long userId) {
-        return aiRecipeRepository.findAvailableByUserId(userId);
+        return aiRecipeRepository.findAllByUserId(userId);
     }
 
     // 채택된 AI 레시피 상세 조회 (레시피 선택 후 내용 확인)
@@ -63,11 +63,6 @@ public class DailyRecipeService {
         // 본인의 AI 레시피인지 확인
         if (!aiRecipe.getUserId().equals(userId)) {
             throw new AppException(ErrorCode.DAILY_RECIPE_FORBIDDEN);
-        }
-
-        // 이미 데일리 레시피로 등록된 AI 레시피인지 확인
-        if (dailyRecipeRepository.existsByAiRecipe(aiRecipe)) {
-            throw new AppException(ErrorCode.DAILY_RECIPE_ALREADY_EXISTS);
         }
 
         // AI 레시피 내용 스냅샷 생성

--- a/src/main/java/com/cookeep/cookeep/domain/dailyrecipe/dao/DailyRecipeRepository.java
+++ b/src/main/java/com/cookeep/cookeep/domain/dailyrecipe/dao/DailyRecipeRepository.java
@@ -1,7 +1,6 @@
 package com.cookeep.cookeep.domain.dailyrecipe.dao;
 
 import com.cookeep.cookeep.domain.dailyrecipe.entity.DailyRecipe;
-import com.cookeep.cookeep.domain.recipe.entity.AiRecipe;
 import com.cookeep.cookeep.domain.user.entity.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -16,8 +15,6 @@ import java.util.Optional;
 public interface DailyRecipeRepository extends JpaRepository<DailyRecipe, Long> {
 
     Optional<DailyRecipe> findByIdAndUser(Long id, User user); // 특정 레시피 조회 + 본인 소유 확인
-
-    boolean existsByAiRecipe(AiRecipe aiRecipe); // AI 레시피 중복 등록 방지
 
     // 날짜 기반 데일리 레시피 조회 (최신순)
     @Query("SELECT dr FROM DailyRecipe dr WHERE dr.user = :user " +

--- a/src/main/java/com/cookeep/cookeep/domain/recipe/dao/AiRecipeRepository.java
+++ b/src/main/java/com/cookeep/cookeep/domain/recipe/dao/AiRecipeRepository.java
@@ -14,12 +14,10 @@ public interface AiRecipeRepository extends JpaRepository<AiRecipe, Long> {
     // 세션 삭제 시 레시피 삭제
     void deleteBySessionId(Long sessionId);
 
-    // 데일리 레시피로 아직 등록하지 않은 AI 레시피만 조회 (최신순, session fetch join으로 isPinned 조회)
+    // 채택된 AI 레시피 전체 조회 (최신순, session fetch join으로 isPinned 조회)
     @EntityGraph(attributePaths = {"session"})
-    @Query("SELECT ar FROM AiRecipe ar WHERE ar.userId = :userId " +
-           "AND NOT EXISTS (SELECT dr FROM DailyRecipe dr WHERE dr.aiRecipe = ar) " +
-           "ORDER BY ar.createdAt DESC")
-    List<AiRecipe> findAvailableByUserId(@Param("userId") Long userId);
+    @Query("SELECT ar FROM AiRecipe ar WHERE ar.userId = :userId ORDER BY ar.createdAt DESC")
+    List<AiRecipe> findAllByUserId(@Param("userId") Long userId);
 
     // 유저의 채택된 AI 레시피 상세 조회 (session fetch join)
     @EntityGraph(attributePaths = {"session"})


### PR DESCRIPTION
# Related Issue
CLOSE #125 

# Description
기존: 
하나의 AI 레시피는 최대 1번만 데일리 레시피로 등록 가능하며, 이미 등록된 AI 레시피는 '채택된 레시피 목록'에서도 제외됨. 

변경: 
같은 AI 레시피로 여러 번 데일리 레시피를 기록할 수 있도록 하고, '채택된 레시피 목록'에서도 등록 여부와 무관하게 전부 노출되게 수정

# Changes


파일 | 변경 내용
-- | --
AiRecipeRepository.java | findAvailableByUserId → findAllByUserId로 변경, NOT EXISTS 서브쿼리 제거
DailyRecipeService.java | existsByAiRecipe 중복 체크 제거, repository 메서드명 반영
DailyRecipeRepository.java | existsByAiRecipe(AiRecipe) 메서드 삭제, 미사용 AiRecipe import 제거
DailyRecipeController.java | Swagger에서 DAILY_RECIPE_ALREADY_EXISTS 에러코드/409 응답 제거, description 수정


<!-- notionvc: 4372fded-0d67-44e3-aaf7-72bcce0ca546 -->