### PR TITLE
Refactor: ai schema 규칙 적용

### DIFF
--- a/src/main/java/com/cookeep/cookeep/domain/recipe/application/GeminiService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/recipe/application/GeminiService.java
@@ -175,10 +175,14 @@ public class GeminiService {
         return "당신은 요리 레시피 전문가입니다.\n\n" +
                 "[난이도] " + difficulty.name() + "\n" +
                 exclusionBlock + "\n" +
-                "[규칙]\n" +
+                "[재료 구성 규칙]\n" +
+                // 규칙 1: user_ingredients — 원본 데이터 그대로 사용
                 "1. user_ingredients의 ingredientId, name, unit은 아래 데이터 값 그대로 사용하세요. quantity는 0보다 큰 양수로 생성하세요.\n" +
-                "2. additional_ingredients는 레시피에 반드시 필요한 추가 재료만 포함하세요.\n" +
-                "3. optional_ingredients는 user_ingredients 또는 additional_ingredients에 이미 존재하는 재료만 사용하세요. " +
+                // 규칙 2: additional_ingredients — 레시피에 필요한 추가 재료 (필수/선택/대체 포함)
+                "2. additional_ingredients는 레시피에 필요한 추가 재료 목록입니다. 필수 재료뿐 아니라 없어도 되는 재료나 다른 재료로 대체 가능한 재료도 모두 이 목록에 먼저 추가하세요.\n" +
+                // 규칙 3: optional_ingredients — additional_ingredients에서만 선택
+                "3. optional_ingredients는 additional_ingredients에 이미 추가한 재료 중 일부를 선택해서 '생략 가능' 또는 '대체 가능' 여부를 표시하는 목록입니다. " +
+                "additional_ingredients에 없는 새로운 재료를 이 목록에 추가하는 것은 절대 금지합니다. " +
                 "description은 \"이 재료는 [대체재료]로 대체 가능합니다\" 또는 \"이 재료는 생략 가능합니다\" 중 하나로만 작성하세요.\n" +
                 "4. youtube_search_queries는 한국어 검색어 1~3개를 작성하세요.\n" +
                 "5. steps는 단계별 조리 방법을 작성하세요.\n\n" +

--- a/src/main/java/com/cookeep/cookeep/domain/recipe/application/GeminiService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/recipe/application/GeminiService.java
@@ -160,51 +160,29 @@ public class GeminiService {
             List<String> excludedTitles) {
 
         // 재료 리스트 (이름 + 단위만)
-        String ingredientList = ingredients.stream()
-                .map(i -> String.format("%s (%s 단위)", i.getName(), i.getUnit()))
-                .collect(Collectors.joining(", "));
-
-        // JSON 형식 (type, referenceId, name, unit만 전달)
         String ingredientsJson = ingredients.stream()
                 .map(i -> String.format(
-                        "{ \"ingredientId\": %d, \"name\": \"%s\", \"unit\": \"%s\" }",
+                        "{\"ingredientId\":%d,\"name\":\"%s\",\"unit\":\"%s\"}",
                         i.getIngredientId(), i.getName(), i.getUnit()))
-                .collect(Collectors.joining(",\n    ", "[\n    ", "\n  ]"));
+                .collect(Collectors.joining(",", "[", "]"));
 
-        // 제외할 요리 (레시피 재요청 시 이전 요리 제외)
-        String exclusionBlock = "";
-        if (excludedTitles != null && !excludedTitles.isEmpty()) {
-            exclusionBlock = excludedTitles.stream()
-                    .map(t -> "- " + t)
-                    .collect(Collectors.joining("\n"));
-        }
+        // 레시피 재요청 시 이전 요리 제외 (첫 요청은 제외)
+        String exclusionBlock = (excludedTitles == null || excludedTitles.isEmpty()) ? "" :
+                "\n[제외할 요리]\n" +
+                        excludedTitles.stream().map(t -> "- " + t).collect(Collectors.joining("\n")) +
+                        "\n위 요리와 겹치지 않는 새로운 레시피를 추천하세요.\n";
 
-        return """
-        당신은 요리 레시피 전문가입니다.
-        
-        [사용 가능한 재료]
-        %s
-        
-        [난이도]
-        %s
-        
-        [제외할 요리]
-        %s
-        위 요리와 겹치지 않는 새로운 레시피를 추천하세요.
-        
-        [규칙]
-        1. user_ingredients 의 ingredientId, name, unit 은 반드시 아래 제공된 값을 그대로 사용하세요.
-           각 재료의 quantity(수량)는 0보다 큰 양수로 생성하세요.
-        2. additional_ingredients 는 레시피에 반드시 필요한 추가 재료만 포함하세요.
-        3. optional_ingredients 는 user_ingredients 또는 additional_ingredients 에 이미 존재하는 재료만 사용하세요.
-           description 은 아래 두 형식 중 하나로만 작성하세요:
-           - "이 재료는 [대체재료]로 대체 가능합니다"  (대체재료는 반드시 목록에 존재하는 재료여야 함)
-           - "이 재료는 생략 가능합니다"
-        4. youtube_search_queries 는 이 레시피를 검색할 한국어 검색어 1~3개를 작성하세요.
-        5. steps 는 간결하고 실용적인 단계별 조리 방법을 작성하세요.
-
-        [user_ingredients 기준 데이터]
-        %s
-        """.formatted(ingredientList, difficulty.name(), exclusionBlock, ingredientsJson);
+        return "당신은 요리 레시피 전문가입니다.\n\n" +
+                "[난이도] " + difficulty.name() + "\n" +
+                exclusionBlock + "\n" +
+                "[규칙]\n" +
+                "1. user_ingredients의 ingredientId, name, unit은 아래 데이터 값 그대로 사용하세요. quantity는 0보다 큰 양수로 생성하세요.\n" +
+                "2. additional_ingredients는 레시피에 반드시 필요한 추가 재료만 포함하세요.\n" +
+                "3. optional_ingredients는 user_ingredients 또는 additional_ingredients에 이미 존재하는 재료만 사용하세요. " +
+                "description은 \"이 재료는 [대체재료]로 대체 가능합니다\" 또는 \"이 재료는 생략 가능합니다\" 중 하나로만 작성하세요.\n" +
+                "4. youtube_search_queries는 한국어 검색어 1~3개를 작성하세요.\n" +
+                "5. steps는 단계별 조리 방법을 작성하세요.\n\n" +
+                "[user_ingredients]\n" +
+                ingredientsJson + "\n";
     }
 }

--- a/src/main/java/com/cookeep/cookeep/domain/recipe/application/GeminiService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/recipe/application/GeminiService.java
@@ -39,7 +39,7 @@ public class GeminiService {
     public GeminiRecipeResponseDto generateRecipe(
             List<IngredientDetailDto> ingredients,
             Difficulty difficulty) {
-        return generateRecipeByPrompt(buildPrompt(ingredients, difficulty));
+        return generateRecipeByPrompt(buildPrompt(ingredients, difficulty, List.of()));
     }
 
     public GeminiRecipeResponseDto generateRecipeWithExclusion(
@@ -47,25 +47,24 @@ public class GeminiService {
             Difficulty difficulty,
             List<String> excludedTitles
     ) {
-        String prompt = buildPrompt(ingredients, difficulty);
-
-        if (!excludedTitles.isEmpty()) {
-            prompt += "\n\n이전에 추천한 다음 요리는 제외하고 추천해줘:\n";
-            for (String title : excludedTitles) {
-                prompt += "- " + title + "\n";
-            }
-        }
-
-        prompt += "\n기존 요리와 겹치지 않는 새로운 레시피를 추천해줘.";
-
-        return generateRecipeByPrompt(prompt);
+        return generateRecipeByPrompt(buildPrompt(ingredients, difficulty, excludedTitles));
     }
-
 
     // 레시피 생성
     public GeminiRecipeResponseDto generateRecipeByPrompt(String prompt) {
         try {
+
+            log.info("========== Gemini 요청 시작 ==========");
+            log.info("Gemini model = {}", model);
+            log.info("Prompt length = {}", prompt.length());
+            log.debug("Prompt 내용 = \n{}", prompt);
+
             GeminiRecipeRequestDto requestBody = GeminiRecipeRequestDto.from(prompt);
+
+            log.info("Gemini requestBody 생성 완료");
+            log.debug("Gemini requestBody JSON = {}", objectMapper.writeValueAsString(requestBody));
+
+            log.info("Gemini API 호출 시작");
 
             String response = webClient.post()
                     .uri(uriBuilder -> uriBuilder
@@ -81,6 +80,7 @@ public class GeminiService {
                     .bodyToMono(String.class)
                     .block();
 
+            log.info("Gemini API 응답 수신 완료");
             log.info("Gemini raw response = {}", response);
 
             return parseResponse(response);
@@ -107,27 +107,26 @@ public class GeminiService {
             JsonNode root = objectMapper.readTree(responseBody);
 
             JsonNode textNode = root
-                    .path("candidates")
-                    .path(0)
-                    .path("content")
-                    .path("parts")
-                    .path(0)
+                    .path("candidates").path(0)
+                    .path("content").path("parts").path(0)
                     .path("text");
 
             if (textNode.isMissingNode() || textNode.isNull()) {
                 throw new AppException(ErrorCode.AI_RESPONSE_INVALID_FORMAT);
             }
 
+            // 펜스가 있으면 제거 (에러 방지)
             String rawText = textNode.asText().trim();
+            if (rawText.startsWith("```")) {
+                rawText = rawText
+                        .replaceAll("```json\\n?", "")
+                        .replaceAll("\\n?```", "")
+                        .trim();
+            }
 
-            String cleanedJson = rawText
-                    .replaceAll("```json\\n?", "")
-                    .replaceAll("\\n?```", "")
-                    .trim();
+            log.info("[Gemini Parsed JSON]\n{}", rawText);
 
-            log.info("[Gemini Parsed JSON]\n{}", cleanedJson);
-
-            GeminiRecipeResponseDto result = objectMapper.readValue(cleanedJson, GeminiRecipeResponseDto.class);
+            GeminiRecipeResponseDto result = objectMapper.readValue(rawText, GeminiRecipeResponseDto.class);
 
             // 필수 필드 검증
             validateRecipeResponse(result);
@@ -155,13 +154,14 @@ public class GeminiService {
     }
 
     // 프롬프트 생성
-    private String buildPrompt(List<IngredientDetailDto> ingredients, Difficulty difficulty) {
+    private String buildPrompt(
+            List<IngredientDetailDto> ingredients,
+            Difficulty difficulty,
+            List<String> excludedTitles) {
 
         // 재료 리스트 (이름 + 단위만)
         String ingredientList = ingredients.stream()
-                .map(i -> String.format("%s (%s 단위 사용)",
-                        i.getName(),
-                        i.getUnit()))
+                .map(i -> String.format("%s (%s 단위)", i.getName(), i.getUnit()))
                 .collect(Collectors.joining(", "));
 
         // JSON 형식 (type, referenceId, name, unit만 전달)
@@ -171,10 +171,16 @@ public class GeminiService {
                         i.getIngredientId(), i.getName(), i.getUnit()))
                 .collect(Collectors.joining(",\n    ", "[\n    ", "\n  ]"));
 
+        // 제외할 요리 (레시피 재요청 시 이전 요리 제외)
+        String exclusionBlock = "";
+        if (excludedTitles != null && !excludedTitles.isEmpty()) {
+            exclusionBlock = excludedTitles.stream()
+                    .map(t -> "- " + t)
+                    .collect(Collectors.joining("\n"));
+        }
+
         return """
         당신은 요리 레시피 전문가입니다.
-        당신은 JSON만 출력하는 시스템입니다.
-        설명 없이 반드시 유효한 JSON 객체 하나만 반환하세요.
         
         [사용 가능한 재료]
         %s
@@ -182,62 +188,23 @@ public class GeminiService {
         [난이도]
         %s
         
-        [규칙]
-        1. 각 재료의 적절한 수량(quantity)을 생성하세요.
-           - 수량은 반드시 0보다 큰 양수여야 합니다. (0은 절대 불가)
-           - 소수점 첫 번째 자리까지 표현 가능합니다. 예: 0.5, 1, 1.5, 2
-        2. 추가로 필요한 재료가 있다면 additional_ingredients에 포함하세요.
-        3. user_ingredients에는 반드시 제공된 ingredientId, name, quantity, unit 값 그대로 사용하세요.
-        4. additional_ingredients에는 레시피에 반드시 필요한 추가 재료만 포함하세요.
-           - description 필드는 절대 생성하지 마세요. null로 들어가도록 하세요.
-        5. optional_ingredients에는 절대 새로운 재료를 생성하지 마세요.
-           - 반드시 user_ingredients 또는 additional_ingredients에 이미 존재하는 재료만 사용하세요.
-           - 위 두 목록에 없는 새로운 재료를 생성하는 것은 절대 금지합니다.
-           - optional_ingredients에 포함된 재료는 반드시 user_ingredients 또는 additional_ingredients 중 하나와 동일한 name을 가져야 합니다.
-           - description 필드는 반드시 포함해야 합니다.
-           - description은 반드시 아래 두 형식 중 하나로만 작성하세요:
-             1) "이 재료는 [다른 재료]로 대체 가능합니다"
-               - [다른 재료]는 반드시 user_ingredients 또는 additional_ingredients에 존재하는 실제 재료명을 사용하세요.
-               - 존재하지 않는 재료명은 절대 사용하지 마세요.
-             2) "이 재료는 생략 가능합니다"
-            - 위 형식 외의 문장은 절대 생성하지 마세요.
-        6. additional_ingredients와 optional_ingredients의 unit은 반드시 아래 목록 중 하나만 사용하세요:
-           [개, 팩, 봉지, 병, 묶음, 캔, g, ml, 티스푼, 테이블스푼]
-           - 위 목록에 없는 단위는 절대 사용하지 마세요.
-           - user_ingredients에는 해당 단위 제한을 적용하지 않습니다.
-        7. youtube_search_queries에는 이 레시피를 유튜브에서 검색할 때 사용할 한국어 검색어를 1~3개 작성하세요.
-           - 실제로 유튜브에서 검색했을 때 관련 영상이 나올만한 구체적인 표현을 사용하세요.
-           - 예: "김치볶음밥 만들기", "간단한 김치볶음밥 레시피"
-        8. URL이나 링크는 절대 생성하지 마세요. 검색어만 제공하세요.
-        9. steps는 간결하고 실용적인 요리 방법을 단계별로 작성하세요.
-        10. 반드시 JSON만 응답하세요. 설명 문구는 절대 포함하지 마세요.
+        [제외할 요리]
+        %s
+        위 요리와 겹치지 않는 새로운 레시피를 추천하세요.
         
-        [응답 형식]
-        {
-          "title": "요리 제목",
-          "ingredients": {
-            "user_ingredients": %s,
-            "additional_ingredients": [
-              {"name": "간장", "quantity": 2.0, "unit": "GRAM"}
-            ],
-            "optional_ingredients": [
-              {"name": "참기름", "quantity": 0.5, "unit": "GRAM"}
-            ]
-          },
-          "steps": [
-            "1. 양파를 채썬다.",
-            "2. 팬에 기름을 두르고 양파를 볶는다.",
-            "3. 간장으로 간을 맞춘다."
-          ],
-          "youtube_search_queries": [
-           "김치볶음밥 만들기",
-           "간단한 김치볶음밥 레시피"
-         ]
-        }
-        """.formatted(
-                ingredientList,
-                difficulty.name(),
-                ingredientsJson
-        );
+        [규칙]
+        1. user_ingredients 의 ingredientId, name, unit 은 반드시 아래 제공된 값을 그대로 사용하세요.
+           각 재료의 quantity(수량)는 0보다 큰 양수로 생성하세요.
+        2. additional_ingredients 는 레시피에 반드시 필요한 추가 재료만 포함하세요.
+        3. optional_ingredients 는 user_ingredients 또는 additional_ingredients 에 이미 존재하는 재료만 사용하세요.
+           description 은 아래 두 형식 중 하나로만 작성하세요:
+           - "이 재료는 [대체재료]로 대체 가능합니다"  (대체재료는 반드시 목록에 존재하는 재료여야 함)
+           - "이 재료는 생략 가능합니다"
+        4. youtube_search_queries 는 이 레시피를 검색할 한국어 검색어 1~3개를 작성하세요.
+        5. steps 는 간결하고 실용적인 단계별 조리 방법을 작성하세요.
+
+        [user_ingredients 기준 데이터]
+        %s
+        """.formatted(ingredientList, difficulty.name(), exclusionBlock, ingredientsJson);
     }
 }

--- a/src/main/java/com/cookeep/cookeep/domain/recipe/dto/GeminiRecipeRequestDto.java
+++ b/src/main/java/com/cookeep/cookeep/domain/recipe/dto/GeminiRecipeRequestDto.java
@@ -5,6 +5,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 import java.util.List;
+import java.util.Map;
 
 @Schema(
         name = "GeminiRecipeRequest",
@@ -14,22 +15,94 @@ import java.util.List;
 @AllArgsConstructor
 public class GeminiRecipeRequestDto {
 
-    @Schema(
-            description = "Gemini API에 전달되는 콘텐츠 목록",
-            requiredMode = Schema.RequiredMode.REQUIRED
-    )
     private List<Content> contents;
+    private GenerationConfig generationConfig;
 
     public static GeminiRecipeRequestDto from(String prompt) {
         return new GeminiRecipeRequestDto(
-                List.of(
-                        new Content(
-                                List.of(new Part(prompt))
-                        )
-                )
+                List.of(new Content(List.of(new Part(prompt)))),
+                buildGenerationConfig()
         );
     }
 
+
+    // 응답 스키마 정의
+    private static GenerationConfig buildGenerationConfig() {
+
+        // unit enum (additional / optional 에만 적용)
+        Map<String, Object> unitEnum = Map.of(
+                "type", "string",
+                "enum", List.of("개", "팩", "봉지", "병", "묶음", "캔", "g", "ml", "티스푼", "테이블스푼")
+        );
+
+        // user_ingredients
+        Map<String, Object> userIngredient = Map.of(
+                "type", "object",
+                "properties", Map.of(
+                        "ingredientId", Map.of("type", "integer"),
+                        "name",         Map.of("type", "string"),
+                        "quantity",     Map.of("type", "number", "minimum", 0.1),
+                        "unit",         Map.of("type", "string")   // user 단위는 자유
+                ),
+                "required", List.of("ingredientId", "name", "quantity", "unit")
+        );
+
+        // additional_ingredients
+        Map<String, Object> additionalIngredient = Map.of(
+                "type", "object",
+                "properties", Map.of(
+                        "name",     Map.of("type", "string"),
+                        "quantity", Map.of("type", "number", "minimum", 0.1),
+                        "unit",     unitEnum
+                        // description 키 자체를 schema에 포함 안 함
+                ),
+                "required", List.of("name", "quantity", "unit")
+        );
+
+        // optional_ingredients (description 필수)
+        // description 필드 타입 string으로 제한 (required)
+        // 상세 포맷은 서비스에서 validateAiResponse 메서드로 관리
+        Map<String, Object> optionalIngredient = Map.of(
+                "type", "object",
+                "properties", Map.of(
+                        "name",        Map.of("type", "string"),
+                        "quantity",    Map.of("type", "number", "minimum", 0.1),
+                        "unit",        unitEnum,
+                        "description", Map.of("type", "string")
+                ),
+                "required", List.of("name", "description")
+        );
+
+        // ingredients 객체
+        Map<String, Object> ingredients = Map.of(
+                "type", "object",
+                "properties", Map.of(
+                        "user_ingredients",      Map.of("type", "array", "items", userIngredient),
+                        "additional_ingredients", Map.of("type", "array", "items", additionalIngredient),
+                        "optional_ingredients",   Map.of("type", "array", "items", optionalIngredient)
+                ),
+                "required", List.of("user_ingredients")
+        );
+
+        // 최상위 schema
+        Map<String, Object> schema = Map.of(
+                "type", "object",
+                "properties", Map.of(
+                        "title",       Map.of("type", "string"),
+                        "ingredients", ingredients,
+                        "steps",       Map.of("type", "array", "items", Map.of("type", "string")),
+                        "youtube_search_queries", Map.of(
+                                "type", "array",
+                                "items", Map.of("type", "string")
+                        )
+                ),
+                "required", List.of("title", "ingredients", "steps", "youtube_search_queries")
+        );
+
+        return new GenerationConfig("application/json", schema);
+    }
+
+    // 내부 메서드
     @Schema(
             name = "GeminiRecipeRequestContent",
             description = "Gemini 요청 콘텐츠 단위 DTO"
@@ -49,4 +122,12 @@ public class GeminiRecipeRequestDto {
     static class Part {
         private String text;
     }
+
+    @Getter
+    @AllArgsConstructor
+    static class GenerationConfig {
+        private String responseMimeType;
+        private Map<String, Object> responseSchema;
+    }
+
 }


### PR DESCRIPTION
# Issue
#160 

# Description
JSON Schema(responseSchema)를 활용한 Gemini API 응답 구조 강제 및 프롬프트 최적화
기존: 프롬프트 텍스트로만 AI 응답 규칙을 설명
변경: Gemini API의 generationConfig.responseSchema를 도입해 응답 구조를 schema 수준에서 제어하도록 변경했습니다. 
- 프롬프트 중복 제거 및 조건부 블록 처리로 불필요한 토큰 소모를 줄임

# Changes
GeminiRecipeRequestDto
- generationConfig 필드 추가 (responseMimeType: application/json + responseSchema)
- responseSchema로 구조적으로 강제하는 항목
- - additional_ingredients: unit 허용값을 enum으로 제한, quantity minimum 0.1 강제
- - optional_ingredients: description 필드 required 강제
- - youtube_search_queries: array of string 타입 강제
- - 최상위 필드(title, ingredients, steps, youtube_search_queries) required 강제
- Gemini 미지원 키(additionalProperties, minItems, maxItems) 제거 — 해당 키로 인한 400 에러 수정
- 불필요한 import 제거 (java.net.URI, java.util.Map)

GeminiService
- buildPrompt() 리팩토링
- - 기존 ingredientList(텍스트) + ingredientsJson(JSON) 중복 생성 → JSON 단일 포맷으로 통합
- - 제외 요리가 없는 신규 요청 시 [제외할 요리] 블록 자체를 생략하도록 수정 (빈 헤더 토큰 낭비 제거)
- - generateRecipeWithExclusion()의 별도 프롬프트 조립 로직을 buildPrompt() 단일 메서드로 통합
- optional_ingredients 규칙 명확화
- - 기존: "user_ingredients 또는 additional_ingredients에 존재하는 재료만 사용"
- - 변경: "additional_ingredients에 추가한 재료 중에서만 선택", additional에 없는 신규 재료 추가 금지 명시
- - additional/optional의 관계(optional은 additional의 부분집합)를 규칙에 명시

# Test Checklist
- [x] 레시피 생성/재생성 정상 동작 확인
- [x] optional_ingredients의 모든 재료가 additional_ingredients에 존재하는지 확인
- [x] Gemini API 400 에러 발생 시 응답 body가 로그에 출력되는지 확인