### PR TITLE
fix: 회원가입 시 비밀번호 특수문자 허용

### DIFF
--- a/src/main/java/com/cookeep/cookeep/api/dto/request/SignupRequestDTO.java
+++ b/src/main/java/com/cookeep/cookeep/api/dto/request/SignupRequestDTO.java
@@ -19,10 +19,10 @@ public record SignupRequestDTO(
 	@Email(message = "이메일 주소를 다시 확인해주세요")
 	String email,
 
-	// 영문, 숫자 포함 8자 이상 값
+	// 영문, 숫자 포함 8자 이상 값, 특수문자는 선택사항
 	@NotBlank(message = "비밀번호는 필수 입력 값입니다.")
 	@Pattern(
-		regexp = "^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d]{8,}$",
+		regexp = "^(?=.*[A-Za-z])(?=.*\\d).{8,}$",
 		message = "영문, 숫자 포함 8자 이상의 비밀번호를 사용해주세요"
 	)
 	String password,


### PR DESCRIPTION
# Related Issue  
#151
</br></br>

# Description  
## 회원가입 시 비밀번호 특수문자 허용
- SignupRequestDTO 내 Pattern 수정을 통해 특수문자 입력을 허용하도록 함
- 특수문자는 필수 X 선택사항
</br></br>

# Changes

- SignupRequestDTO 수정
