### PR TITLE
feature: 커스텀 식재료 삭제 api 구현

### DIFF
--- a/src/main/java/com/cookeep/cookeep/api/controller/CustomIngredientController.java
+++ b/src/main/java/com/cookeep/cookeep/api/controller/CustomIngredientController.java
@@ -20,7 +20,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
-@Tag( name = "(MAIN01) 커스텀 재료 등록", description = "커스텀 식재료 관리 API")
+@Tag( name = "(MAIN01-1) 커스텀 재료 등록", description = "커스텀 식재료 관리 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/users/me/ingredients/custom")

--- a/src/main/java/com/cookeep/cookeep/api/controller/CustomIngredientController.java
+++ b/src/main/java/com/cookeep/cookeep/api/controller/CustomIngredientController.java
@@ -29,7 +29,7 @@ public class CustomIngredientController {
     private final CustomIngredientService customIngredientService;
     private final JwtTokenProvider jwtTokenProvider;
 
-    @Operation( summary = "커스텀 식재료 등록", description = "유저가 새로운 커스텀 식재료를 등록합니다."
+    @Operation( summary = "1. 커스텀 식재료 등록", description = "유저가 새로운 커스텀 식재료를 등록합니다."
     )
     @ApiErrorCodeExamples({
             ErrorCode.CUSTOM_INGREDIENT_REQUIRED_FIELDS_MISSING,
@@ -71,5 +71,38 @@ public class CustomIngredientController {
         return ResponseEntity
                 .status(HttpStatus.CREATED)
                 .body(DataResponse.created(response));
+    }
+
+    @Operation(summary = "2. 커스텀 식재료 삭제", description = "유저가 본인이 등록한 커스텀 식재료를 삭제합니다.")
+    @ApiErrorCodeExamples({
+            ErrorCode.INGREDIENT_REFERENCE_NOT_FOUND,
+            ErrorCode.UNAUTHORIZED,
+            ErrorCode.INTERNAL_SERVER_ERROR
+    })
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "커스텀 식재료 삭제 성공"),
+            @ApiResponse(responseCode = "401", description = """
+            인증 실패입니다. 다음 오류가 발생할 수 있습니다:
+            - UNAUTHORIZED: 인증 정보가 없거나 유효하지 않습니다.
+            """, content = @Content),
+            @ApiResponse(responseCode = "404", description = """
+            리소스를 찾을 수 없습니다. 다음 오류가 발생할 수 있습니다:
+            - INGREDIENT_REFERENCE_NOT_FOUND: 커스텀 식재료가 존재하지 않습니다.
+            """, content = @Content),
+            @ApiResponse(responseCode = "500", description = """
+            서버 오류입니다. 다음 오류가 발생할 수 있습니다:
+            - INTERNAL_SERVER_ERROR: 서버 내부 오류가 발생했습니다.
+            """, content = @Content)
+    })
+    @DeleteMapping("/{customIngredientId}")
+    public ResponseEntity<DataResponse<Void>> deleteCustomIngredient(
+            @AuthenticationPrincipal(expression = "userId") Long userId,
+            @PathVariable Long customIngredientId
+    ) {
+        customIngredientService.delete(userId, customIngredientId);
+
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(DataResponse.ok());
     }
 }

--- a/src/main/java/com/cookeep/cookeep/api/dto/response/CustomIngredientCreateResponseDto.java
+++ b/src/main/java/com/cookeep/cookeep/api/dto/response/CustomIngredientCreateResponseDto.java
@@ -23,7 +23,7 @@ public class CustomIngredientCreateResponseDto {
 
     @Schema(
             description = "커스텀 식재료 이름",
-            example = "두쫀쿠"
+            example = "킹스베리딸기"
     )
     private String name;
 
@@ -41,7 +41,7 @@ public class CustomIngredientCreateResponseDto {
 
     @Schema(
             description = "식재료 카테고리",
-            example = "PROCESSED"
+            example = "FRUIT"
     )
     private Category category;
 

--- a/src/main/java/com/cookeep/cookeep/domain/ingredient/customingredient/application/CustomIngredientService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/ingredient/customingredient/application/CustomIngredientService.java
@@ -70,16 +70,11 @@ public class CustomIngredientService {
 
     public void delete(Long userId, Long customIngredientId) {
 
-        // 1. 유저 인증 확인
-        if (userId == null) {
-            throw new AppException(ErrorCode.UNAUTHORIZED);
-        }
-
-        // 2. 커스텀 식재료 존재 여부 + 소유자 검증 (한 번에)
+        // 1. 커스텀 식재료 존재 여부 + 소유자 검증 (한 번에)
         CustomIngredient ingredient = repository.findByIdAndUserId(customIngredientId, userId)
                 .orElseThrow(() -> new AppException(ErrorCode.INGREDIENT_REFERENCE_NOT_FOUND));
 
-        // 3. 삭제
+        // 2. 삭제
         repository.delete(ingredient);
     }
 }

--- a/src/main/java/com/cookeep/cookeep/domain/ingredient/customingredient/application/CustomIngredientService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/ingredient/customingredient/application/CustomIngredientService.java
@@ -67,4 +67,19 @@ public class CustomIngredientService {
         return CustomIngredientCreateResponseDto.from(saved);
 
     }
+
+    public void delete(Long userId, Long customIngredientId) {
+
+        // 1. 유저 인증 확인
+        if (userId == null) {
+            throw new AppException(ErrorCode.UNAUTHORIZED);
+        }
+
+        // 2. 커스텀 식재료 존재 여부 + 소유자 검증 (한 번에)
+        CustomIngredient ingredient = repository.findByIdAndUserId(customIngredientId, userId)
+                .orElseThrow(() -> new AppException(ErrorCode.INGREDIENT_REFERENCE_NOT_FOUND));
+
+        // 3. 삭제
+        repository.delete(ingredient);
+    }
 }


### PR DESCRIPTION
# Issue
#155 

# Description
- 커스텀 식재료 삭제용 API 구현
- 유저 본인 식재료만 제거 가능하도록 검증 로직 구현
- 존재하지 않는 식재료 삭제 시도 시 404 에러 발생

# Changes
- service에 delete 메서드 구현
- controller에 deleteCustomIngredient 메서드 구현
- 요청 DTO description 수정

# Test Checklist
- [x] 커스텀 식재료 제거 동작 확인
- [x] 에러처리 정상 동작 확인