### PR TITLE
Fix: MAIN03 냉장고 검색 상세 조회 createdAt 필드 추가 및 JPQL 쿼리 버그 수정

### DIFF
--- a/src/main/java/com/cookeep/cookeep/api/dto/response/UserIngredientDetailResponseDto.java
+++ b/src/main/java/com/cookeep/cookeep/api/dto/response/UserIngredientDetailResponseDto.java
@@ -89,4 +89,7 @@ public class UserIngredientDetailResponseDto {
             requiredMode = Schema.RequiredMode.REQUIRED
     )
     private String imageUrl;
+
+    @Schema(description = "등록일자", example = "2026-04-12", type = "string", format = "date")
+    private LocalDate createdAt;
 }

--- a/src/main/java/com/cookeep/cookeep/domain/ingredient/useringredient/dao/UserIngredientRepository.java
+++ b/src/main/java/com/cookeep/cookeep/domain/ingredient/useringredient/dao/UserIngredientRepository.java
@@ -70,24 +70,16 @@ public interface UserIngredientRepository extends JpaRepository<UserIngredient, 
 
     // 카테고리별 분류 + 이름 검색 (storage 있을 때)
     @Query("""
-        SELECT ui FROM UserIngredient ui
-        WHERE ui.user.userId = :userId
-        AND ui.storage = :storage
-        AND (
-            EXISTS (
-                SELECT 1 FROM DefaultIngredient di
-                WHERE di.id = ui.referenceId
-                AND ui.type = 'DEFAULT'
-                AND LOWER(di.ingredient) LIKE LOWER(CONCAT('%', :searchQuery, '%'))
-            )
-            OR EXISTS (
-                SELECT 1 FROM CustomIngredient ci
-                WHERE ci.id = ui.referenceId
-                AND ui.type = 'CUSTOM'
-                AND LOWER(ci.name) LIKE LOWER(CONCAT('%', :searchQuery, '%'))
-            )
-        )
-    """)
+    SELECT ui FROM UserIngredient ui
+    LEFT JOIN DefaultIngredient di ON di.id = ui.referenceId AND ui.type = 'DEFAULT'
+    LEFT JOIN CustomIngredient ci ON ci.id = ui.referenceId AND ui.type = 'CUSTOM'
+    WHERE ui.user.userId = :userId
+    AND ui.storage = :storage
+    AND (
+        LOWER(di.ingredient) LIKE LOWER(CONCAT('%', :searchQuery, '%'))
+        OR LOWER(ci.name) LIKE LOWER(CONCAT('%', :searchQuery, '%'))
+    )
+""")
     Page<UserIngredient> searchIngredientsWithStorage(
             @Param("userId") Long userId,
             @Param("searchQuery") String searchQuery,
@@ -97,23 +89,15 @@ public interface UserIngredientRepository extends JpaRepository<UserIngredient, 
 
     // storage 없을 때 (전체 검색)
     @Query("""
-        SELECT ui FROM UserIngredient ui
-        WHERE ui.user.userId = :userId
-        AND (
-            EXISTS (
-                SELECT 1 FROM DefaultIngredient di
-                WHERE di.id = ui.referenceId
-                AND ui.type = 'DEFAULT'
-                AND LOWER(di.ingredient) LIKE LOWER(CONCAT('%', :searchQuery, '%'))
-            )
-            OR EXISTS (
-                SELECT 1 FROM CustomIngredient ci
-                WHERE ci.id = ui.referenceId
-                AND ui.type = 'CUSTOM'
-                AND LOWER(ci.name) LIKE LOWER(CONCAT('%', :searchQuery, '%'))
-            )
-        )
-    """)
+    SELECT ui FROM UserIngredient ui
+    LEFT JOIN DefaultIngredient di ON di.id = ui.referenceId AND ui.type = 'DEFAULT'
+    LEFT JOIN CustomIngredient ci ON ci.id = ui.referenceId AND ui.type = 'CUSTOM'
+    WHERE ui.user.userId = :userId
+    AND (
+        LOWER(di.ingredient) LIKE LOWER(CONCAT('%', :searchQuery, '%'))
+        OR LOWER(ci.name) LIKE LOWER(CONCAT('%', :searchQuery, '%'))
+    )
+""")
     Page<UserIngredient> searchIngredientsWithoutStorage(
             @Param("userId") Long userId,
             @Param("searchQuery") String searchQuery,

--- a/src/main/java/com/cookeep/cookeep/domain/ingredient/useringredient/dao/UserIngredientRepository.java
+++ b/src/main/java/com/cookeep/cookeep/domain/ingredient/useringredient/dao/UserIngredientRepository.java
@@ -68,30 +68,55 @@ public interface UserIngredientRepository extends JpaRepository<UserIngredient, 
             @Param("userId") Long userId
     );
 
-    // 카테고리별 분류 + 이름 검색
+    // 카테고리별 분류 + 이름 검색 (storage 있을 때)
     @Query("""
         SELECT ui FROM UserIngredient ui
         WHERE ui.user.userId = :userId
-        AND (:storage IS NULL OR ui.storage = :storage)
-        AND (:searchQuery IS NULL OR 
+        AND ui.storage = :storage
+        AND (
             EXISTS (
-                SELECT 1 FROM DefaultIngredient di 
-                WHERE di.id = ui.referenceId 
+                SELECT 1 FROM DefaultIngredient di
+                WHERE di.id = ui.referenceId
                 AND ui.type = 'DEFAULT'
                 AND LOWER(di.ingredient) LIKE LOWER(CONCAT('%', :searchQuery, '%'))
             )
             OR EXISTS (
-                SELECT 1 FROM CustomIngredient ci 
-                WHERE ci.id = ui.referenceId 
+                SELECT 1 FROM CustomIngredient ci
+                WHERE ci.id = ui.referenceId
                 AND ui.type = 'CUSTOM'
                 AND LOWER(ci.name) LIKE LOWER(CONCAT('%', :searchQuery, '%'))
             )
         )
     """)
-    Page<UserIngredient> searchIngredients(
+    Page<UserIngredient> searchIngredientsWithStorage(
             @Param("userId") Long userId,
             @Param("searchQuery") String searchQuery,
             @Param("storage") Storage storage,
+            Pageable pageable
+    );
+
+    // storage 없을 때 (전체 검색)
+    @Query("""
+        SELECT ui FROM UserIngredient ui
+        WHERE ui.user.userId = :userId
+        AND (
+            EXISTS (
+                SELECT 1 FROM DefaultIngredient di
+                WHERE di.id = ui.referenceId
+                AND ui.type = 'DEFAULT'
+                AND LOWER(di.ingredient) LIKE LOWER(CONCAT('%', :searchQuery, '%'))
+            )
+            OR EXISTS (
+                SELECT 1 FROM CustomIngredient ci
+                WHERE ci.id = ui.referenceId
+                AND ui.type = 'CUSTOM'
+                AND LOWER(ci.name) LIKE LOWER(CONCAT('%', :searchQuery, '%'))
+            )
+        )
+    """)
+    Page<UserIngredient> searchIngredientsWithoutStorage(
+            @Param("userId") Long userId,
+            @Param("searchQuery") String searchQuery,
             Pageable pageable
     );
 

--- a/src/main/java/com/cookeep/cookeep/domain/refrigerator/application/RefrigeratorService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/refrigerator/application/RefrigeratorService.java
@@ -163,8 +163,9 @@ public class RefrigeratorService {
         Pageable pageable = PageRequest.of(page, size, sortCriteria);
 
         // 검색 실행
-        Page<UserIngredient> searchResults = userIngredientRepository
-                .searchIngredients(userId, processedQuery, storage, pageable);
+        Page<UserIngredient> searchResults = (storage != null)
+                ? userIngredientRepository.searchIngredientsWithStorage(userId, processedQuery, storage, pageable)
+                : userIngredientRepository.searchIngredientsWithoutStorage(userId, processedQuery, pageable);
 
         // 결과 변환
         List<RefrigeratorSearchResponseDto.SearchResultItem> items = searchResults.getContent()

--- a/src/main/java/com/cookeep/cookeep/domain/refrigerator/application/RefrigeratorService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/refrigerator/application/RefrigeratorService.java
@@ -134,6 +134,7 @@ public class RefrigeratorService {
                 .memo(userIngredient.getMemo())
                 .aiTip(aiTip)
                 .imageUrl(imageUrl)
+                .createdAt(userIngredient.getCreatedAt().toLocalDate())
                 .build();
     }
 


### PR DESCRIPTION
# Issue
#166 

# Description
식재료 상세 조회 응답에 createdAt 누락
- 냉장고 상세 조회(MAIN03-03) 응답 DTO 및 서비스 매핑에서 누락되어 있었음. 
- BaseEntity의 createdAt(LocalDateTime)을 LocalDate로 변환하여 응답에 포함

검색 시 다른 유저의 식재료가 노출되는 문제
- OR EXISTS 절이 괄호 없이 작성되어 AND 우선순위를 벗어나는 문제 발생
- userId 필터 조건이 무시되어 전체 유저의 데이터가 반환
- 쿼리를 storage 유무에 따라 두 메서드로 분리하여 각 쿼리에서 명확하게 userId 조건이 항상 적용되도록 수정

# Changes
UserIngredientRepository.java
- searchIngredients 단일 쿼리 제거
- searchIngredientsWithStorage / searchIngredientsWithoutStorage 두 메서드로 분리
- 기존 JPQL의 :param IS NULL 패턴 및 OR 연산자 괄호 오류로 인해 userId 조건이 무시되던 문제 수정

RefrigeratorService.java
- searchIngredients() 내 storage 파라미터 유무에 따라 분기 처리
- getIngredientDetail() builder에 createdAt 매핑 추가

UserIngredientDetailResponseDto.java
- createdAt 필드(LocalDate) 및 Swagger @Schema 추가

# Test Checklist
- [x] 상세 조회 응답에 createdAt 필드가 포함되는지 확인
- [x] SQL 문으로 검색하여 유저 본인 재료만 조회되는지 확인