### PR TITLE
fix: 쿠킵스 랭킹 조회 시 예외 경우 처리

### DIFF
--- a/src/main/java/com/cookeep/cookeep/domain/cookeeps/application/CookeepsService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/cookeeps/application/CookeepsService.java
@@ -9,7 +9,7 @@ import com.cookeep.cookeep.common.exception.AppException;
 import com.cookeep.cookeep.common.exception.ErrorCode;
 import com.cookeep.cookeep.common.util.DateTimeUtils;
 import com.cookeep.cookeep.domain.dailyrecipe.dao.DailyRecipeRepository;
-import com.cookeep.cookeep.domain.dailyrecipe.dao.RecipeLikeRepository;
+
 import com.cookeep.cookeep.domain.dailyrecipe.entity.DailyRecipe;
 import com.cookeep.cookeep.domain.plant.dao.WateringLogRepository;
 import com.cookeep.cookeep.domain.user.entity.User;
@@ -33,7 +33,6 @@ import java.util.stream.IntStream;
 public class CookeepsService {
 
 	private final WateringLogRepository wateringLogRepository;
-	private final RecipeLikeRepository recipeLikeRepository;
 	private final DailyRecipeRepository dailyRecipeRepository;
 
 	@Transactional(readOnly = true)
@@ -81,23 +80,19 @@ public class CookeepsService {
 	}
 
 	private List<RecipeRankDto> getRecipeRanking(LocalDateTime weekStart, LocalDateTime weekEnd) {
-		// 1단계: 이번 주 좋아요 상위 3개 레시피 조회
-		List<Object[]> results = recipeLikeRepository.findTopLikedRecipes(
+		// 이번 주 공개 레시피 중 좋아요 상위 3개 조회 (좋아요 내림차순, 동점 시 등록 오래된 순)
+		List<DailyRecipe> results = dailyRecipeRepository.findTopRankedRecipes(
 			weekStart, weekEnd, PageRequest.of(0, 3));
-		
-		// 2단계: 인덱스를 포함한 스트림 처리
+
 		return IntStream.range(0, results.size())
 			.mapToObj(index -> {
-				Object[] row = results.get(index);
-				DailyRecipe recipe = (DailyRecipe) row[0]; // 레시피 객체 추출
-				Long likeCount = (Long) row[1]; // 좋아요 수 추출
-				
-				// DTO로 변환 (rank = 인덱스 + 1 → 1, 2, 3)
+				DailyRecipe recipe = results.get(index);
+
 				return RecipeRankDto.builder()
 						.dailyRecipeId(recipe.getId())
 						.rank(index + 1)
 						.title(recipe.getTitle())
-						.likeCount(likeCount)
+						.likeCount(recipe.getLikeCount().longValue())
 						.recipeImageUrl(recipe.getRecipeImageUrl())
 						.build();
 			})

--- a/src/main/java/com/cookeep/cookeep/domain/dailyrecipe/dao/DailyRecipeRepository.java
+++ b/src/main/java/com/cookeep/cookeep/domain/dailyrecipe/dao/DailyRecipeRepository.java
@@ -47,4 +47,13 @@ public interface DailyRecipeRepository extends JpaRepository<DailyRecipe, Long> 
 
     boolean existsByAiRecipe_Session_Id(Long sessionId);
 
+    // 이번 주 공개 레시피 중 좋아요 랭킹 Top N 조회 (좋아요 내림차순, 동점 시 등록 오래된 순)
+    @Query("SELECT dr FROM DailyRecipe dr WHERE dr.isPublic = true " +
+            "AND dr.createdAt >= :start AND dr.createdAt < :end " +
+            "ORDER BY dr.likeCount DESC, dr.createdAt ASC")
+    List<DailyRecipe> findTopRankedRecipes(
+            @Param("start") LocalDateTime start,
+            @Param("end") LocalDateTime end,
+            Pageable pageable);
+
 }


### PR DESCRIPTION
# Related Issue
CLOSE #128 

# Description
쿠킵스 랭킹 'x월 x번째 주 쿠킵이들이 만든 레시피' ('이번 주'에 올라온 레시피들 중에서 좋아요 top 3) 에서 다음과 같은 예외 경우에 대한 처리를 추가했습니다.

- 모든 레시피 좋아요가 0개 → **등록 오래된 순**으로 Top 3 표시

- 좋아요 1개라도 받으면 → 해당 레시피가 상위로 올라감

- 좋아요 동점 → **등록 오래된 순**으로 정렬

# Changes

AS IS:
`RecipeLikeRepository.findTopLikedRecipes()`는 RecipeLike 테이블을 JOIN하기 때문에 좋아요가 0개인 레시피는 아예 결과에 포함되지 않았었음

TO BE:
DailyRecipe를 직접 조회하면서 likeCount DESC, createdAt ASC로 정렬
1. DailyRecipeRepository - `findTopRankedRecipes()` 쿼리 추가
    - DailyRecipe를 직접 조회하므로 좋아요 0개 레시피도 포함됨
    - 정렬: likeCount DESC, createdAt ASC (좋아요 내림차순 → 동점 시 등록 오래된 순)
2. CookeepsService - `getRecipeRanking()` 수정
    - recipeLikeRepository.findTopLikedRecipes() 대신 dailyRecipeRepository.findTopRankedRecipes() 사용
    - 더 이상 사용하지 않는 RecipeLikeRepository 의존성 제거
