### PR TITLE
feat: 주간 목표 (요리사진 N회 기록, 좋아요 N회) 달성 시 자동 쿠키 지급 로직 구현

### DIFF
--- a/src/main/java/com/cookeep/cookeep/api/controller/DailyRecipeController.java
+++ b/src/main/java/com/cookeep/cookeep/api/controller/DailyRecipeController.java
@@ -113,7 +113,7 @@ public class DailyRecipeController {
             @AuthenticationPrincipal(expression = "userId") Long userId,
             @Valid @RequestBody DailyRecipeCreateRequestDto request
     ) {
-        DailyRecipe dailyRecipe = dailyRecipeService.createDailyRecipe(
+        DailyRecipeService.DailyRecipeResult result = dailyRecipeService.createDailyRecipe(
                 userId,
                 request.getAiRecipeId(),
                 request.getTitle(),
@@ -123,7 +123,7 @@ public class DailyRecipeController {
         );
 
         return ResponseEntity.status(201)
-                .body(DataResponse.created(DailyRecipeCreateResponseDto.from(dailyRecipe)));
+                .body(DataResponse.created(DailyRecipeCreateResponseDto.from(result.dailyRecipe(), result.weeklyGoalAchieved())));
     }
 
     @Operation(
@@ -172,12 +172,12 @@ public class DailyRecipeController {
             @PathVariable Long dailyRecipeId,
             @Valid @RequestBody DailyRecipeUpdateRequestDto request
     ) {
-        DailyRecipe dailyRecipe = dailyRecipeService.updateDailyRecipe(
+        DailyRecipeService.DailyRecipeResult result = dailyRecipeService.updateDailyRecipe(
                 userId, dailyRecipeId, request.getTitle(), request.getDescription(),
                 request.getRecipeImageUrl(), request.getDeleteRecipeImage()
         );
 
-        return ResponseEntity.ok(DataResponse.from(DailyRecipeDetailResponseDto.from(dailyRecipe)));
+        return ResponseEntity.ok(DataResponse.from(DailyRecipeDetailResponseDto.from(result.dailyRecipe(), result.weeklyGoalAchieved())));
     }
 
     @Operation(

--- a/src/main/java/com/cookeep/cookeep/api/controller/RecipeLikeController.java
+++ b/src/main/java/com/cookeep/cookeep/api/controller/RecipeLikeController.java
@@ -49,13 +49,14 @@ public class RecipeLikeController {
 		@Parameter(description = "데일리 레시피 ID", required = true)
 		@PathVariable Long dailyRecipeId
 	) {
-		boolean isLiked = recipeLikeService.toggleLike(userId, dailyRecipeId);
+		RecipeLikeService.ToggleLikeResult result = recipeLikeService.toggleLike(userId, dailyRecipeId);
 		long likeCount = recipeLikeService.getLikeCount(dailyRecipeId);
 
 		RecipeLikeResponseDto response = RecipeLikeResponseDto.from(
 			dailyRecipeId,
-			isLiked,
-			(int) likeCount
+			result.isLiked(),
+			(int) likeCount,
+			result.weeklyGoalAchieved()
 		);
 
 		return ResponseEntity.ok(DataResponse.from(response));

--- a/src/main/java/com/cookeep/cookeep/api/dto/response/DailyRecipeCreateResponseDto.java
+++ b/src/main/java/com/cookeep/cookeep/api/dto/response/DailyRecipeCreateResponseDto.java
@@ -27,12 +27,16 @@ public class DailyRecipeCreateResponseDto {
     @Schema(description = "등록 시각", example = "2026-02-07T14:30:00")
     private LocalDateTime createdAt;
 
-    public static DailyRecipeCreateResponseDto from(DailyRecipe dailyRecipe) {
+    @Schema(description = "이번 액션으로 주간 목표 달성 여부", example = "false")
+    private boolean weeklyGoalAchieved;
+
+    public static DailyRecipeCreateResponseDto from(DailyRecipe dailyRecipe, boolean weeklyGoalAchieved) {
         return DailyRecipeCreateResponseDto.builder()
                 .dailyRecipeId(dailyRecipe.getId())
                 .title(dailyRecipe.getTitle())
                 .message("새로운 데일리 레시피가 등록되었습니다.")
                 .createdAt(dailyRecipe.getCreatedAt())
+                .weeklyGoalAchieved(weeklyGoalAchieved)
                 .build();
     }
 }

--- a/src/main/java/com/cookeep/cookeep/api/dto/response/DailyRecipeDetailResponseDto.java
+++ b/src/main/java/com/cookeep/cookeep/api/dto/response/DailyRecipeDetailResponseDto.java
@@ -41,7 +41,14 @@ public class DailyRecipeDetailResponseDto {
     @Schema(description = "등록 시각", example = "2026-02-07T14:30:00")
     private LocalDateTime createdAt;
 
+    @Schema(description = "이번 액션으로 주간 목표 달성 여부 (수정 시에만 유효)", example = "false")
+    private boolean weeklyGoalAchieved;
+
     public static DailyRecipeDetailResponseDto from(DailyRecipe dailyRecipe) {
+        return from(dailyRecipe, false);
+    }
+
+    public static DailyRecipeDetailResponseDto from(DailyRecipe dailyRecipe, boolean weeklyGoalAchieved) {
         return DailyRecipeDetailResponseDto.builder()
                 .dailyRecipeId(dailyRecipe.getId())
                 .title(dailyRecipe.getTitle())
@@ -51,6 +58,7 @@ public class DailyRecipeDetailResponseDto {
                 .isPublic(dailyRecipe.getIsPublic())
                 .aiRecipeId(dailyRecipe.getAiRecipe() != null ? dailyRecipe.getAiRecipe().getId() : null)
                 .createdAt(dailyRecipe.getCreatedAt())
+                .weeklyGoalAchieved(weeklyGoalAchieved)
                 .build();
     }
 }

--- a/src/main/java/com/cookeep/cookeep/api/dto/response/RecipeLikeResponseDto.java
+++ b/src/main/java/com/cookeep/cookeep/api/dto/response/RecipeLikeResponseDto.java
@@ -9,12 +9,18 @@ public class RecipeLikeResponseDto {
 	private Long dailyRecipeId;
 	private boolean isLiked; // true: 좋아요 추가, false: 좋아요 취소
 	private Integer likeCount; // 현재 좋아요 수
+	private boolean weeklyGoalAchieved; // 이번 액션으로 주간 목표 달성 여부
 
 	public static RecipeLikeResponseDto from(Long dailyRecipeId, boolean isLiked, Integer likeCount) {
+		return from(dailyRecipeId, isLiked, likeCount, false);
+	}
+
+	public static RecipeLikeResponseDto from(Long dailyRecipeId, boolean isLiked, Integer likeCount, boolean weeklyGoalAchieved) {
 		return RecipeLikeResponseDto.builder()
 			.dailyRecipeId(dailyRecipeId)
 			.isLiked(isLiked)
 			.likeCount(likeCount)
+			.weeklyGoalAchieved(weeklyGoalAchieved)
 			.build();
 	}
 }

--- a/src/main/java/com/cookeep/cookeep/domain/dailyrecipe/application/DailyRecipeService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/dailyrecipe/application/DailyRecipeService.java
@@ -7,6 +7,8 @@ import com.cookeep.cookeep.domain.cookie.application.CookieService;
 import com.cookeep.cookeep.domain.cookie.entity.CookieLog;
 import com.cookeep.cookeep.domain.dailyrecipe.dao.DailyRecipeRepository;
 import com.cookeep.cookeep.domain.dailyrecipe.entity.DailyRecipe;
+import com.cookeep.cookeep.domain.onboarding.application.WeeklyGoalService;
+import com.cookeep.cookeep.domain.onboarding.entity.GoalActionType;
 import com.cookeep.cookeep.domain.recipe.dao.AiRecipeRepository;
 import com.cookeep.cookeep.domain.recipe.entity.AiRecipe;
 import com.cookeep.cookeep.domain.user.application.UserReader;
@@ -37,9 +39,12 @@ public class DailyRecipeService {
     private final DailyRecipeRepository dailyRecipeRepository;
     private final AiRecipeRepository aiRecipeRepository;
     private final CookieService cookieService;
+    private final WeeklyGoalService weeklyGoalService;
     private final UserReader userReader;
     private final ObjectMapper objectMapper;
     private final S3Service s3Service;
+
+    public record DailyRecipeResult(DailyRecipe dailyRecipe, boolean weeklyGoalAchieved) {}
 
     // 채택된 AI 레시피 목록 조회
     @Transactional(readOnly = true)
@@ -55,8 +60,8 @@ public class DailyRecipeService {
     }
 
     // 데일리 레시피 등록
-    public DailyRecipe createDailyRecipe(Long userId, Long aiRecipeId, String title,
-                                         String description, String recipeImageUrl, Boolean isPublic) {
+    public DailyRecipeResult createDailyRecipe(Long userId, Long aiRecipeId, String title,
+                                               String description, String recipeImageUrl, Boolean isPublic) {
         User user = userReader.readById(userId);
 
         AiRecipe aiRecipe = aiRecipeRepository.findById(aiRecipeId)
@@ -88,12 +93,14 @@ public class DailyRecipeService {
         // 쿠키 지급: 레시피 기록 (1개)
         cookieService.updateCookie(userId, CookieLog.CookieLogType.BASIC_LOAD_RECIPE);
 
-        // 쿠키 추가 지급: 음식 사진 등록 시 (1개)
+        // 쿠키 추가 지급: 음식 사진 등록 시 (1개) + 주간 목표 진행
+        boolean goalAchieved = false;
         if (recipeImageUrl != null && !recipeImageUrl.isBlank()) {
             cookieService.updateCookie(userId, CookieLog.CookieLogType.BASIC_FOOD_PHOTO_REG);
+            goalAchieved = weeklyGoalService.handleGoalProgress(userId, GoalActionType.PHOTO_RECORD);
         }
 
-        return dailyRecipe;
+        return new DailyRecipeResult(dailyRecipe, goalAchieved);
     }
 
     // 데일리 레시피 상세 조회
@@ -106,8 +113,8 @@ public class DailyRecipeService {
     }
 
     // 데일리 레시피 수정 (제목, 한줄평, 사진)
-    public DailyRecipe updateDailyRecipe(Long userId, Long dailyRecipeId, String title, String description,
-                                         String recipeImageUrl, Boolean deleteRecipeImage) {
+    public DailyRecipeResult updateDailyRecipe(Long userId, Long dailyRecipeId, String title, String description,
+                                               String recipeImageUrl, Boolean deleteRecipeImage) {
         boolean isDeleteImage = Boolean.TRUE.equals(deleteRecipeImage);
 
         if ((title == null || title.isBlank())
@@ -139,7 +146,8 @@ public class DailyRecipeService {
             dailyRecipe.updateDescription(description);
         }
 
-        // 기존에 사진이 없었고 새로 사진을 추가하는 경우 쿠키 지급
+        // 기존에 사진이 없었고 새로 사진을 추가하는 경우 쿠키 지급 + 주간 목표 진행
+        boolean goalAchieved = false;
         if (recipeImageUrl != null && !recipeImageUrl.isBlank()) {
             if (recipeImageUrl.equals(dailyRecipe.getRecipeImageUrl())) {
                 throw new AppException(ErrorCode.DAILY_RECIPE_IMAGE_SAME_URL);
@@ -148,10 +156,11 @@ public class DailyRecipeService {
             dailyRecipe.updateRecipeImageUrl(recipeImageUrl);
             if (isNewPhotoAdded) {
                 cookieService.updateCookie(userId, CookieLog.CookieLogType.BASIC_FOOD_PHOTO_REG);
+                goalAchieved = weeklyGoalService.handleGoalProgress(userId, GoalActionType.PHOTO_RECORD);
             }
         }
 
-        return dailyRecipe;
+        return new DailyRecipeResult(dailyRecipe, goalAchieved);
     }
 
     // 데일리 레시피 공개 범위 수정

--- a/src/main/java/com/cookeep/cookeep/domain/dailyrecipe/application/RecipeLikeService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/dailyrecipe/application/RecipeLikeService.java
@@ -7,6 +7,8 @@ import com.cookeep.cookeep.domain.dailyrecipe.dao.DailyRecipeRepository;
 import com.cookeep.cookeep.domain.dailyrecipe.dao.RecipeLikeRepository;
 import com.cookeep.cookeep.domain.dailyrecipe.entity.DailyRecipe;
 import com.cookeep.cookeep.domain.dailyrecipe.entity.RecipeLike;
+import com.cookeep.cookeep.domain.onboarding.application.WeeklyGoalService;
+import com.cookeep.cookeep.domain.onboarding.entity.GoalActionType;
 import com.cookeep.cookeep.domain.user.application.UserReader;
 import com.cookeep.cookeep.domain.user.entity.User;
 import lombok.RequiredArgsConstructor;
@@ -23,9 +25,12 @@ public class RecipeLikeService {
 	private final RecipeLikeRepository recipeLikeRepository;
 	private final DailyRecipeRepository dailyRecipeRepository;
 	private final UserReader userReader;
+	private final WeeklyGoalService weeklyGoalService;
+
+	public record ToggleLikeResult(boolean isLiked, boolean weeklyGoalAchieved) {}
 
 	// 좋아요 추가/삭제 토글
-	public boolean toggleLike(Long userId, Long dailyRecipeId) {
+	public ToggleLikeResult toggleLike(Long userId, Long dailyRecipeId) {
 		User user = userReader.readById(userId);
 		DailyRecipe dailyRecipe = dailyRecipeRepository.findById(dailyRecipeId)
 			.orElseThrow(() -> new AppException(ErrorCode.DAILY_RECIPE_NOT_FOUND));
@@ -41,7 +46,8 @@ public class RecipeLikeService {
 		if (existingLike.isPresent()) {
 			recipeLikeRepository.delete(existingLike.get());
 			dailyRecipe.decrementLikeCount();
-			return false; // 좋아요 취소
+			weeklyGoalService.handleGoalUndo(userId, GoalActionType.RECIPE_LIKE);
+			return new ToggleLikeResult(false, false); // 좋아요 취소
 		}
 
 		// 좋아요 추가
@@ -51,7 +57,8 @@ public class RecipeLikeService {
 			.build();
 		recipeLikeRepository.save(recipeLike);
 		dailyRecipe.incrementLikeCount();
-		return true; // 좋아요 추가
+		boolean goalAchieved = weeklyGoalService.handleGoalProgress(userId, GoalActionType.RECIPE_LIKE);
+		return new ToggleLikeResult(true, goalAchieved); // 좋아요 추가
 	}
 
 	// 특정 레시피의 좋아요 수 조회

--- a/src/main/java/com/cookeep/cookeep/domain/onboarding/application/WeeklyGoalService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/onboarding/application/WeeklyGoalService.java
@@ -1,0 +1,74 @@
+package com.cookeep.cookeep.domain.onboarding.application;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.temporal.TemporalAdjusters;
+import java.util.Optional;
+
+import com.cookeep.cookeep.domain.cookie.application.CookieService;
+import com.cookeep.cookeep.domain.cookie.entity.CookieLog;
+import com.cookeep.cookeep.domain.onboarding.dao.WeeklyGoalRepository;
+import com.cookeep.cookeep.domain.onboarding.entity.GoalActionType;
+import com.cookeep.cookeep.domain.onboarding.entity.WeeklyGoal;
+import com.cookeep.cookeep.domain.user.application.UserReader;
+import com.cookeep.cookeep.domain.user.entity.User;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class WeeklyGoalService {
+
+    private final WeeklyGoalRepository weeklyGoalRepository;
+    private final UserReader userReader;
+    private final CookieService cookieService;
+
+    /**
+     * 해당 액션 타입의 주간 목표가 있다면 진행 카운트를 1 증가시키고,
+     * 이번 호출로 처음 달성된 경우 쿠키를 지급한다.
+     *
+     * @return true: 이번 호출로 목표를 달성함 (쿠키 지급됨), false: 달성 아님
+     */
+    public boolean handleGoalProgress(Long userId, GoalActionType actionType) {
+        User user = userReader.readById(userId);
+        LocalDate weekStart = LocalDate.now()
+                .with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY));
+
+        Optional<WeeklyGoal> goalOpt = weeklyGoalRepository
+                .findFirstByUserAndWeekStartDateOrderByCreatedAtDesc(user, weekStart);
+
+        if (goalOpt.isEmpty()) return false;
+
+        WeeklyGoal goal = goalOpt.get();
+        if (!goal.getGoalActionType().equals(actionType)) return false;
+        if (goal.isAchieved()) return false;
+
+        goal.incrementCount();
+
+        if (goal.isAchieved()) {
+            cookieService.updateCookie(userId, CookieLog.CookieLogType.BONUS_WEEKLY_GOAL_ACHIEVE);
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * 액션 취소 시 주간 목표 카운트를 1 감소시킨다.
+     * 이미 달성된 경우 아무 동작도 하지 않는다 (쿠키 회수 없음).
+     */
+    public void handleGoalUndo(Long userId, GoalActionType actionType) {
+        User user = userReader.readById(userId);
+        LocalDate weekStart = LocalDate.now()
+                .with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY));
+
+        weeklyGoalRepository
+                .findFirstByUserAndWeekStartDateOrderByCreatedAtDesc(user, weekStart)
+                .ifPresent(goal -> {
+                    if (!goal.getGoalActionType().equals(actionType)) return;
+                    goal.decrementCount();
+                });
+    }
+}

--- a/src/main/java/com/cookeep/cookeep/domain/onboarding/entity/WeeklyGoal.java
+++ b/src/main/java/com/cookeep/cookeep/domain/onboarding/entity/WeeklyGoal.java
@@ -61,6 +61,12 @@ public class WeeklyGoal extends BaseEntity {
 		}
 	}
 
+	public void decrementCount() {
+		if (!this.isAchieved && this.currentCount > 0) {
+			this.currentCount--;
+		}
+	}
+
 	public void initWeekStartDate() {
 		// 현재 날짜를 받아와서 해당 주차 시작일(월요일)로 값을 설정함
 		this.weekStartDate = LocalDate.now()

--- a/src/test/java/com/cookeep/cookeep/domain/dailyrecipe/application/DailyRecipeServiceTest.java
+++ b/src/test/java/com/cookeep/cookeep/domain/dailyrecipe/application/DailyRecipeServiceTest.java
@@ -1,0 +1,171 @@
+package com.cookeep.cookeep.domain.dailyrecipe.application;
+
+import com.cookeep.cookeep.domain.cookie.application.CookieService;
+import com.cookeep.cookeep.domain.cookie.entity.CookieLog;
+import com.cookeep.cookeep.domain.dailyrecipe.dao.DailyRecipeRepository;
+import com.cookeep.cookeep.domain.dailyrecipe.entity.DailyRecipe;
+import com.cookeep.cookeep.domain.onboarding.application.WeeklyGoalService;
+import com.cookeep.cookeep.domain.onboarding.entity.GoalActionType;
+import com.cookeep.cookeep.domain.recipe.dao.AiRecipeRepository;
+import com.cookeep.cookeep.domain.recipe.entity.AiRecipe;
+import com.cookeep.cookeep.domain.user.application.UserReader;
+import com.cookeep.cookeep.domain.user.entity.User;
+import com.cookeep.cookeep.common.util.S3Service;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class DailyRecipeServiceTest {
+
+    @Mock private DailyRecipeRepository dailyRecipeRepository;
+    @Mock private AiRecipeRepository aiRecipeRepository;
+    @Mock private CookieService cookieService;
+    @Mock private WeeklyGoalService weeklyGoalService;
+    @Mock private UserReader userReader;
+    @Mock private ObjectMapper objectMapper;
+    @Mock private S3Service s3Service;
+
+    @InjectMocks
+    private DailyRecipeService dailyRecipeService;
+
+    private User user;
+    private AiRecipe aiRecipe;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        user = User.builder().nickname("테스터").build();
+        aiRecipe = AiRecipe.builder()
+                .id(10L)
+                .userId(1L)
+                .title("테스트 레시피")
+                .ingredientsJson("[]")
+                .stepsJson("[]")
+                .build();
+
+        given(userReader.readById(1L)).willReturn(user);
+        given(aiRecipeRepository.findById(10L)).willReturn(Optional.of(aiRecipe));
+        given(dailyRecipeRepository.save(any(DailyRecipe.class))).willAnswer(inv -> inv.getArgument(0));
+
+        // ObjectMapper는 buildContentSnapshot() 내부에서 사용 — 실제 인스턴스로 교체
+        ObjectMapper realMapper = new ObjectMapper();
+        given(objectMapper.readTree("[]")).willReturn(realMapper.readTree("[]"));
+        given(objectMapper.writeValueAsString(any())).willReturn("{}");
+    }
+
+    @Nested
+    @DisplayName("createDailyRecipe - PHOTO_RECORD 목표 연동")
+    class CreateDailyRecipe {
+
+        @Test
+        @DisplayName("사진 포함 등록 시 PHOTO_RECORD 목표 진행을 호출한다")
+        void 사진포함_등록_목표진행_호출() {
+            dailyRecipeService.createDailyRecipe(1L, 10L, null, null, "https://s3.example.com/photo.jpg", false);
+
+            verify(weeklyGoalService).handleGoalProgress(1L, GoalActionType.PHOTO_RECORD);
+        }
+
+        @Test
+        @DisplayName("사진 없이 등록 시 PHOTO_RECORD 목표 진행을 호출하지 않는다")
+        void 사진없음_등록_목표진행_미호출() {
+            dailyRecipeService.createDailyRecipe(1L, 10L, null, null, null, false);
+
+            verify(weeklyGoalService, never()).handleGoalProgress(any(), any());
+        }
+
+        @Test
+        @DisplayName("사진 포함 등록 시 목표 달성이면 weeklyGoalAchieved=true를 반환한다")
+        void 사진포함_등록_목표달성_true반환() {
+            given(weeklyGoalService.handleGoalProgress(1L, GoalActionType.PHOTO_RECORD)).willReturn(true);
+
+            DailyRecipeService.DailyRecipeResult result =
+                    dailyRecipeService.createDailyRecipe(1L, 10L, null, null, "https://s3.example.com/photo.jpg", false);
+
+            assertThat(result.weeklyGoalAchieved()).isTrue();
+        }
+
+        @Test
+        @DisplayName("사진 없이 등록 시 weeklyGoalAchieved=false를 반환한다")
+        void 사진없음_등록_weeklyGoalAchieved_false() {
+            DailyRecipeService.DailyRecipeResult result =
+                    dailyRecipeService.createDailyRecipe(1L, 10L, null, null, null, false);
+
+            assertThat(result.weeklyGoalAchieved()).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("updateDailyRecipe - PHOTO_RECORD 목표 연동")
+    class UpdateDailyRecipe {
+
+        private DailyRecipe existingRecipeWithoutPhoto;
+        private DailyRecipe existingRecipeWithPhoto;
+
+        @BeforeEach
+        void setUp() {
+            existingRecipeWithoutPhoto = DailyRecipe.builder()
+                    .title("기존 레시피")
+                    .content("{}")
+                    .user(user)
+                    .build();
+
+            existingRecipeWithPhoto = DailyRecipe.builder()
+                    .title("기존 레시피")
+                    .content("{}")
+                    .recipeImageUrl("https://s3.example.com/existing.jpg")
+                    .user(user)
+                    .build();
+        }
+
+        @Test
+        @DisplayName("사진이 없던 레시피에 사진을 추가하면 PHOTO_RECORD 목표 진행을 호출한다")
+        void 신규사진_추가_목표진행_호출() {
+            given(dailyRecipeRepository.findByIdAndUser(100L, user))
+                    .willReturn(Optional.of(existingRecipeWithoutPhoto));
+
+            dailyRecipeService.updateDailyRecipe(1L, 100L, null, null, "https://s3.example.com/new.jpg", false);
+
+            verify(weeklyGoalService).handleGoalProgress(1L, GoalActionType.PHOTO_RECORD);
+        }
+
+        @Test
+        @DisplayName("이미 사진이 있는 레시피에 사진을 교체하면 PHOTO_RECORD 목표 진행을 호출하지 않는다")
+        void 기존사진_교체_목표진행_미호출() {
+            given(dailyRecipeRepository.findByIdAndUser(100L, user))
+                    .willReturn(Optional.of(existingRecipeWithPhoto));
+
+            dailyRecipeService.updateDailyRecipe(1L, 100L, null, null, "https://s3.example.com/replaced.jpg", false);
+
+            verify(weeklyGoalService, never()).handleGoalProgress(any(), any());
+        }
+
+        @Test
+        @DisplayName("신규 사진 추가 시 목표 달성이면 weeklyGoalAchieved=true를 반환한다")
+        void 신규사진_추가_목표달성_true반환() {
+            given(dailyRecipeRepository.findByIdAndUser(100L, user))
+                    .willReturn(Optional.of(existingRecipeWithoutPhoto));
+            given(weeklyGoalService.handleGoalProgress(1L, GoalActionType.PHOTO_RECORD)).willReturn(true);
+
+            DailyRecipeService.DailyRecipeResult result =
+                    dailyRecipeService.updateDailyRecipe(1L, 100L, null, null, "https://s3.example.com/new.jpg", false);
+
+            assertThat(result.weeklyGoalAchieved()).isTrue();
+        }
+    }
+}

--- a/src/test/java/com/cookeep/cookeep/domain/dailyrecipe/application/RecipeLikeServiceTest.java
+++ b/src/test/java/com/cookeep/cookeep/domain/dailyrecipe/application/RecipeLikeServiceTest.java
@@ -1,0 +1,203 @@
+package com.cookeep.cookeep.domain.dailyrecipe.application;
+
+import com.cookeep.cookeep.common.exception.AppException;
+import com.cookeep.cookeep.common.exception.ErrorCode;
+import com.cookeep.cookeep.domain.dailyrecipe.dao.DailyRecipeRepository;
+import com.cookeep.cookeep.domain.dailyrecipe.dao.RecipeLikeRepository;
+import com.cookeep.cookeep.domain.dailyrecipe.entity.DailyRecipe;
+import com.cookeep.cookeep.domain.dailyrecipe.entity.RecipeLike;
+import com.cookeep.cookeep.domain.onboarding.application.WeeklyGoalService;
+import com.cookeep.cookeep.domain.onboarding.entity.GoalActionType;
+import com.cookeep.cookeep.domain.user.application.UserReader;
+import com.cookeep.cookeep.domain.user.entity.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class RecipeLikeServiceTest {
+
+    @Mock
+    private RecipeLikeRepository recipeLikeRepository;
+
+    @Mock
+    private DailyRecipeRepository dailyRecipeRepository;
+
+    @Mock
+    private UserReader userReader;
+
+    @Mock
+    private WeeklyGoalService weeklyGoalService;
+
+    @InjectMocks
+    private RecipeLikeService recipeLikeService;
+
+    private User liker;
+    private User recipeOwner;
+    private DailyRecipe recipe;
+
+    @BeforeEach
+    void setUp() {
+        liker = User.builder().nickname("좋아요누르는유저").build();
+        recipeOwner = User.builder().nickname("레시피작성자").build();
+
+        // 리플렉션으로 userId 설정 없이 테스트하기 위해 별도 User 객체 사용
+        // recipeOwner의 userId != liker의 userId 를 보장하기 위해 mock 사용
+        liker = mock(User.class);
+        recipeOwner = mock(User.class);
+        given(liker.getUserId()).willReturn(1L);
+        given(recipeOwner.getUserId()).willReturn(2L);
+
+        recipe = DailyRecipe.builder()
+                .title("테스트 레시피")
+                .content("{}")
+                .isPublic(true)
+                .user(recipeOwner)
+                .build();
+    }
+
+    @Nested
+    @DisplayName("toggleLike - 좋아요 추가")
+    class LikeAdd {
+
+        @BeforeEach
+        void setUp() {
+            given(userReader.readById(1L)).willReturn(liker);
+            given(dailyRecipeRepository.findById(100L)).willReturn(Optional.of(recipe));
+            given(recipeLikeRepository.findByDailyRecipeAndUser(recipe, liker)).willReturn(Optional.empty());
+            given(recipeLikeRepository.save(any(RecipeLike.class))).willAnswer(inv -> inv.getArgument(0));
+        }
+
+        @Test
+        @DisplayName("좋아요 추가 시 isLiked=true를 반환한다")
+        void 좋아요추가_isLiked_true() {
+            RecipeLikeService.ToggleLikeResult result = recipeLikeService.toggleLike(1L, 100L);
+
+            assertThat(result.isLiked()).isTrue();
+        }
+
+        @Test
+        @DisplayName("좋아요 추가 시 주간 목표 진행을 호출한다")
+        void 좋아요추가_목표진행_호출() {
+            recipeLikeService.toggleLike(1L, 100L);
+
+            verify(weeklyGoalService).handleGoalProgress(1L, GoalActionType.RECIPE_LIKE);
+        }
+
+        @Test
+        @DisplayName("좋아요 추가 시 목표 달성이면 weeklyGoalAchieved=true를 반환한다")
+        void 좋아요추가_목표달성_true반환() {
+            given(weeklyGoalService.handleGoalProgress(1L, GoalActionType.RECIPE_LIKE)).willReturn(true);
+
+            RecipeLikeService.ToggleLikeResult result = recipeLikeService.toggleLike(1L, 100L);
+
+            assertThat(result.weeklyGoalAchieved()).isTrue();
+        }
+
+        @Test
+        @DisplayName("좋아요 추가 시 목표 미달성이면 weeklyGoalAchieved=false를 반환한다")
+        void 좋아요추가_목표미달성_false반환() {
+            given(weeklyGoalService.handleGoalProgress(1L, GoalActionType.RECIPE_LIKE)).willReturn(false);
+
+            RecipeLikeService.ToggleLikeResult result = recipeLikeService.toggleLike(1L, 100L);
+
+            assertThat(result.weeklyGoalAchieved()).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("toggleLike - 좋아요 취소")
+    class LikeCancel {
+
+        private RecipeLike existingLike;
+
+        @BeforeEach
+        void setUp() {
+            existingLike = RecipeLike.builder().dailyRecipe(recipe).user(liker).build();
+
+            given(userReader.readById(1L)).willReturn(liker);
+            given(dailyRecipeRepository.findById(100L)).willReturn(Optional.of(recipe));
+            given(recipeLikeRepository.findByDailyRecipeAndUser(recipe, liker))
+                    .willReturn(Optional.of(existingLike));
+        }
+
+        @Test
+        @DisplayName("좋아요 취소 시 isLiked=false를 반환한다")
+        void 좋아요취소_isLiked_false() {
+            RecipeLikeService.ToggleLikeResult result = recipeLikeService.toggleLike(1L, 100L);
+
+            assertThat(result.isLiked()).isFalse();
+        }
+
+        @Test
+        @DisplayName("좋아요 취소 시 목표 카운트 감소를 호출한다")
+        void 좋아요취소_목표되돌리기_호출() {
+            recipeLikeService.toggleLike(1L, 100L);
+
+            verify(weeklyGoalService).handleGoalUndo(1L, GoalActionType.RECIPE_LIKE);
+        }
+
+        @Test
+        @DisplayName("좋아요 취소 시 weeklyGoalAchieved=false를 반환한다")
+        void 좋아요취소_weeklyGoalAchieved_false() {
+            RecipeLikeService.ToggleLikeResult result = recipeLikeService.toggleLike(1L, 100L);
+
+            assertThat(result.weeklyGoalAchieved()).isFalse();
+        }
+
+        @Test
+        @DisplayName("좋아요 취소 시 handleGoalProgress를 호출하지 않는다")
+        void 좋아요취소_목표진행_미호출() {
+            recipeLikeService.toggleLike(1L, 100L);
+
+            verify(weeklyGoalService, never()).handleGoalProgress(any(), any());
+        }
+    }
+
+    @Nested
+    @DisplayName("toggleLike - 예외 케이스")
+    class LikeException {
+
+        @Test
+        @DisplayName("자신의 레시피에 좋아요를 누르면 예외가 발생한다")
+        void 자신의레시피_좋아요_예외() {
+            given(userReader.readById(2L)).willReturn(recipeOwner);
+            given(dailyRecipeRepository.findById(100L)).willReturn(Optional.of(recipe));
+
+            assertThatThrownBy(() -> recipeLikeService.toggleLike(2L, 100L))
+                    .isInstanceOf(AppException.class)
+                    .hasMessageContaining(ErrorCode.CANNOT_LIKE_OWN_RECIPE.getMessage());
+
+            verifyNoInteractions(weeklyGoalService);
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 레시피에 좋아요를 누르면 예외가 발생한다")
+        void 없는레시피_좋아요_예외() {
+            given(userReader.readById(1L)).willReturn(liker);
+            given(dailyRecipeRepository.findById(999L)).willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> recipeLikeService.toggleLike(1L, 999L))
+                    .isInstanceOf(AppException.class)
+                    .hasMessageContaining(ErrorCode.DAILY_RECIPE_NOT_FOUND.getMessage());
+
+            verifyNoInteractions(weeklyGoalService);
+        }
+    }
+}

--- a/src/test/java/com/cookeep/cookeep/domain/onboarding/application/WeeklyGoalServiceTest.java
+++ b/src/test/java/com/cookeep/cookeep/domain/onboarding/application/WeeklyGoalServiceTest.java
@@ -1,0 +1,254 @@
+package com.cookeep.cookeep.domain.onboarding.application;
+
+import com.cookeep.cookeep.domain.cookie.application.CookieService;
+import com.cookeep.cookeep.domain.cookie.entity.CookieLog;
+import com.cookeep.cookeep.domain.onboarding.dao.WeeklyGoalRepository;
+import com.cookeep.cookeep.domain.onboarding.entity.GoalActionType;
+import com.cookeep.cookeep.domain.onboarding.entity.WeeklyGoal;
+import com.cookeep.cookeep.domain.user.application.UserReader;
+import com.cookeep.cookeep.domain.user.entity.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.temporal.TemporalAdjusters;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class WeeklyGoalServiceTest {
+
+    @Mock
+    private WeeklyGoalRepository weeklyGoalRepository;
+
+    @Mock
+    private UserReader userReader;
+
+    @Mock
+    private CookieService cookieService;
+
+    @InjectMocks
+    private WeeklyGoalService weeklyGoalService;
+
+    private User user;
+    private LocalDate weekStart;
+
+    @BeforeEach
+    void setUp() {
+        user = User.builder().nickname("테스터").build();
+        weekStart = LocalDate.now().with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY));
+        given(userReader.readById(any())).willReturn(user);
+    }
+
+    @Nested
+    @DisplayName("handleGoalProgress - 목표 카운트 증가")
+    class HandleGoalProgress {
+
+        @Test
+        @DisplayName("이번 주 목표가 없으면 false를 반환한다")
+        void 목표없음_false반환() {
+            given(weeklyGoalRepository.findFirstByUserAndWeekStartDateOrderByCreatedAtDesc(user, weekStart))
+                    .willReturn(Optional.empty());
+
+            boolean result = weeklyGoalService.handleGoalProgress(1L, GoalActionType.RECIPE_LIKE);
+
+            assertThat(result).isFalse();
+            verifyNoInteractions(cookieService);
+        }
+
+        @Test
+        @DisplayName("목표 타입이 액션과 다르면 false를 반환한다")
+        void 목표타입불일치_false반환() {
+            WeeklyGoal goal = buildGoal(GoalActionType.PHOTO_RECORD, 1, 0); // targetCount=1: 타입만 맞았다면 이 한 번으로 달성됐을 상황
+            given(weeklyGoalRepository.findFirstByUserAndWeekStartDateOrderByCreatedAtDesc(user, weekStart))
+                    .willReturn(Optional.of(goal));
+
+            boolean result = weeklyGoalService.handleGoalProgress(1L, GoalActionType.RECIPE_LIKE);
+
+            assertThat(result).isFalse();
+            assertThat(goal.getCurrentCount()).isZero();
+            verifyNoInteractions(cookieService);
+        }
+
+        @Test
+        @DisplayName("이미 달성된 목표는 카운트를 증가시키지 않고 false를 반환한다")
+        void 이미달성_false반환() {
+            WeeklyGoal goal = buildGoal(GoalActionType.RECIPE_LIKE, 1, 0);
+            goal.incrementCount(); // targetCount=1이므로 isAchieved=true
+
+            given(weeklyGoalRepository.findFirstByUserAndWeekStartDateOrderByCreatedAtDesc(user, weekStart))
+                    .willReturn(Optional.of(goal));
+
+            boolean result = weeklyGoalService.handleGoalProgress(1L, GoalActionType.RECIPE_LIKE);
+
+            assertThat(result).isFalse();
+            assertThat(goal.getCurrentCount()).isEqualTo(1); // 그대로
+            verifyNoInteractions(cookieService);
+        }
+
+        @Test
+        @DisplayName("목표 카운트가 증가하지만 아직 미달성이면 false를 반환한다")
+        void 카운트증가_미달성_false반환() {
+            WeeklyGoal goal = buildGoal(GoalActionType.RECIPE_LIKE, 3, 0);
+            given(weeklyGoalRepository.findFirstByUserAndWeekStartDateOrderByCreatedAtDesc(user, weekStart))
+                    .willReturn(Optional.of(goal));
+
+            boolean result = weeklyGoalService.handleGoalProgress(1L, GoalActionType.RECIPE_LIKE);
+
+            assertThat(result).isFalse();
+            assertThat(goal.getCurrentCount()).isEqualTo(1);
+            assertThat(goal.isAchieved()).isFalse();
+            verifyNoInteractions(cookieService);
+        }
+
+        @Test
+        @DisplayName("목표 달성 시 true를 반환하고 쿠키를 지급한다")
+        void 목표달성_true반환_쿠키지급() {
+            WeeklyGoal goal = buildGoal(GoalActionType.RECIPE_LIKE, 3, 2); // 2/3 진행 중
+            given(weeklyGoalRepository.findFirstByUserAndWeekStartDateOrderByCreatedAtDesc(user, weekStart))
+                    .willReturn(Optional.of(goal));
+
+            boolean result = weeklyGoalService.handleGoalProgress(1L, GoalActionType.RECIPE_LIKE);
+
+            assertThat(result).isTrue();
+            assertThat(goal.getCurrentCount()).isEqualTo(3);
+            assertThat(goal.isAchieved()).isTrue();
+            verify(cookieService).updateCookie(1L, CookieLog.CookieLogType.BONUS_WEEKLY_GOAL_ACHIEVE);
+        }
+
+        @Test
+        @DisplayName("PHOTO_RECORD 목표도 동일하게 동작한다")
+        void PHOTO_RECORD_목표달성() {
+            WeeklyGoal goal = buildGoal(GoalActionType.PHOTO_RECORD, 2, 1);
+            given(weeklyGoalRepository.findFirstByUserAndWeekStartDateOrderByCreatedAtDesc(user, weekStart))
+                    .willReturn(Optional.of(goal));
+
+            boolean result = weeklyGoalService.handleGoalProgress(1L, GoalActionType.PHOTO_RECORD);
+
+            assertThat(result).isTrue();
+            assertThat(goal.isAchieved()).isTrue();
+            verify(cookieService).updateCookie(1L, CookieLog.CookieLogType.BONUS_WEEKLY_GOAL_ACHIEVE);
+        }
+    }
+
+    @Nested
+    @DisplayName("handleGoalUndo - 목표 카운트 감소")
+    class HandleGoalUndo {
+
+        @Test
+        @DisplayName("미달성 상태에서 취소하면 카운트가 감소한다")
+        void 미달성_카운트감소() {
+            WeeklyGoal goal = buildGoal(GoalActionType.RECIPE_LIKE, 3, 2);
+            given(weeklyGoalRepository.findFirstByUserAndWeekStartDateOrderByCreatedAtDesc(user, weekStart))
+                    .willReturn(Optional.of(goal));
+
+            weeklyGoalService.handleGoalUndo(1L, GoalActionType.RECIPE_LIKE);
+
+            assertThat(goal.getCurrentCount()).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("카운트가 0일 때 취소해도 음수가 되지 않는다")
+        void 카운트0_취소시_음수방지() {
+            WeeklyGoal goal = buildGoal(GoalActionType.RECIPE_LIKE, 3, 0);
+            given(weeklyGoalRepository.findFirstByUserAndWeekStartDateOrderByCreatedAtDesc(user, weekStart))
+                    .willReturn(Optional.of(goal));
+
+            weeklyGoalService.handleGoalUndo(1L, GoalActionType.RECIPE_LIKE);
+
+            assertThat(goal.getCurrentCount()).isZero();
+        }
+
+        @Test
+        @DisplayName("이미 달성된 경우 취소해도 카운트가 변하지 않는다")
+        void 달성후_카운트불변() {
+            WeeklyGoal goal = buildGoal(GoalActionType.RECIPE_LIKE, 1, 0);
+            goal.incrementCount(); // isAchieved = true
+
+            given(weeklyGoalRepository.findFirstByUserAndWeekStartDateOrderByCreatedAtDesc(user, weekStart))
+                    .willReturn(Optional.of(goal));
+
+            weeklyGoalService.handleGoalUndo(1L, GoalActionType.RECIPE_LIKE);
+
+            assertThat(goal.getCurrentCount()).isEqualTo(1); // 변화 없음
+            assertThat(goal.isAchieved()).isTrue();
+        }
+
+        @Test
+        @DisplayName("목표가 없으면 아무 동작도 하지 않는다")
+        void 목표없음_노옵() {
+            given(weeklyGoalRepository.findFirstByUserAndWeekStartDateOrderByCreatedAtDesc(user, weekStart))
+                    .willReturn(Optional.empty());
+
+            weeklyGoalService.handleGoalUndo(1L, GoalActionType.RECIPE_LIKE);
+
+            verifyNoInteractions(cookieService);
+        }
+    }
+
+    @Nested
+    @DisplayName("like/unlike 반복 시나리오")
+    class LikeToggleScenario {
+
+        @Test
+        @DisplayName("같은 레시피 like-unlike-like 반복 시 카운트는 최대 1이다")
+        void 좋아요_토글반복_카운트최대1() {
+            WeeklyGoal goal = buildGoal(GoalActionType.RECIPE_LIKE, 3, 0);
+            given(weeklyGoalRepository.findFirstByUserAndWeekStartDateOrderByCreatedAtDesc(user, weekStart))
+                    .willReturn(Optional.of(goal));
+
+            weeklyGoalService.handleGoalProgress(1L, GoalActionType.RECIPE_LIKE); // like → 1
+            weeklyGoalService.handleGoalUndo(1L, GoalActionType.RECIPE_LIKE);     // unlike → 0
+            weeklyGoalService.handleGoalProgress(1L, GoalActionType.RECIPE_LIKE); // like → 1
+            weeklyGoalService.handleGoalUndo(1L, GoalActionType.RECIPE_LIKE);     // unlike → 0
+            weeklyGoalService.handleGoalProgress(1L, GoalActionType.RECIPE_LIKE); // like → 1
+
+            assertThat(goal.getCurrentCount()).isEqualTo(1);
+            assertThat(goal.isAchieved()).isFalse();
+            verifyNoInteractions(cookieService);
+        }
+
+        @Test
+        @DisplayName("서로 다른 레시피 3개에 좋아요를 누르면 목표가 달성된다")
+        void 다른레시피3개_좋아요_목표달성() {
+            WeeklyGoal goal = buildGoal(GoalActionType.RECIPE_LIKE, 3, 0);
+            given(weeklyGoalRepository.findFirstByUserAndWeekStartDateOrderByCreatedAtDesc(user, weekStart))
+                    .willReturn(Optional.of(goal));
+
+            weeklyGoalService.handleGoalProgress(1L, GoalActionType.RECIPE_LIKE); // 레시피A → 1
+            weeklyGoalService.handleGoalProgress(1L, GoalActionType.RECIPE_LIKE); // 레시피B → 2
+            boolean achieved = weeklyGoalService.handleGoalProgress(1L, GoalActionType.RECIPE_LIKE); // 레시피C → 3
+
+            assertThat(achieved).isTrue();
+            assertThat(goal.getCurrentCount()).isEqualTo(3);
+            assertThat(goal.isAchieved()).isTrue();
+            verify(cookieService, times(1)).updateCookie(1L, CookieLog.CookieLogType.BONUS_WEEKLY_GOAL_ACHIEVE);
+        }
+    }
+
+    // 테스트용 WeeklyGoal 빌더 헬퍼
+    private WeeklyGoal buildGoal(GoalActionType actionType, int targetCount, int initialCount) {
+        WeeklyGoal goal = WeeklyGoal.builder()
+                .user(user)
+                .goalActionType(actionType)
+                .targetCount(targetCount)
+                .weekStartDate(weekStart)
+                .build();
+        for (int i = 0; i < initialCount; i++) {
+            goal.incrementCount();
+        }
+        return goal;
+    }
+}


### PR DESCRIPTION
# Related Issue
CLOSE #163 

# Description                                                                                                                                                          
주간 목표 중 `PHOTO_RECORD`(요리 사진 n번 기록하기), `RECIPE_LIKE`(다른 사람 레시피 좋아요 n회 남기기) 두 가지 유형에 대한 달성 체크 및 쿠키 지급 기능을 구현합니다.
목표 달성 여부는  **API 응답에 포함**된 `weeklyGoalAchieved` 필드를 통해 전달하며, 이를 통해 프론트엔드에서 모달 노출 여부를 판단할 수 있습니다.  

# Changes
- **`WeeklyGoalService` 추가**
    - **`handleGoalProgress()` : 액션 발생 시 호출**되며, 해당 타입의 주간 목표 카운트 증가, 달성 시 `BONUS_WEEKLY_GOAL_ACHIEVE` 쿠키 지급
    - `handleGoalUndo()` : 좋아요 취소 시 현재의 카운트 감소 (그러나 목표 달성 이후에는 동작하지 않음)
- `WeeklyGoal` 엔티티에 `decrementCount()` 추가 — `isAchieved` = true이면 감소 차단 
- `DailyRecipeService` — 사진 포함 레시피 등록/수정 시 `PHOTO_RECORD` 목표 진행 처리
- `RecipeLikeService` — 좋아요 추가 시 `RECIPE_LIKE` 목표 진행, but 좋아요 취소 시 카운트 감소 처리
- **응답 DTO 3개(`DailyRecipeCreateResponseDto`, `DailyRecipeDetailResponseDto`, `RecipeLikeResponseDto`)에 `weeklyGoalAchieved` 필드 추가**

 # Test

주간 목표 달성과 관련한 단위 테스트를 만들어 서비스 내 로직을 검증하는 작업을 거쳤습니다.

`WeeklyGoalServiceTest` (13개)
- 목표 없음 / 타입 불일치 / 이미 달성 → false 반환, 카운트 및 쿠키 변화 없음
- 미달성 카운트 증가 → false 반환
- 목표 달성 → true 반환, 쿠키 지급 1회 확인
- handleGoalUndo — 미달성 시 카운트 감소, 달성 이후 카운트 불변
- like-unlike 반복 시나리오 — 같은 레시피로 카운트 최대 1, 다른 레시피 3개 좋아요 시 정상 달성
    
`RecipeLikeServiceTest` (9개)
- 좋아요 추가 시 handleGoalProgress 호출 확인, weeklyGoalAchieved 반환값 검증
- 좋아요 취소 시 handleGoalUndo 호출, handleGoalProgress 미호출 확인
- 자신의 레시피 좋아요 / 없는 레시피 좋아요 → 예외 발생, goal 메서드 미호출 확인

`DailyRecipeServiceTest` (7개)
- 사진 포함 레시피 등록 시 handleGoalProgress 호출, 목표 달성 시 weeklyGoalAchieved=true 반환
- 사진 없이 등록 시 handleGoalProgress 미호출, weeklyGoalAchieved=false 반환
- 사진 없던 레시피에 신규 사진 추가 시 handleGoalProgress 호출, 목표 달성 시 weeklyGoalAchieved=true 반환
- 기존 사진이 있는 레시피에 사진 교체 시 handleGoalProgress 미호출