### PR TITLE
fix: 데일리 레시피 등록 시 content 스냅샷에 유투브 서치 쿼리 추가

### DIFF
--- a/src/main/java/com/cookeep/cookeep/domain/dailyrecipe/application/DailyRecipeService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/dailyrecipe/application/DailyRecipeService.java
@@ -183,6 +183,9 @@ public class DailyRecipeService {
             if (aiRecipe.getYoutubeUrlJson() != null) {
                 contentMap.put("youtubeReferences", objectMapper.readTree(aiRecipe.getYoutubeUrlJson()));
             }
+            if (aiRecipe.getYoutubeSearchQueries() != null) {
+                contentMap.put("youtubeSearchQueries", objectMapper.readTree(aiRecipe.getYoutubeSearchQueries()));
+            }
             return objectMapper.writeValueAsString(contentMap);
         } catch (Exception e) {
             log.error("AI 레시피 내용 스냅샷 생성 실패", e);


### PR DESCRIPTION
# Related Issue
CLOSE #139 

# Description
AI 레시피 채택 시 '유투브 서치 쿼리'도 함께 저장하도록 수정함에 따라, 
데일리 레시피 등록할 때 채택된 레시피를 불러오고 스냅샷을 생성하는 과정에서 유투브 서치 쿼리도 함께 저장되도록 수정했습니다.

# Changes
DailyRecipeSerivce에 로직 추가