### PR TITLE
fix: 유통기한, 보관장소 조회

### DIFF
--- a/src/main/java/com/cookeep/cookeep/api/dto/response/IngredientListResponseDto.java
+++ b/src/main/java/com/cookeep/cookeep/api/dto/response/IngredientListResponseDto.java
@@ -1,6 +1,7 @@
 package com.cookeep.cookeep.api.dto.response;
 
 import com.cookeep.cookeep.domain.ingredient.common.domain.Category;
+import com.cookeep.cookeep.domain.ingredient.common.domain.Storage;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -104,6 +105,16 @@ public class IngredientListResponseDto {
                 requiredMode = Schema.RequiredMode.NOT_REQUIRED
         )
         private String unit;
+
+        @Schema(description = "유통기한 (일)",
+                example = "7",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        private Integer expirationDays;
+
+        @Schema(description = "보관 장소",
+                example = "FRIDGE",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        private Storage storage;
 
     }
 

--- a/src/main/java/com/cookeep/cookeep/domain/ingredient/common/application/IngredientListService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/ingredient/common/application/IngredientListService.java
@@ -64,6 +64,8 @@ public class IngredientListService {
                         .imageUrl(ingredient.getImageUrl())
                         .category(ingredient.getCategory())
                         .unit(ingredient.getUnit() != null ? ingredient.getUnit().name() : Unit.PIECE.name())
+                        .expirationDays(ingredient.getDefaultExpirationDays())
+                        .storage(ingredient.getDefaultStorage())
                         .build())
         );
         customIngredients.forEach(ingredient ->
@@ -74,6 +76,8 @@ public class IngredientListService {
                         .imageUrl(ingredient.getImageUrl())
                         .category(ingredient.getCategory())
                         .unit(Unit.PIECE.name())
+                        .expirationDays(ingredient.getExpirationDays())
+                        .storage(ingredient.getStorage())
                         .build())
         );
 


### PR DESCRIPTION
# Issue
#141

# Description
- 리스트 조회 시 식재료 유통기한/보관장소 조회되도록 수정

# Changes
- dto에 expirationDate, Storage 필드 추가
-  service에서 유통기한/보관장소 조회하여 응답

# Test
- [x] 스웨거 조회 테스트 완료