### PR TITLE
Refactor: 식재료 등록 방식 수정

### DIFF
--- a/src/main/java/com/cookeep/cookeep/api/controller/UserIngredientController.java
+++ b/src/main/java/com/cookeep/cookeep/api/controller/UserIngredientController.java
@@ -1,19 +1,15 @@
 package com.cookeep.cookeep.api.controller;
 
-import com.cookeep.cookeep.api.dto.request.UserIngredientCreateRequestDto;
 import com.cookeep.cookeep.api.dto.request.UserIngredientListCreateRequestDto;
-import com.cookeep.cookeep.api.dto.response.UserIngredientCreateResponseDto;
 import com.cookeep.cookeep.api.dto.response.UserIngredientListCreateResponseDto;
 import com.cookeep.cookeep.common.dto.DataResponse;
 import com.cookeep.cookeep.common.exception.ErrorCode;
 import com.cookeep.cookeep.config.ApiErrorCodeExamples;
-import com.cookeep.cookeep.security.JwtTokenProvider;
 import com.cookeep.cookeep.domain.ingredient.useringredient.application.UserIngredientService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
-import io.swagger.v3.oas.annotations.security.SecurityRequirements;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -37,13 +33,14 @@ public class UserIngredientController {
     @ApiErrorCodeExamples({
             ErrorCode.USER_NOT_FOUND,
             ErrorCode.INGREDIENT_REFERENCE_NOT_FOUND,
-            ErrorCode.INTERNAL_SERVER_ERROR
+            ErrorCode.INTERNAL_SERVER_ERROR,
+            ErrorCode.INVALID_INGREDIENT_REQUEST
     })
     @ApiResponses(value = {
             @ApiResponse(responseCode = "201", description = "식재료 등록 성공"),
             @ApiResponse(responseCode = "400", description = """
                     잘못된 요청입니다. 다음 오류가 발생할 수 있습니다:
-                    - (Validation/Jackson) 필수값 누락 또는 ENUM 값 오류
+                    - INVALID_INGREDIENT_REQUEST: 필수값 누락 또는 ENUM 값 오류
                     """, content = @Content),
             @ApiResponse(responseCode = "401", description = """
                     인증 실패입니다.
@@ -61,7 +58,7 @@ public class UserIngredientController {
     @PostMapping
     public ResponseEntity<DataResponse<UserIngredientListCreateResponseDto>> createUserIngredients(
             @AuthenticationPrincipal(expression = "userId") Long userId,
-            @RequestBody @Valid UserIngredientListCreateRequestDto request
+            @RequestBody UserIngredientListCreateRequestDto request
     ) {
         UserIngredientListCreateResponseDto response = userIngredientService.createAll(userId, request.getIngredients());
 

--- a/src/main/java/com/cookeep/cookeep/api/controller/UserIngredientController.java
+++ b/src/main/java/com/cookeep/cookeep/api/controller/UserIngredientController.java
@@ -51,9 +51,11 @@ public class UserIngredientController {
     })
     @PostMapping("/preview")
     public ResponseEntity<DataResponse<UserIngredientListPreviewResponseDto>> previewUserIngredients(
+            @AuthenticationPrincipal(expression = "userId") Long userId,
             @RequestBody @Valid UserIngredientListPreviewRequestDto request
     ) {
-        UserIngredientListPreviewResponseDto response = userIngredientService.previewAll(request.getIngredients());
+        UserIngredientListPreviewResponseDto response =
+                userIngredientService.previewAll(userId, request.getIngredients());
 
         return ResponseEntity
                 .status(HttpStatus.OK)

--- a/src/main/java/com/cookeep/cookeep/api/controller/UserIngredientController.java
+++ b/src/main/java/com/cookeep/cookeep/api/controller/UserIngredientController.java
@@ -1,7 +1,9 @@
 package com.cookeep.cookeep.api.controller;
 
 import com.cookeep.cookeep.api.dto.request.UserIngredientListCreateRequestDto;
+import com.cookeep.cookeep.api.dto.request.UserIngredientListPreviewRequestDto;
 import com.cookeep.cookeep.api.dto.response.UserIngredientListCreateResponseDto;
+import com.cookeep.cookeep.api.dto.response.UserIngredientListPreviewResponseDto;
 import com.cookeep.cookeep.common.dto.DataResponse;
 import com.cookeep.cookeep.common.exception.ErrorCode;
 import com.cookeep.cookeep.config.ApiErrorCodeExamples;
@@ -26,9 +28,47 @@ public class UserIngredientController {
 
     private final UserIngredientService userIngredientService;
 
+    // 1단계: 기본 정보 조회
     @Operation(
-            summary = "유저 식재료 등록",
-            description = "유저가 보유 중인 식재료를 등록합니다. (기본 식재료 또는 커스텀 식재료)"
+            summary = "[1단계] 식재료 기본 정보 조회",
+            description = "재료 DB의 기본 정보(보관장소, 유통기한, 단위 등) 조회"
+    )
+    @ApiErrorCodeExamples({
+            ErrorCode.INGREDIENT_REFERENCE_NOT_FOUND,
+            ErrorCode.INTERNAL_SERVER_ERROR,
+            ErrorCode.INVALID_INGREDIENT_REQUEST
+    })
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "기본 정보 조회 성공"),
+            @ApiResponse(responseCode = "400", description = """
+                    잘못된 요청입니다.
+                    - INVALID_INGREDIENT_REQUEST: 필수값(type, referenceId) 누락 또는 ENUM 값 오류
+                    """, content = @Content),
+            @ApiResponse(responseCode = "404", description = """
+                    - INGREDIENT_REFERENCE_NOT_FOUND: 참조한 식재료를 찾을 수 없습니다.
+                    """, content = @Content),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류", content = @Content)
+    })
+    @PostMapping("/preview")
+    public ResponseEntity<DataResponse<UserIngredientListPreviewResponseDto>> previewUserIngredients(
+            @RequestBody @Valid UserIngredientListPreviewRequestDto request
+    ) {
+        UserIngredientListPreviewResponseDto response = userIngredientService.previewAll(request.getIngredients());
+
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(DataResponse.from(response));
+    }
+
+    // 2단계: 최종 등록
+    @Operation(
+            summary = "[2단계] 유저 식재료 등록",
+            description = """
+                    유저 확인/수정한 정보로 식재료 최종 등록
+                    - type, referenceId는 필수입니다.
+                    - 나머지 필드(quantity, unit, storage, expirationDate, memo)는 선택입니다.
+                    - 미입력 시 DB 기본값 또는 시스템 기본값이 적용
+                    """
     )
     @ApiErrorCodeExamples({
             ErrorCode.USER_NOT_FOUND,
@@ -39,26 +79,20 @@ public class UserIngredientController {
     @ApiResponses(value = {
             @ApiResponse(responseCode = "201", description = "식재료 등록 성공"),
             @ApiResponse(responseCode = "400", description = """
-                    잘못된 요청입니다. 다음 오류가 발생할 수 있습니다:
+                    잘못된 요청입니다.
                     - INVALID_INGREDIENT_REQUEST: 필수값 누락 또는 ENUM 값 오류
                     """, content = @Content),
-            @ApiResponse(responseCode = "401", description = """
-                    인증 실패입니다.
-                    """, content = @Content),
+            @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content),
             @ApiResponse(responseCode = "404", description = """
-                    리소스를 찾을 수 없습니다. 다음 오류가 발생할 수 있습니다:
                     - USER_NOT_FOUND: 유저를 찾을 수 없습니다.
-                    - INGREDIENT_REFERENCE_NOT_FOUND: 참조한 식재료(기본/커스텀)를 찾을 수 없습니다.
+                    - INGREDIENT_REFERENCE_NOT_FOUND: 참조한 식재료를 찾을 수 없습니다.
                     """, content = @Content),
-            @ApiResponse(responseCode = "500", description = """
-                    서버 오류입니다. 다음 오류가 발생할 수 있습니다:
-                    - INTERNAL_SERVER_ERROR: 서버 내부 오류가 발생했습니다.
-                    """, content = @Content)
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류", content = @Content)
     })
     @PostMapping
     public ResponseEntity<DataResponse<UserIngredientListCreateResponseDto>> createUserIngredients(
             @AuthenticationPrincipal(expression = "userId") Long userId,
-            @RequestBody UserIngredientListCreateRequestDto request
+            @RequestBody @Valid UserIngredientListCreateRequestDto request
     ) {
         UserIngredientListCreateResponseDto response = userIngredientService.createAll(userId, request.getIngredients());
 

--- a/src/main/java/com/cookeep/cookeep/api/controller/UserIngredientController.java
+++ b/src/main/java/com/cookeep/cookeep/api/controller/UserIngredientController.java
@@ -1,7 +1,9 @@
 package com.cookeep.cookeep.api.controller;
 
 import com.cookeep.cookeep.api.dto.request.UserIngredientCreateRequestDto;
+import com.cookeep.cookeep.api.dto.request.UserIngredientListCreateRequestDto;
 import com.cookeep.cookeep.api.dto.response.UserIngredientCreateResponseDto;
+import com.cookeep.cookeep.api.dto.response.UserIngredientListCreateResponseDto;
 import com.cookeep.cookeep.common.dto.DataResponse;
 import com.cookeep.cookeep.common.exception.ErrorCode;
 import com.cookeep.cookeep.config.ApiErrorCodeExamples;
@@ -27,7 +29,6 @@ import org.springframework.web.bind.annotation.*;
 public class UserIngredientController {
 
     private final UserIngredientService userIngredientService;
-    private final JwtTokenProvider jwtTokenProvider;
 
     @Operation(
             summary = "유저 식재료 등록",
@@ -58,11 +59,11 @@ public class UserIngredientController {
                     """, content = @Content)
     })
     @PostMapping
-    public ResponseEntity<DataResponse<UserIngredientCreateResponseDto>> createUserIngredient(
+    public ResponseEntity<DataResponse<UserIngredientListCreateResponseDto>> createUserIngredients(
             @AuthenticationPrincipal(expression = "userId") Long userId,
-            @RequestBody @Valid UserIngredientCreateRequestDto request
+            @RequestBody @Valid UserIngredientListCreateRequestDto request
     ) {
-        UserIngredientCreateResponseDto response = userIngredientService.create(userId, request);
+        UserIngredientListCreateResponseDto response = userIngredientService.createAll(userId, request.getIngredients());
 
         return ResponseEntity
                 .status(HttpStatus.CREATED)

--- a/src/main/java/com/cookeep/cookeep/api/dto/request/UserIngredientCreateRequestDto.java
+++ b/src/main/java/com/cookeep/cookeep/api/dto/request/UserIngredientCreateRequestDto.java
@@ -15,13 +15,13 @@ import java.time.LocalDate;
 @NoArgsConstructor
 @Schema(
         name = "UserIngredientCreateRequest",
-        description = "유저 식재료 등록 요청 DTO"
+        description = "유저 식재료 등록 요청 DTO (단일항목)"
 )
 public class UserIngredientCreateRequestDto {
 
     @NotNull(message = "식재료 타입은 필수입니다.")
     @Schema(
-            description = "식재료 타입 (기본/커스텀 등 시스템이 정의한 타입)",
+            description = "식재료 타입 (DEFAULT / CUSTOM)",
             example = "CUSTOM",
             requiredMode = Schema.RequiredMode.REQUIRED
     )
@@ -29,33 +29,26 @@ public class UserIngredientCreateRequestDto {
 
     @NotNull(message = "식재료 ID는 필수입니다.")
     @Schema(
-            description = "참조 ID (type에 따라 참조 대상이 달라짐). 예: CUSTOM이면 CustomIngredient의 ID, DEFAULT면 기본 식재료 ID",
+            description = "참조 ID (DefaultIngredient/CustomIngredient DB의 ID)",
             example = "3",
             requiredMode = Schema.RequiredMode.REQUIRED
     )
     private Long referenceId;
 
-    @NotNull(message = "수량은 필수입니다.")
     @Positive(message = "수량은 양수여야 합니다.")
-    @Schema(
-            description = "수량 (양수)",
-            example = "2",
-            requiredMode = Schema.RequiredMode.REQUIRED,
-            minimum = "1"
-    )
+    @Schema(description = "수량 (미입력 시 기본값 1)", example = "2", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     private Integer quantity;
 
-    @NotNull(message = "단위는 필수입니다.")
     @Schema(
-            description = "수량 단위",
+            description = "수량 단위 (미입력 시 DEFAULT=db값, CUSTOM=PIECE)",
             example = "PIECE",
             allowableValues = {"PIECE", "PACK", "BAG", "BOTTLE", "BUNDLE", "CAN", "GRAM", "MILLILITER"},
-            requiredMode = Schema.RequiredMode.REQUIRED
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
     )
     private Unit unit;
 
     @Schema(
-            description = "보관 장소 (미입력 시 서버 정책/기본값 적용 가능)",
+            description = "보관 장소 (미입력 시 db 기본값)",
             example = "FRIDGE",
             allowableValues = {"FRIDGE", "FREEZER", "PANTRY"},
             requiredMode = Schema.RequiredMode.NOT_REQUIRED
@@ -63,8 +56,8 @@ public class UserIngredientCreateRequestDto {
     private Storage storage;
 
     @Schema(
-            description = "소비/만료 날짜 (yyyy-MM-dd). 미입력 시 서버에서 기본값 계산 가능",
-            example = "2026-01-20",
+            description = "소비/만료 날짜 (yyyy-MM-dd). 미입력 시 db expirationDays 기준 계산",
+            example = "2026-03-20",
             type = "string",
             format = "date",
             requiredMode = Schema.RequiredMode.NOT_REQUIRED
@@ -72,7 +65,7 @@ public class UserIngredientCreateRequestDto {
     private LocalDate expirationDate;
 
     @Schema(
-            description = "메모(선택)",
+            description = "메모(선택). 미입력 시 null",
             example = "유통기한 짧음. 먼저 사용",
             requiredMode = Schema.RequiredMode.NOT_REQUIRED
     )

--- a/src/main/java/com/cookeep/cookeep/api/dto/request/UserIngredientListCreateRequestDto.java
+++ b/src/main/java/com/cookeep/cookeep/api/dto/request/UserIngredientListCreateRequestDto.java
@@ -1,0 +1,21 @@
+package com.cookeep.cookeep.api.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@Schema(name = "UserIngredientListCreateRequest", description = "유저 식재료 일괄 등록 요청 DTO")
+public class UserIngredientListCreateRequestDto {
+
+    @Valid
+    @NotEmpty(message = "식재료 목록은 1개 이상이어야 합니다.")
+    @Schema(description = "등록할 식재료 목록", requiredMode = Schema.RequiredMode.REQUIRED)
+    private List<UserIngredientCreateRequestDto> ingredients;
+
+}

--- a/src/main/java/com/cookeep/cookeep/api/dto/request/UserIngredientListPreviewRequestDto.java
+++ b/src/main/java/com/cookeep/cookeep/api/dto/request/UserIngredientListPreviewRequestDto.java
@@ -1,0 +1,23 @@
+package com.cookeep.cookeep.api.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@Schema(
+        name = "UserIngredientListPreviewRequest",
+        description = "(2) 식재료 기본 정보 일괄 조회 요청 DTO"
+)
+public class UserIngredientListPreviewRequestDto {
+
+    @Valid
+    @NotEmpty(message = "식재료 목록은 1개 이상이어야 합니다.")
+    @Schema(description = "조회할 식재료 목록 (type + referenceId만 필요)", requiredMode = Schema.RequiredMode.REQUIRED)
+    private List<UserIngredientPreviewRequestDto> ingredients;
+}

--- a/src/main/java/com/cookeep/cookeep/api/dto/request/UserIngredientPreviewRequestDto.java
+++ b/src/main/java/com/cookeep/cookeep/api/dto/request/UserIngredientPreviewRequestDto.java
@@ -1,0 +1,32 @@
+package com.cookeep.cookeep.api.dto.request;
+
+import com.cookeep.cookeep.domain.ingredient.common.domain.Type;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@Schema(
+        name = "UserIngredientPreviewRequest",
+        description = "식재료 기본 정보 조회 요청 DTO (단일 항목)"
+)
+public class UserIngredientPreviewRequestDto {
+
+    @NotNull(message = "식재료 타입은 필수입니다.")
+    @Schema(
+            description = "식재료 타입 (DEFAULT / CUSTOM)",
+            example = "DEFAULT",
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
+    private Type type;
+
+    @NotNull(message = "식재료 ID는 필수입니다.")
+    @Schema(
+            description = "참조 ID (DefaultIngredient 또는 CustomIngredient의 DB ID)",
+            example = "3",
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
+    private Long referenceId;
+}

--- a/src/main/java/com/cookeep/cookeep/api/dto/response/UserIngredientCreateResponseDto.java
+++ b/src/main/java/com/cookeep/cookeep/api/dto/response/UserIngredientCreateResponseDto.java
@@ -48,6 +48,9 @@ public class UserIngredientCreateResponseDto {
     @Schema(description = "식재료 이미지 URL", example = "https://s3.amazonaws.com/cookeep/ingredients/carrot.png")
     private String imageUrl;
 
+    @Schema(description = "등록일", example = "2026-03-06", type = "string", format = "date")
+    private LocalDate createdAt;
+
     public static UserIngredientCreateResponseDto of(
             UserIngredient userIngredient,
             String ingredientName,
@@ -64,7 +67,8 @@ public class UserIngredientCreateResponseDto {
                 userIngredient.getExpirationDate(),
                 userIngredient.getLeftDays(),
                 userIngredient.getMemo(),
-                imageUrl
+                imageUrl,
+                userIngredient.getCreatedAt().toLocalDate()
         );
     }
 }

--- a/src/main/java/com/cookeep/cookeep/api/dto/response/UserIngredientCreateResponseDto.java
+++ b/src/main/java/com/cookeep/cookeep/api/dto/response/UserIngredientCreateResponseDto.java
@@ -15,7 +15,7 @@ import java.time.LocalDate;
 )
 public class UserIngredientCreateResponseDto {
 
-    @Schema(description = "식재료 타입", example = "CUSTOM")
+    @Schema(description = "식재료 타입", example = "DEFAULT")
     private String type;
 
     @Schema(description = "유저 식재료(UserIngredient DB) ID", example = "1")
@@ -24,7 +24,7 @@ public class UserIngredientCreateResponseDto {
     @Schema(description = "참조 ID (요청에서 전달한 referenceId)", example = "3")
     private Long referenceId;
 
-    @Schema(description = "식재료 이름", example = "두쫀쿠")
+    @Schema(description = "식재료 이름", example = "시금치")
     private String name;
 
     @Schema(description = "수량", example = "2")
@@ -36,7 +36,7 @@ public class UserIngredientCreateResponseDto {
     @Schema(description = "보관 장소", example = "FRIDGE")
     private String storage;
 
-    @Schema(description = "만료일 (yyyy-MM-dd)", example = "2026-01-20", type = "string", format = "date")
+    @Schema(description = "만료일 (yyyy-MM-dd)", example = "2026-04-20", type = "string", format = "date")
     private LocalDate expirationDate;
 
     @Schema(description = "남은 일수(만료일까지)", example = "4")

--- a/src/main/java/com/cookeep/cookeep/api/dto/response/UserIngredientListCreateResponseDto.java
+++ b/src/main/java/com/cookeep/cookeep/api/dto/response/UserIngredientListCreateResponseDto.java
@@ -1,0 +1,24 @@
+package com.cookeep.cookeep.api.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+@Schema(name = "UserIngredientListCreateResponse", description = "유저 식재료 일괄 등록 응답 DTO")
+public class UserIngredientListCreateResponseDto {
+
+    @Schema(description = "등록된 식재료 목록")
+    private List<UserIngredientCreateResponseDto> ingredients;
+
+    @Schema(description = "등록된 식재료 수", example = "4")
+    private int count;
+
+    public static UserIngredientListCreateResponseDto of(List<UserIngredientCreateResponseDto> ingredients) {
+        return new UserIngredientListCreateResponseDto(ingredients, ingredients.size());
+    }
+
+}

--- a/src/main/java/com/cookeep/cookeep/api/dto/response/UserIngredientListPreviewResponseDto.java
+++ b/src/main/java/com/cookeep/cookeep/api/dto/response/UserIngredientListPreviewResponseDto.java
@@ -1,0 +1,27 @@
+package com.cookeep.cookeep.api.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+@Schema(
+        name = "UserIngredientListPreviewResponse",
+        description = "식재료 기본 정보 일괄 조회 응답 DTO"
+)
+public class UserIngredientListPreviewResponseDto {
+
+    @Schema(description = "조회된 식재료 기본 정보 목록")
+    private List<UserIngredientPreviewResponseDto> ingredients;
+
+    @Schema(description = "조회된 식재료 수", example = "3")
+    private int count;
+
+    public static UserIngredientListPreviewResponseDto of(List<UserIngredientPreviewResponseDto> ingredients) {
+        return new UserIngredientListPreviewResponseDto(ingredients, ingredients.size());
+    }
+
+}

--- a/src/main/java/com/cookeep/cookeep/api/dto/response/UserIngredientPreviewResponseDto.java
+++ b/src/main/java/com/cookeep/cookeep/api/dto/response/UserIngredientPreviewResponseDto.java
@@ -1,0 +1,79 @@
+package com.cookeep.cookeep.api.dto.response;
+
+import com.cookeep.cookeep.domain.ingredient.customingredient.entity.CustomIngredient;
+import com.cookeep.cookeep.domain.ingredient.defaultingredient.entity.DefaultIngredient;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+@AllArgsConstructor
+@Schema(
+        name = "UserIngredientPreviewResponse",
+        description = "(1) 식재료 기본 정보 조회 응답 DTO (단일 항목). DB에 저장된 기본값을 그대로 사용"
+)
+public class UserIngredientPreviewResponseDto {
+
+    @Schema(description = "식재료 타입", example = "DEFAULT")
+    private String type;
+
+    @Schema(description = "참조 ID (요청에서 전달한 referenceId)", example = "3")
+    private Long referenceId;
+
+    @Schema(description = "식재료 이름", example = "상추")
+    private String name;
+
+    @Schema(description = "식재료 이미지 URL", example = "https://s3.amazonaws.com/cookeep/ingredients/lettuce.png")
+    private String imageUrl;
+
+    @Schema(description = "기본 수량 (항상 1)", example = "1")
+    private Integer defaultQuantity;
+
+    @Schema(description = "기본 단위 (DEFAULT=db값, CUSTOM=PIECE)", example = "PIECE")
+    private String defaultUnit;
+
+    @Schema(description = "기본 보관 장소", example = "FRIDGE")
+    private String defaultStorage;
+
+    @Schema(description = "기본 만료일 (오늘 + expirationDays, yyyy-MM-dd)", example = "2026-03-06", type = "string", format = "date")
+    private LocalDate defaultExpirationDate;
+
+    // ── 팩토리 메서드 ─────────────────────────────────────────────────────────
+
+    public static UserIngredientPreviewResponseDto ofDefault(DefaultIngredient ref) {
+        LocalDate expiration = calcExpiration(ref.getDefaultExpirationDays());
+
+        return new UserIngredientPreviewResponseDto(
+                "DEFAULT",
+                ref.getId(),
+                ref.getIngredient(),
+                ref.getImageUrl(),
+                1,
+                ref.getUnit() != null ? ref.getUnit().name() : null,
+                ref.getDefaultStorage() != null ? ref.getDefaultStorage().name() : null,
+                expiration
+        );
+    }
+
+    public static UserIngredientPreviewResponseDto ofCustom(CustomIngredient ref) {
+        LocalDate expiration = calcExpiration(ref.getExpirationDays());
+
+        return new UserIngredientPreviewResponseDto(
+                "CUSTOM",
+                ref.getId(),
+                ref.getName(),
+                ref.getImageUrl(),
+                1,
+                "PIECE",
+                ref.getStorage() != null ? ref.getStorage().name() : null,
+                expiration
+        );
+    }
+
+    private static LocalDate calcExpiration(Integer expirationDays) {
+        if (expirationDays == null) return null;
+        return LocalDate.now().plusDays(expirationDays);
+    }
+}

--- a/src/main/java/com/cookeep/cookeep/api/dto/response/UserIngredientPreviewResponseDto.java
+++ b/src/main/java/com/cookeep/cookeep/api/dto/response/UserIngredientPreviewResponseDto.java
@@ -40,7 +40,7 @@ public class UserIngredientPreviewResponseDto {
     @Schema(description = "기본 만료일 (오늘 + expirationDays, yyyy-MM-dd)", example = "2026-03-06", type = "string", format = "date")
     private LocalDate defaultExpirationDate;
 
-    // ── 팩토리 메서드 ─────────────────────────────────────────────────────────
+    // 식재료를 객체로 생성
 
     public static UserIngredientPreviewResponseDto ofDefault(DefaultIngredient ref) {
         LocalDate expiration = calcExpiration(ref.getDefaultExpirationDays());

--- a/src/main/java/com/cookeep/cookeep/common/exception/ErrorCode.java
+++ b/src/main/java/com/cookeep/cookeep/common/exception/ErrorCode.java
@@ -59,6 +59,7 @@ public enum ErrorCode {
 	PASSWORD_MISMATCH(HttpStatus.BAD_REQUEST, "현재 비밀번호가 일치하지 않습니다.", "AUTH-006"),
 	REGISTERED_PHONE_NUMBER_MISMATCH(HttpStatus.BAD_REQUEST, "회원정보에 등록된 전화번호와 일치하지 않습니다.", "AUTH-008"),
 	RECIPE_DELETE_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "데일리레시피에 기록된 레시피는 삭제할 수 없습니다.", "RECIPE-024"),
+	INVALID_INGREDIENT_REQUEST(HttpStatus.BAD_REQUEST, "type과 referenceId는 필수 입력입니다.", "INGREDIENT-011"),
 
 	// 401 UNAUTHORIZED (인증 관련)
 	UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증에 실패했습니다.", "AUTH-001"),

--- a/src/main/java/com/cookeep/cookeep/domain/ingredient/useringredient/application/UserIngredientService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/ingredient/useringredient/application/UserIngredientService.java
@@ -1,105 +1,11 @@
 package com.cookeep.cookeep.domain.ingredient.useringredient.application;
 
 import com.cookeep.cookeep.api.dto.request.UserIngredientCreateRequestDto;
-import com.cookeep.cookeep.api.dto.response.UserIngredientCreateResponseDto;
-import com.cookeep.cookeep.common.exception.EntityNotFoundException;
-import com.cookeep.cookeep.common.exception.ErrorCode;
-import com.cookeep.cookeep.domain.ingredient.common.domain.Storage;
-import com.cookeep.cookeep.domain.ingredient.common.domain.Type;
-import com.cookeep.cookeep.domain.ingredient.customingredient.dao.CustomIngredientRepository;
-import com.cookeep.cookeep.domain.ingredient.customingredient.entity.CustomIngredient;
-import com.cookeep.cookeep.domain.ingredient.defaultingredient.dao.DefaultIngredientRepository;
-import com.cookeep.cookeep.domain.ingredient.defaultingredient.entity.DefaultIngredient;
-import com.cookeep.cookeep.domain.ingredient.useringredient.dao.UserIngredientRepository;
-import com.cookeep.cookeep.domain.ingredient.useringredient.entity.UserIngredient;
-import com.cookeep.cookeep.domain.mycookeep.application.ConsumptionReportService;
-import com.cookeep.cookeep.domain.user.dao.UserRepository;
-import com.cookeep.cookeep.domain.user.entity.User;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
+import com.cookeep.cookeep.api.dto.response.UserIngredientListCreateResponseDto;
 
-import java.time.LocalDate;
+import java.util.List;
 
-@Service
-@RequiredArgsConstructor
-@Transactional(readOnly = true)
-public class UserIngredientService {
+public interface UserIngredientService {
 
-    private final UserIngredientRepository userIngredientRepository;
-    private final DefaultIngredientRepository defaultIngredientRepository;
-    private final CustomIngredientRepository customIngredientRepository;
-    private final UserRepository userRepository;
-    private final ConsumptionReportService consumptionReportService;
-
-    @Transactional
-    public UserIngredientCreateResponseDto create(Long userId, UserIngredientCreateRequestDto request) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.USER_NOT_FOUND));
-
-        Type type;
-        String ingredientName;
-        String imageUrl;
-        Storage finalStorage;
-        LocalDate finalExpirationDate;
-
-        // type에 따라 분기 처리
-        if (request.getType() == Type.DEFAULT) {
-            // DefaultIngredient 조회
-            DefaultIngredient defaultIngredient = defaultIngredientRepository
-                    .findById(request.getReferenceId())
-                    .orElseThrow(() -> new EntityNotFoundException(ErrorCode.INGREDIENT_REFERENCE_NOT_FOUND));
-
-            ingredientName = defaultIngredient.getIngredient();
-            imageUrl = defaultIngredient.getImageUrl();
-
-            // storage: 사용자가 입력하지 않으면 기본값 사용
-            finalStorage = request.getStorage() != null
-                    ? request.getStorage()
-                    : defaultIngredient.getDefaultStorage();
-
-            // expirationDate: 사용자가 입력하지 않으면 자동 계산
-            finalExpirationDate = request.getExpirationDate() != null
-                    ? request.getExpirationDate()
-                    : LocalDate.now().plusDays(defaultIngredient.getDefaultExpirationDays());
-
-        } else {
-            // CustomIngredient 조회 (해당 유저의 것만)
-            CustomIngredient customIngredient = customIngredientRepository
-                    .findByIdAndUserId(request.getReferenceId(), userId)
-                    .orElseThrow(() -> new EntityNotFoundException(ErrorCode.INGREDIENT_REFERENCE_NOT_FOUND));
-
-            ingredientName = customIngredient.getName();
-            imageUrl = customIngredient.getImageUrl();
-
-            // storage: 사용자가 입력하지 않으면 기본값 사용
-            finalStorage = request.getStorage() != null
-                    ? request.getStorage()
-                    : customIngredient.getStorage();
-
-            // expirationDate: 사용자가 입력하지 않으면 자동 계산
-            finalExpirationDate = request.getExpirationDate() != null
-                    ? request.getExpirationDate()
-                    : LocalDate.now().plusDays(customIngredient.getExpirationDays());
-        }
-
-        // UserIngredient 생성
-        UserIngredient userIngredient = UserIngredient.builder()
-                .type(request.getType())
-                .referenceId(request.getReferenceId())
-                .quantity(request.getQuantity())
-                .unit(request.getUnit())
-                .storage(finalStorage)
-                .expirationDate(finalExpirationDate)
-                .memo(request.getMemo())
-                .user(user)
-                .build();
-
-        UserIngredient saved = userIngredientRepository.save(userIngredient);
-
-        // 주간 소비 리포트용 로그 생성
-        consumptionReportService.createLogForNewIngredient(user, saved);
-
-        return UserIngredientCreateResponseDto.of(saved, ingredientName, imageUrl);
-    }
+    UserIngredientListCreateResponseDto createAll(Long userId, List<UserIngredientCreateRequestDto> requests);
 }

--- a/src/main/java/com/cookeep/cookeep/domain/ingredient/useringredient/application/UserIngredientService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/ingredient/useringredient/application/UserIngredientService.java
@@ -1,11 +1,17 @@
 package com.cookeep.cookeep.domain.ingredient.useringredient.application;
 
 import com.cookeep.cookeep.api.dto.request.UserIngredientCreateRequestDto;
+import com.cookeep.cookeep.api.dto.request.UserIngredientPreviewRequestDto;
 import com.cookeep.cookeep.api.dto.response.UserIngredientListCreateResponseDto;
+import com.cookeep.cookeep.api.dto.response.UserIngredientListPreviewResponseDto;
 
 import java.util.List;
 
 public interface UserIngredientService {
 
+    // 1. 선택한 재료들의 DB 기본값을 조회
+    UserIngredientListPreviewResponseDto previewAll(List<UserIngredientPreviewRequestDto> requests);
+
+    // 2. 사용자가 확인/수정한 정보로 식재료를 최종 등록
     UserIngredientListCreateResponseDto createAll(Long userId, List<UserIngredientCreateRequestDto> requests);
 }

--- a/src/main/java/com/cookeep/cookeep/domain/ingredient/useringredient/application/UserIngredientService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/ingredient/useringredient/application/UserIngredientService.java
@@ -31,8 +31,6 @@ public class UserIngredientService {
     private final CustomIngredientRepository customIngredientRepository;
     private final UserRepository userRepository;
     private final ConsumptionReportService consumptionReportService;
-    private static final String DEFAULT_IMAGE =
-            "https://cookeep-images.s3.ap-northeast-2.amazonaws.com/ingredients/0a0cc3bd-1ade-46ed-897e-ba89ec09b7c0.png";
 
     @Transactional
     public UserIngredientCreateResponseDto create(Long userId, UserIngredientCreateRequestDto request) {

--- a/src/main/java/com/cookeep/cookeep/domain/ingredient/useringredient/application/UserIngredientService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/ingredient/useringredient/application/UserIngredientService.java
@@ -10,7 +10,7 @@ import java.util.List;
 public interface UserIngredientService {
 
     // 1. 선택한 재료들의 DB 기본값을 조회
-    UserIngredientListPreviewResponseDto previewAll(List<UserIngredientPreviewRequestDto> requests);
+    UserIngredientListPreviewResponseDto previewAll(Long userId, List<UserIngredientPreviewRequestDto> requests);
 
     // 2. 사용자가 확인/수정한 정보로 식재료를 최종 등록
     UserIngredientListCreateResponseDto createAll(Long userId, List<UserIngredientCreateRequestDto> requests);

--- a/src/main/java/com/cookeep/cookeep/domain/ingredient/useringredient/application/UserIngredientServiceImpl.java
+++ b/src/main/java/com/cookeep/cookeep/domain/ingredient/useringredient/application/UserIngredientServiceImpl.java
@@ -1,4 +1,115 @@
 package com.cookeep.cookeep.domain.ingredient.useringredient.application;
 
-public class UserIngredientServiceImpl {
+import com.cookeep.cookeep.api.dto.request.UserIngredientCreateRequestDto;
+import com.cookeep.cookeep.api.dto.response.UserIngredientCreateResponseDto;
+import com.cookeep.cookeep.api.dto.response.UserIngredientListCreateResponseDto;
+import com.cookeep.cookeep.common.exception.ErrorCode;
+import com.cookeep.cookeep.domain.ingredient.common.domain.Storage;
+import com.cookeep.cookeep.domain.ingredient.common.domain.Type;
+import com.cookeep.cookeep.domain.ingredient.common.domain.Unit;
+import com.cookeep.cookeep.domain.ingredient.customingredient.dao.CustomIngredientRepository;
+import com.cookeep.cookeep.domain.ingredient.customingredient.entity.CustomIngredient;
+import com.cookeep.cookeep.domain.ingredient.defaultingredient.dao.DefaultIngredientRepository;
+import com.cookeep.cookeep.domain.ingredient.defaultingredient.entity.DefaultIngredient;
+import com.cookeep.cookeep.domain.ingredient.useringredient.dao.UserIngredientRepository;
+import com.cookeep.cookeep.domain.ingredient.useringredient.entity.UserIngredient;
+import com.cookeep.cookeep.domain.user.dao.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class UserIngredientServiceImpl implements UserIngredientService {
+
+    private static final int DEFAULT_QUANTITY = 1;
+    private static final Unit DEFAULT_CUSTOM_UNIT = Unit.PIECE;
+
+    private final UserIngredientRepository userIngredientRepository;
+    private final DefaultIngredientRepository defaultIngredientRepository;
+    private final CustomIngredientRepository customIngredientRepository;
+    private final UserRepository userRepository;
+
+    @Override
+    public UserIngredientListCreateResponseDto createAll(Long userId, List<UserIngredientCreateRequestDto> requests) {
+        // 유저 존재 검증
+        userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        List<UserIngredientCreateResponseDto> results = requests.stream()
+                .map(req -> createOne(userId, req))
+                .toList();
+
+        return UserIngredientListCreateResponseDto.of(results);
+    }
+
+    private UserIngredientCreateResponseDto createOne(Long userId, UserIngredientCreateRequestDto req) {
+        if (req.getType() == Type.DEFAULT) {
+            return createFromDefault(userId, req);
+        } else {
+            return createFromCustom(userId, req);
+        }
+    }
+
+    private UserIngredientCreateResponseDto createFromDefault(Long userId, UserIngredientCreateRequestDto req) {
+        DefaultIngredient ref = defaultIngredientRepository.findById(req.getReferenceId())
+                .orElseThrow(() -> new BusinessException(ErrorCode.INGREDIENT_REFERENCE_NOT_FOUND));
+
+        int quantity = req.getQuantity()!= null ? req.getQuantity():DEFAULT_QUANTITY;
+        Unit unit = req.getUnit()!= null ? req.getUnit():ref.getUnit();
+        Storage storage = req.getStorage()!= null ? req.getStorage():ref.getDefaultStorage();
+        LocalDate expiration = req.getExpirationDate()!= null ? req.getExpirationDate():calcExpiration(ref.getDefaultExpirationDays());
+        String memo = req.getMemo();
+
+        UserIngredient entity = UserIngredient.builder()
+                .userId(userId)
+                .type(Type.DEFAULT)
+                .referenceId(ref.getId())
+                .quantity(quantity)
+                .unit(unit)
+                .storage(storage)
+                .expirationDate(expiration)
+                .memo(memo)
+                .build();
+
+        userIngredientRepository.save(entity);
+
+        return UserIngredientCreateResponseDto.of(entity, ref.getIngredient(), ref.getImageUrl());
+    }
+
+    private UserIngredientCreateResponseDto createFromCustom(Long userId, UserIngredientCreateRequestDto req) {
+        CustomIngredient ref = customIngredientRepository.findById(req.getReferenceId())
+                .orElseThrow(() -> new BusinessException(ErrorCode.INGREDIENT_REFERENCE_NOT_FOUND));
+
+        int quantity = req.getQuantity()!= null ? req.getQuantity():DEFAULT_QUANTITY;
+        Unit unit = req.getUnit()!= null ? req.getUnit():DEFAULT_CUSTOM_UNIT;
+        Storage storage = req.getStorage()!= null ? req.getStorage():ref.getStorage();
+        LocalDate expiration = req.getExpirationDate() != null ? req.getExpirationDate():calcExpiration(ref.getExpirationDays());
+        String memo = req.getMemo();
+
+        UserIngredient entity = UserIngredient.builder()
+                .userId(userId)
+                .type(Type.CUSTOM)
+                .referenceId(ref.getId())
+                .quantity(quantity)
+                .unit(unit)
+                .storage(storage)
+                .expirationDate(expiration)
+                .memo(memo)
+                .build();
+
+        userIngredientRepository.save(entity);
+
+        return UserIngredientCreateResponseDto.of(entity, ref.getName(), ref.getImageUrl());
+    }
+
+    private LocalDate calcExpiration(Integer expirationDays) {
+        if (expirationDays == null) return null;
+        return LocalDate.now().plusDays(expirationDays);
+    }
+
 }

--- a/src/main/java/com/cookeep/cookeep/domain/ingredient/useringredient/application/UserIngredientServiceImpl.java
+++ b/src/main/java/com/cookeep/cookeep/domain/ingredient/useringredient/application/UserIngredientServiceImpl.java
@@ -1,0 +1,4 @@
+package com.cookeep.cookeep.domain.ingredient.useringredient.application;
+
+public class UserIngredientServiceImpl {
+}

--- a/src/main/java/com/cookeep/cookeep/domain/ingredient/useringredient/application/UserIngredientServiceImpl.java
+++ b/src/main/java/com/cookeep/cookeep/domain/ingredient/useringredient/application/UserIngredientServiceImpl.java
@@ -82,18 +82,8 @@ public class UserIngredientServiceImpl implements UserIngredientService {
 
     private UserIngredientCreateResponseDto createOne(User user, UserIngredientCreateRequestDto req) {
 
-        // null 요청 자체 검증
-        if (req == null) {
-            throw new AppException(ErrorCode.INVALID_INGREDIENT_REQUEST);
-        }
-
-        // type 필수 검증
-        if (req.getType() == null) {
-            throw new AppException(ErrorCode.INVALID_INGREDIENT_REQUEST);
-        }
-
-        // referenceId 필수 검증
-        if (req.getReferenceId() == null) {
+        // null 요청 & type & referenceId 검증
+        if (req == null || req.getType() == null || req.getReferenceId() == null) {
             throw new AppException(ErrorCode.INVALID_INGREDIENT_REQUEST);
         }
 

--- a/src/main/java/com/cookeep/cookeep/domain/ingredient/useringredient/application/UserIngredientServiceImpl.java
+++ b/src/main/java/com/cookeep/cookeep/domain/ingredient/useringredient/application/UserIngredientServiceImpl.java
@@ -50,11 +50,30 @@ public class UserIngredientServiceImpl implements UserIngredientService {
     }
 
     private UserIngredientCreateResponseDto createOne(User user, UserIngredientCreateRequestDto req) {
+
+        // null 요청 자체 검증
+        if (req == null) {
+            throw new AppException(ErrorCode.INVALID_INGREDIENT_REQUEST);
+        }
+
+        // type 필수 검증
+        if (req.getType() == null) {
+            throw new AppException(ErrorCode.INVALID_INGREDIENT_REQUEST);
+        }
+
+        // referenceId 필수 검증
+        if (req.getReferenceId() == null) {
+            throw new AppException(ErrorCode.INVALID_INGREDIENT_REQUEST);
+        }
+
         if (req.getType() == Type.DEFAULT) {
             return createFromDefault(user, req);
-        } else {
+        } else if (req.getType() == Type.CUSTOM) {
             return createFromCustom(user, req);
+        } else {
+            throw new AppException(ErrorCode.INVALID_INGREDIENT_REQUEST);
         }
+
     }
 
     private UserIngredientCreateResponseDto createFromDefault(User user, UserIngredientCreateRequestDto req) {

--- a/src/main/java/com/cookeep/cookeep/domain/ingredient/useringredient/application/UserIngredientServiceImpl.java
+++ b/src/main/java/com/cookeep/cookeep/domain/ingredient/useringredient/application/UserIngredientServiceImpl.java
@@ -1,8 +1,11 @@
 package com.cookeep.cookeep.domain.ingredient.useringredient.application;
 
 import com.cookeep.cookeep.api.dto.request.UserIngredientCreateRequestDto;
+import com.cookeep.cookeep.api.dto.request.UserIngredientPreviewRequestDto;
 import com.cookeep.cookeep.api.dto.response.UserIngredientCreateResponseDto;
 import com.cookeep.cookeep.api.dto.response.UserIngredientListCreateResponseDto;
+import com.cookeep.cookeep.api.dto.response.UserIngredientListPreviewResponseDto;
+import com.cookeep.cookeep.api.dto.response.UserIngredientPreviewResponseDto;
 import com.cookeep.cookeep.common.exception.AppException;
 import com.cookeep.cookeep.common.exception.ErrorCode;
 import com.cookeep.cookeep.domain.ingredient.common.domain.Storage;
@@ -36,6 +39,34 @@ public class UserIngredientServiceImpl implements UserIngredientService {
     private final CustomIngredientRepository customIngredientRepository;
     private final UserRepository userRepository;
 
+    // 1. 기본 정보 조회 (저장 안 함)
+    @Override
+    @Transactional(readOnly = true)
+    public UserIngredientListPreviewResponseDto previewAll(List<UserIngredientPreviewRequestDto> requests) {
+        List<UserIngredientPreviewResponseDto> results = requests.stream()
+                .map(this::previewOne)
+                .toList();
+
+        return UserIngredientListPreviewResponseDto.of(results);
+    }
+
+    private UserIngredientPreviewResponseDto previewOne(UserIngredientPreviewRequestDto req) {
+        if (req.getType() == Type.DEFAULT) {
+            DefaultIngredient ref = defaultIngredientRepository.findById(req.getReferenceId())
+                    .orElseThrow(() -> new AppException(ErrorCode.INGREDIENT_REFERENCE_NOT_FOUND));
+            return UserIngredientPreviewResponseDto.ofDefault(ref);
+
+        } else if (req.getType() == Type.CUSTOM) {
+            CustomIngredient ref = customIngredientRepository.findById(req.getReferenceId())
+                    .orElseThrow(() -> new AppException(ErrorCode.INGREDIENT_REFERENCE_NOT_FOUND));
+            return UserIngredientPreviewResponseDto.ofCustom(ref);
+
+        } else {
+            throw new AppException(ErrorCode.INVALID_INGREDIENT_REQUEST);
+        }
+    }
+
+    // 2. 최종등록
     @Override
     public UserIngredientListCreateResponseDto createAll(Long userId, List<UserIngredientCreateRequestDto> requests) {
         // 유저 존재 검증

--- a/src/main/java/com/cookeep/cookeep/domain/ingredient/useringredient/application/UserIngredientServiceImpl.java
+++ b/src/main/java/com/cookeep/cookeep/domain/ingredient/useringredient/application/UserIngredientServiceImpl.java
@@ -83,17 +83,10 @@ public class UserIngredientServiceImpl implements UserIngredientService {
 
     private UserIngredientCreateResponseDto createOne(User user, UserIngredientCreateRequestDto req) {
 
-        // null 요청 & type & referenceId 검증
-        if (req == null || req.getType() == null || req.getReferenceId() == null) {
-            throw new AppException(ErrorCode.INVALID_INGREDIENT_REQUEST);
-        }
-
         if (req.getType() == Type.DEFAULT) {
             return createFromDefault(user, req);
-        } else if (req.getType() == Type.CUSTOM) {
-            return createFromCustom(user, req);
         } else {
-            throw new AppException(ErrorCode.INVALID_INGREDIENT_REQUEST);
+            return createFromCustom(user, req);
         }
 
     }

--- a/src/main/java/com/cookeep/cookeep/domain/ingredient/useringredient/application/UserIngredientServiceImpl.java
+++ b/src/main/java/com/cookeep/cookeep/domain/ingredient/useringredient/application/UserIngredientServiceImpl.java
@@ -3,6 +3,7 @@ package com.cookeep.cookeep.domain.ingredient.useringredient.application;
 import com.cookeep.cookeep.api.dto.request.UserIngredientCreateRequestDto;
 import com.cookeep.cookeep.api.dto.response.UserIngredientCreateResponseDto;
 import com.cookeep.cookeep.api.dto.response.UserIngredientListCreateResponseDto;
+import com.cookeep.cookeep.common.exception.AppException;
 import com.cookeep.cookeep.common.exception.ErrorCode;
 import com.cookeep.cookeep.domain.ingredient.common.domain.Storage;
 import com.cookeep.cookeep.domain.ingredient.common.domain.Type;
@@ -14,6 +15,7 @@ import com.cookeep.cookeep.domain.ingredient.defaultingredient.entity.DefaultIng
 import com.cookeep.cookeep.domain.ingredient.useringredient.dao.UserIngredientRepository;
 import com.cookeep.cookeep.domain.ingredient.useringredient.entity.UserIngredient;
 import com.cookeep.cookeep.domain.user.dao.UserRepository;
+import com.cookeep.cookeep.domain.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -37,27 +39,27 @@ public class UserIngredientServiceImpl implements UserIngredientService {
     @Override
     public UserIngredientListCreateResponseDto createAll(Long userId, List<UserIngredientCreateRequestDto> requests) {
         // 유저 존재 검증
-        userRepository.findById(userId)
-                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new AppException(ErrorCode.USER_NOT_FOUND));
 
         List<UserIngredientCreateResponseDto> results = requests.stream()
-                .map(req -> createOne(userId, req))
+                .map(req -> createOne(user, req))
                 .toList();
 
         return UserIngredientListCreateResponseDto.of(results);
     }
 
-    private UserIngredientCreateResponseDto createOne(Long userId, UserIngredientCreateRequestDto req) {
+    private UserIngredientCreateResponseDto createOne(User user, UserIngredientCreateRequestDto req) {
         if (req.getType() == Type.DEFAULT) {
-            return createFromDefault(userId, req);
+            return createFromDefault(user, req);
         } else {
-            return createFromCustom(userId, req);
+            return createFromCustom(user, req);
         }
     }
 
-    private UserIngredientCreateResponseDto createFromDefault(Long userId, UserIngredientCreateRequestDto req) {
+    private UserIngredientCreateResponseDto createFromDefault(User user, UserIngredientCreateRequestDto req) {
         DefaultIngredient ref = defaultIngredientRepository.findById(req.getReferenceId())
-                .orElseThrow(() -> new BusinessException(ErrorCode.INGREDIENT_REFERENCE_NOT_FOUND));
+                .orElseThrow(() -> new AppException(ErrorCode.INGREDIENT_REFERENCE_NOT_FOUND));
 
         int quantity = req.getQuantity()!= null ? req.getQuantity():DEFAULT_QUANTITY;
         Unit unit = req.getUnit()!= null ? req.getUnit():ref.getUnit();
@@ -66,7 +68,7 @@ public class UserIngredientServiceImpl implements UserIngredientService {
         String memo = req.getMemo();
 
         UserIngredient entity = UserIngredient.builder()
-                .userId(userId)
+                .user(user)
                 .type(Type.DEFAULT)
                 .referenceId(ref.getId())
                 .quantity(quantity)
@@ -81,9 +83,9 @@ public class UserIngredientServiceImpl implements UserIngredientService {
         return UserIngredientCreateResponseDto.of(entity, ref.getIngredient(), ref.getImageUrl());
     }
 
-    private UserIngredientCreateResponseDto createFromCustom(Long userId, UserIngredientCreateRequestDto req) {
+    private UserIngredientCreateResponseDto createFromCustom(User user, UserIngredientCreateRequestDto req) {
         CustomIngredient ref = customIngredientRepository.findById(req.getReferenceId())
-                .orElseThrow(() -> new BusinessException(ErrorCode.INGREDIENT_REFERENCE_NOT_FOUND));
+                .orElseThrow(() -> new AppException(ErrorCode.INGREDIENT_REFERENCE_NOT_FOUND));
 
         int quantity = req.getQuantity()!= null ? req.getQuantity():DEFAULT_QUANTITY;
         Unit unit = req.getUnit()!= null ? req.getUnit():DEFAULT_CUSTOM_UNIT;
@@ -92,7 +94,7 @@ public class UserIngredientServiceImpl implements UserIngredientService {
         String memo = req.getMemo();
 
         UserIngredient entity = UserIngredient.builder()
-                .userId(userId)
+                .user(user)
                 .type(Type.CUSTOM)
                 .referenceId(ref.getId())
                 .quantity(quantity)

--- a/src/main/java/com/cookeep/cookeep/domain/ingredient/useringredient/application/UserIngredientServiceImpl.java
+++ b/src/main/java/com/cookeep/cookeep/domain/ingredient/useringredient/application/UserIngredientServiceImpl.java
@@ -17,6 +17,7 @@ import com.cookeep.cookeep.domain.ingredient.defaultingredient.dao.DefaultIngred
 import com.cookeep.cookeep.domain.ingredient.defaultingredient.entity.DefaultIngredient;
 import com.cookeep.cookeep.domain.ingredient.useringredient.dao.UserIngredientRepository;
 import com.cookeep.cookeep.domain.ingredient.useringredient.entity.UserIngredient;
+import com.cookeep.cookeep.domain.mycookeep.application.ConsumptionReportService;
 import com.cookeep.cookeep.domain.user.dao.UserRepository;
 import com.cookeep.cookeep.domain.user.entity.User;
 import lombok.RequiredArgsConstructor;
@@ -37,6 +38,7 @@ public class UserIngredientServiceImpl implements UserIngredientService {
     private final UserIngredientRepository userIngredientRepository;
     private final DefaultIngredientRepository defaultIngredientRepository;
     private final CustomIngredientRepository customIngredientRepository;
+    private final ConsumptionReportService consumptionReportService;
     private final UserRepository userRepository;
 
     // 1. 기본 정보 조회 (저장 안 함)
@@ -112,7 +114,10 @@ public class UserIngredientServiceImpl implements UserIngredientService {
                 .memo(memo)
                 .build();
 
-        userIngredientRepository.save(entity);
+        UserIngredient saved = userIngredientRepository.save(entity);
+
+        // 주간 소비 리포트용 로그 생성
+        consumptionReportService.createLogForNewIngredient(user, saved);
 
         return UserIngredientCreateResponseDto.of(entity, ref.getIngredient(), ref.getImageUrl());
     }
@@ -139,7 +144,10 @@ public class UserIngredientServiceImpl implements UserIngredientService {
                 .memo(memo)
                 .build();
 
-        userIngredientRepository.save(entity);
+        UserIngredient saved = userIngredientRepository.save(entity);
+
+        // 주간 소비 리포트용 로그 생성
+        consumptionReportService.createLogForNewIngredient(user, saved);
 
         return UserIngredientCreateResponseDto.of(entity, ref.getName(), ref.getImageUrl());
     }

--- a/src/main/java/com/cookeep/cookeep/domain/ingredient/useringredient/application/UserIngredientServiceImpl.java
+++ b/src/main/java/com/cookeep/cookeep/domain/ingredient/useringredient/application/UserIngredientServiceImpl.java
@@ -125,7 +125,8 @@ public class UserIngredientServiceImpl implements UserIngredientService {
     }
 
     private UserIngredientCreateResponseDto createFromCustom(User user, UserIngredientCreateRequestDto req) {
-        CustomIngredient ref = customIngredientRepository.findById(req.getReferenceId())
+        CustomIngredient ref = customIngredientRepository
+                .findByIdAndUserId(req.getReferenceId(), user.getUserId())
                 .orElseThrow(() -> new AppException(ErrorCode.INGREDIENT_REFERENCE_NOT_FOUND));
 
         int quantity = req.getQuantity()!= null ? req.getQuantity():DEFAULT_QUANTITY;

--- a/src/main/java/com/cookeep/cookeep/domain/ingredient/useringredient/application/UserIngredientServiceImpl.java
+++ b/src/main/java/com/cookeep/cookeep/domain/ingredient/useringredient/application/UserIngredientServiceImpl.java
@@ -42,22 +42,23 @@ public class UserIngredientServiceImpl implements UserIngredientService {
     // 1. 기본 정보 조회 (저장 안 함)
     @Override
     @Transactional(readOnly = true)
-    public UserIngredientListPreviewResponseDto previewAll(List<UserIngredientPreviewRequestDto> requests) {
+    public UserIngredientListPreviewResponseDto previewAll(Long userId, List<UserIngredientPreviewRequestDto> requests) {
         List<UserIngredientPreviewResponseDto> results = requests.stream()
-                .map(this::previewOne)
+                .map(req -> previewOne(userId, req))
                 .toList();
 
         return UserIngredientListPreviewResponseDto.of(results);
     }
 
-    private UserIngredientPreviewResponseDto previewOne(UserIngredientPreviewRequestDto req) {
+    private UserIngredientPreviewResponseDto previewOne(Long userId, UserIngredientPreviewRequestDto req) {
         if (req.getType() == Type.DEFAULT) {
             DefaultIngredient ref = defaultIngredientRepository.findById(req.getReferenceId())
                     .orElseThrow(() -> new AppException(ErrorCode.INGREDIENT_REFERENCE_NOT_FOUND));
             return UserIngredientPreviewResponseDto.ofDefault(ref);
 
         } else if (req.getType() == Type.CUSTOM) {
-            CustomIngredient ref = customIngredientRepository.findById(req.getReferenceId())
+            CustomIngredient ref = customIngredientRepository
+                    .findByIdAndUserId(req.getReferenceId(), userId)
                     .orElseThrow(() -> new AppException(ErrorCode.INGREDIENT_REFERENCE_NOT_FOUND));
             return UserIngredientPreviewResponseDto.ofCustom(ref);
 

--- a/src/main/java/com/cookeep/cookeep/domain/ingredient/useringredient/entity/UserIngredient.java
+++ b/src/main/java/com/cookeep/cookeep/domain/ingredient/useringredient/entity/UserIngredient.java
@@ -10,6 +10,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
 
 import java.time.LocalDate;
 


### PR DESCRIPTION
# Issue
#150

# Description
- 식재료 등록 방식을 두 단계로 나눠서 실행
- 1. /api/users/me/ingredients/preview : 식재료 기본 정보 조회 (DB에 저장된 정보 조회)
- 2. /api/users/me/ingredients : 유저가 기본 정보 수정/추가 정보 입력하여 냉장고에 최종 등록
- 식재료 등록 시 등록일자 추가

# Changes 
- 신규 DTO (식재료 등록용) 추가: UserIngredientPreview Request/Response, UserIngredientPreviewList Reqeust/Response
- 서비스 및 컨트롤러 코드 수정: 수정된 API 방식 적용
- UserIngredient entity 수정: 식재료 등록시 등록일자 등록되도록 수정 (createdAt)

# Test Checklist
- [x] preview  api 호출 시 기본 정보 조회 확인
- [x] 식재료 최종 등록 시 정보 등록 확인
- [x] 선택 필드 유저 입력대로 등록 확인
- [x] 식재료 등록 시 등록일자 조회 확인