### PR TITLE
refactor: ai response 에러 처리 수정

### DIFF
--- a/src/main/java/com/cookeep/cookeep/domain/recipe/application/AiRecipeService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/recipe/application/AiRecipeService.java
@@ -692,17 +692,6 @@ public class AiRecipeService {
                                 (desc.endsWith("로 대체 가능합니다")
                                         || desc.equals("이 재료는 생략 가능합니다"));
 
-                if (!validFormat) {
-                    log.error("❌ optional_ingredients description 형식 오류: name={}, description=[{}]",
-                            ing.getName(), desc);
-                    throw new AppException(ErrorCode.AI_RESPONSE_INVALID_FORMAT);
-                }
-
-                if (ing.getQuantity() == null) {
-                    log.error("❌ optional_ingredients quantity null: name={}", ing.getName());
-                    throw new AppException(ErrorCode.AI_RESPONSE_INVALID_FORMAT);
-                }
-
                 if (ing.getQuantity() <= 0) {
                     log.error("❌ optional_ingredients quantity <= 0: name={}, quantity={}",
                             ing.getName(), ing.getQuantity());


### PR DESCRIPTION
# Issue
#130 

# Description
- optional_ingredients에서 수량/단위 null 허용
- optional_ingredients description 설명 형식 자유화 (프롬프트만으로 관리)
- 기존 방식은 ai가 응답을 조금만 다르게 해도 500에러가 발생하여 에러 처리를 완화했습니다
- user_ingredietnts, addtional_ingredients에서는 수량/단위에서 null 허용 안 함

# Changes
- optional_ingredients 수량/단위 에러 처리 제거
- optional_ingredients 설명 에러처리 제거
