### PR TITLE
Fix:ai recipe

### DIFF
--- a/src/main/java/com/cookeep/cookeep/domain/recipe/application/AiRecipeService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/recipe/application/AiRecipeService.java
@@ -692,13 +692,13 @@ public class AiRecipeService {
                                 (desc.endsWith("로 대체 가능합니다")
                                         || desc.equals("이 재료는 생략 가능합니다"));
 
-                if (ing.getQuantity() <= 0) {
+                if (ing.getQuantity() != null && ing.getQuantity() <= 0) {
                     log.error("❌ optional_ingredients quantity <= 0: name={}, quantity={}",
                             ing.getName(), ing.getQuantity());
                     throw new AppException(ErrorCode.AI_RESPONSE_INVALID_FORMAT);
                 }
 
-                if (!allowedUnits.contains(ing.getUnit())) {
+                if (ing.getUnit() != null && !allowedUnits.contains(ing.getUnit())) {
                     log.error("❌ optional_ingredients 허용되지 않은 unit: name={}, unit={}",
                             ing.getName(), ing.getUnit());
                     throw new AppException(ErrorCode.AI_RESPONSE_INVALID_FORMAT);

--- a/src/main/java/com/cookeep/cookeep/domain/recipe/entity/Difficulty.java
+++ b/src/main/java/com/cookeep/cookeep/domain/recipe/entity/Difficulty.java
@@ -1,5 +1,5 @@
 package com.cookeep.cookeep.domain.recipe.entity;
 
 public enum Difficulty {
-    EASY, MEDIUM, HARD
+    EASY, NORMAL, HARD
 }


### PR DESCRIPTION
# Issue
#133 

# Description
- 기존 작업 실수로 ai 레시피 난이도 MEDIUM -> NORMAL 불일치 문제 발생
- 프론트에 NORMAL로 구현되어 있어 백 코드를 NORMAL로 통일
- additional_ingredients에서 수량/단위 null인 경우 에러 발생하여 해당 부분 수정

# Changes
- Difficulty ENUM: MEDIUM을 NORMAL로 수정
- 에러 처리 수정
- DB 직접 접속해서 수정 필요

# Test Checklist
- [x] NORMAL 난이도 동작 확인
