### PR TITLE
Feat: 최근 등록한 식재료 조회 API

### DIFF
--- a/src/main/java/com/cookeep/cookeep/api/controller/RecentIngredientController.java
+++ b/src/main/java/com/cookeep/cookeep/api/controller/RecentIngredientController.java
@@ -1,0 +1,54 @@
+package com.cookeep.cookeep.api.controller;
+
+import com.cookeep.cookeep.api.dto.response.RecentIngredientsResponseDto;
+import com.cookeep.cookeep.common.dto.DataResponse;
+import com.cookeep.cookeep.common.exception.ErrorCode;
+import com.cookeep.cookeep.config.ApiErrorCodeExamples;
+import com.cookeep.cookeep.domain.ingredient.useringredient.application.RecentIngredientService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "(MAIN01-3) 최근 추가한 재료", description = "직전 배치에서 추가한 재료 목록 조회 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/users/me/ingredients")
+public class RecentIngredientController {
+
+    private final RecentIngredientService recentIngredientService;
+
+    @Operation(
+            summary = "최근 추가한 재료 목록 조회",
+            description = "재료 등록 화면에서 유저가 최근에 추가한 리스트 목록 응답. 첫 등록은 빈 리스트 응답"
+    )
+    @ApiErrorCodeExamples({
+            ErrorCode.UNAUTHORIZED,
+            ErrorCode.INTERNAL_SERVER_ERROR
+    })
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "최근 추가한 재료 목록 조회 성공"),
+            @ApiResponse(responseCode = "401", description = """
+                    인증 실패입니다.
+                    - UNAUTHORIZED: 인증 정보가 없거나 유효하지 않습니다.
+                    """, content = @Content),
+            @ApiResponse(responseCode = "500", description = """
+                    서버 오류입니다.
+                    - INTERNAL_SERVER_ERROR: 서버 내부 오류가 발생했습니다.
+                    """, content = @Content)
+    })
+    @GetMapping("/recent")
+    public ResponseEntity<DataResponse<RecentIngredientsResponseDto>> getRecentIngredients(
+            @AuthenticationPrincipal(expression = "userId") Long userId
+    ) {
+        RecentIngredientsResponseDto response = recentIngredientService.getRecentIngredients(userId);
+        return ResponseEntity.ok(DataResponse.from(response));
+    }
+}

--- a/src/main/java/com/cookeep/cookeep/api/dto/response/RecentIngredientsResponseDto.java
+++ b/src/main/java/com/cookeep/cookeep/api/dto/response/RecentIngredientsResponseDto.java
@@ -1,0 +1,50 @@
+package com.cookeep.cookeep.api.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Schema(
+        name = "RecentIngredientsResponse",
+        description = "최근 추가한 재료 목록 응답 DTO"
+)
+@Getter
+@Builder
+@AllArgsConstructor
+public class RecentIngredientsResponseDto {
+
+    @Schema(description = "최근 추가한 재료 목록 (등록 순서 오름차순)")
+    private List<RecentIngredientItem> ingredients;
+
+    @Schema(
+            name = "RecentIngredientItem",
+            description = "최근 추가한 개별 재료 항목"
+    )
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    public static class RecentIngredientItem {
+
+        @Schema(description = "유저 식재료 ID", example = "12")
+        private Long ingredientId;
+
+        @Schema(
+                description = "식재료 타입",
+                example = "DEFAULT",
+                allowableValues = {"DEFAULT", "CUSTOM"}
+        )
+        private String type;
+
+        @Schema(description = "식재료 이름", example = "사과")
+        private String name;
+
+        @Schema(
+                description = "식재료 이미지 URL",
+                example = "https://cookeep-images.s3.ap-northeast-2.amazonaws.com/ingredients/apple.png"
+        )
+        private String imageUrl;
+    }
+}

--- a/src/main/java/com/cookeep/cookeep/domain/ingredient/useringredient/application/RecentIngredientService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/ingredient/useringredient/application/RecentIngredientService.java
@@ -1,0 +1,113 @@
+package com.cookeep.cookeep.domain.ingredient.useringredient.application;
+
+import com.cookeep.cookeep.api.dto.response.RecentIngredientsResponseDto;
+import com.cookeep.cookeep.common.exception.AppException;
+import com.cookeep.cookeep.common.exception.ErrorCode;
+import com.cookeep.cookeep.domain.ingredient.common.domain.Type;
+import com.cookeep.cookeep.domain.ingredient.customingredient.dao.CustomIngredientRepository;
+import com.cookeep.cookeep.domain.ingredient.customingredient.entity.CustomIngredient;
+import com.cookeep.cookeep.domain.ingredient.defaultingredient.dao.DefaultIngredientRepository;
+import com.cookeep.cookeep.domain.ingredient.defaultingredient.entity.DefaultIngredient;
+import com.cookeep.cookeep.domain.ingredient.useringredient.dao.RecentIngredientBatchRepository;
+import com.cookeep.cookeep.domain.ingredient.useringredient.dao.UserIngredientRepository;
+import com.cookeep.cookeep.domain.ingredient.useringredient.entity.RecentIngredientBatch;
+import com.cookeep.cookeep.domain.ingredient.useringredient.entity.UserIngredient;
+import com.cookeep.cookeep.domain.user.dao.UserRepository;
+import com.cookeep.cookeep.domain.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class RecentIngredientService {
+
+    private final RecentIngredientBatchRepository batchRepository;
+    private final UserIngredientRepository userIngredientRepository;
+    private final DefaultIngredientRepository defaultIngredientRepository;
+    private final CustomIngredientRepository customIngredientRepository;
+    private final UserRepository userRepository;
+
+    // 유저의 직전 배치에 해당하는 재료 목록 반환 (첫 등록은 빈 리스트)
+    public RecentIngredientsResponseDto getRecentIngredients(Long userId) {
+        if (userId == null) {
+            throw new AppException(ErrorCode.UNAUTHORIZED);
+        }
+
+        // 최신 batchId 조회; 없으면 빈 결과 반환
+        return batchRepository.findByUser_UserId(userId)
+                .map(batch -> buildResponse(userId, batch.getBatchId()))
+                .orElseGet(() -> RecentIngredientsResponseDto.builder()
+                        .ingredients(List.of())
+                        .build());
+    }
+
+    // 배치 저장: 재료 등록 완료 후 호출하여 최신 batchId를 업데이트
+    @Transactional
+    public void saveBatch(Long userId, String batchId) {
+        batchRepository.findByUser_UserId(userId)
+                .ifPresentOrElse(
+                        existing -> existing.updateBatchId(batchId),
+                        () -> {
+                            User user = userRepository.findById(userId)
+                                    .orElseThrow(() -> new AppException(ErrorCode.USER_NOT_FOUND));
+                            batchRepository.save(
+                                    RecentIngredientBatch.builder()
+                                            .user(user)
+                                            .batchId(batchId)
+                                            .build()
+                            );
+                        }
+                );
+    }
+
+    // UUID 생성하여 반환. createAll() 에서 배치 시작 시 호출
+    public static String generateBatchId() {
+        return UUID.randomUUID().toString();
+    }
+
+    // 내부 메서드
+    private RecentIngredientsResponseDto buildResponse(Long userId, String batchId) {
+        List<UserIngredient> ingredients =
+                userIngredientRepository.findByUserIdAndBatchId(userId, batchId);
+
+        List<RecentIngredientsResponseDto.RecentIngredientItem> items = ingredients.stream()
+                .map(this::toItem)
+                .toList();
+
+        return RecentIngredientsResponseDto.builder()
+                .ingredients(items)
+                .build();
+    }
+
+    private RecentIngredientsResponseDto.RecentIngredientItem toItem(UserIngredient ui) {
+        String name;
+        String imageUrl;
+
+        if (ui.getType() == Type.DEFAULT) {
+            DefaultIngredient ref = defaultIngredientRepository
+                    .findById(ui.getReferenceId())
+                    .orElse(null);
+            name = ref != null ? ref.getIngredient() : "Unknown";
+            imageUrl = ref != null ? ref.getImageUrl() : "";
+        } else {
+            CustomIngredient ref = customIngredientRepository
+                    .findById(ui.getReferenceId())
+                    .orElse(null);
+            name = ref != null ? ref.getName() : "Unknown";
+            imageUrl = ref != null ? ref.getImageUrl() : "";
+        }
+
+        return RecentIngredientsResponseDto.RecentIngredientItem.builder()
+                .ingredientId(ui.getIngredientId())
+                .type(ui.getType().name())
+                .name(name)
+                .imageUrl(imageUrl)
+                .build();
+    }
+
+}

--- a/src/main/java/com/cookeep/cookeep/domain/ingredient/useringredient/application/UserIngredientServiceImpl.java
+++ b/src/main/java/com/cookeep/cookeep/domain/ingredient/useringredient/application/UserIngredientServiceImpl.java
@@ -40,6 +40,7 @@ public class UserIngredientServiceImpl implements UserIngredientService {
     private final CustomIngredientRepository customIngredientRepository;
     private final ConsumptionReportService consumptionReportService;
     private final UserRepository userRepository;
+    private final RecentIngredientService recentIngredientService;
 
     // 1. 기본 정보 조회 (저장 안 함)
     @Override
@@ -76,24 +77,37 @@ public class UserIngredientServiceImpl implements UserIngredientService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new AppException(ErrorCode.USER_NOT_FOUND));
 
+        // 등록 배치 UUID 생성
+        String batchId = RecentIngredientService.generateBatchId();
+
         List<UserIngredientCreateResponseDto> results = requests.stream()
-                .map(req -> createOne(user, req))
+                .map(req -> createOne(user, req, batchId))
                 .toList();
+
+        // 최신 배치 ID 저장 (upsert)
+        recentIngredientService.saveBatch(userId, batchId);
 
         return UserIngredientListCreateResponseDto.of(results);
     }
 
-    private UserIngredientCreateResponseDto createOne(User user, UserIngredientCreateRequestDto req) {
+    private UserIngredientCreateResponseDto createOne(
+            User user,
+            UserIngredientCreateRequestDto req,
+            String batchId) {
 
         if (req.getType() == Type.DEFAULT) {
-            return createFromDefault(user, req);
+            return createFromDefault(user, req, batchId);
         } else {
-            return createFromCustom(user, req);
+            return createFromCustom(user, req, batchId);
         }
 
     }
 
-    private UserIngredientCreateResponseDto createFromDefault(User user, UserIngredientCreateRequestDto req) {
+    private UserIngredientCreateResponseDto createFromDefault(
+            User user,
+            UserIngredientCreateRequestDto req,
+            String batchId) {
+
         DefaultIngredient ref = defaultIngredientRepository.findById(req.getReferenceId())
                 .orElseThrow(() -> new AppException(ErrorCode.INGREDIENT_REFERENCE_NOT_FOUND));
 
@@ -112,6 +126,7 @@ public class UserIngredientServiceImpl implements UserIngredientService {
                 .storage(storage)
                 .expirationDate(expiration)
                 .memo(memo)
+                .batchId(batchId)
                 .build();
 
         UserIngredient saved = userIngredientRepository.save(entity);
@@ -122,7 +137,12 @@ public class UserIngredientServiceImpl implements UserIngredientService {
         return UserIngredientCreateResponseDto.of(entity, ref.getIngredient(), ref.getImageUrl());
     }
 
-    private UserIngredientCreateResponseDto createFromCustom(User user, UserIngredientCreateRequestDto req) {
+    private UserIngredientCreateResponseDto createFromCustom(
+            User user,
+            UserIngredientCreateRequestDto req,
+            String batchId
+            ) {
+
         CustomIngredient ref = customIngredientRepository
                 .findByIdAndUserId(req.getReferenceId(), user.getUserId())
                 .orElseThrow(() -> new AppException(ErrorCode.INGREDIENT_REFERENCE_NOT_FOUND));
@@ -142,6 +162,7 @@ public class UserIngredientServiceImpl implements UserIngredientService {
                 .storage(storage)
                 .expirationDate(expiration)
                 .memo(memo)
+                .batchId(batchId)
                 .build();
 
         UserIngredient saved = userIngredientRepository.save(entity);

--- a/src/main/java/com/cookeep/cookeep/domain/ingredient/useringredient/dao/RecentIngredientBatchRepository.java
+++ b/src/main/java/com/cookeep/cookeep/domain/ingredient/useringredient/dao/RecentIngredientBatchRepository.java
@@ -1,0 +1,11 @@
+package com.cookeep.cookeep.domain.ingredient.useringredient.dao;
+
+import com.cookeep.cookeep.domain.ingredient.useringredient.entity.RecentIngredientBatch;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface RecentIngredientBatchRepository extends JpaRepository<RecentIngredientBatch, Long> {
+
+    Optional<RecentIngredientBatch> findByUser_UserId(Long userId);
+}

--- a/src/main/java/com/cookeep/cookeep/domain/ingredient/useringredient/dao/UserIngredientRepository.java
+++ b/src/main/java/com/cookeep/cookeep/domain/ingredient/useringredient/dao/UserIngredientRepository.java
@@ -132,4 +132,17 @@ public interface UserIngredientRepository extends JpaRepository<UserIngredient, 
             @Param("expirationDate") LocalDate expirationDate
     );
 
+    // 최근 식재료 조회 (batchId에 해당하는 식재료 응답)
+    @Query("""
+        SELECT ui
+        FROM UserIngredient ui
+        WHERE ui.user.userId = :userId
+          AND ui.batchId = :batchId
+        ORDER BY ui.ingredientId ASC
+    """)
+    List<UserIngredient> findByUserIdAndBatchId(
+            @Param("userId") Long userId,
+            @Param("batchId") String batchId
+    );
+
 }

--- a/src/main/java/com/cookeep/cookeep/domain/ingredient/useringredient/entity/RecentIngredientBatch.java
+++ b/src/main/java/com/cookeep/cookeep/domain/ingredient/useringredient/entity/RecentIngredientBatch.java
@@ -1,0 +1,39 @@
+package com.cookeep.cookeep.domain.ingredient.useringredient.entity;
+
+import com.cookeep.cookeep.common.entity.BaseEntity;
+import com.cookeep.cookeep.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "recent_ingredient_batch")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RecentIngredientBatch extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false, unique = true)
+    private User user;
+
+    // 마지막 등록 배치의 UUID
+    @Column(name = "batch_id", nullable = false, length = 36)
+    private String batchId;
+
+    @Builder
+    public RecentIngredientBatch(User user, String batchId) {
+        this.user = user;
+        this.batchId = batchId;
+    }
+
+    public void updateBatchId(String batchId) {
+        this.batchId = batchId;
+    }
+
+}

--- a/src/main/java/com/cookeep/cookeep/domain/ingredient/useringredient/entity/UserIngredient.java
+++ b/src/main/java/com/cookeep/cookeep/domain/ingredient/useringredient/entity/UserIngredient.java
@@ -52,6 +52,9 @@ public class UserIngredient extends BaseEntity {
     @Column(name = "left_days", nullable = false)
     private Integer leftDays;
 
+    @Column(name = "batch_id", length = 36, nullable = true)
+    private String batchId;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
@@ -64,7 +67,8 @@ public class UserIngredient extends BaseEntity {
             Unit unit, Storage storage,
             LocalDate expirationDate,
             String memo,
-            User user) {
+            User user,
+            String batchId) {
 
         this.type = type;
         this.referenceId = referenceId;
@@ -74,6 +78,7 @@ public class UserIngredient extends BaseEntity {
         this.expirationDate = expirationDate;
         this.memo = memo;
         this.user = user;
+        this.batchId = batchId;
         this.leftDays = calculateLeftDays(expirationDate);
     }
 


### PR DESCRIPTION
# Issue
#171 

# Description
- 재료 등록 화면 하단에 노출되는 "최근 추가한 재료" 목록 조회 API 구현
- 유저가 직전에 한 번에 추가한 재료 묶음을 배치(batch) 단위로 추적
- 첫 등록 이후 재료 등록 화면 진입 시 이전에 추가했던 재료 표시
- createAll() 호출 시마다 UUID(batchId)를 생성하여 해당 배치의 모든 UserIngredient에 저장
- 유저별 최신 batchId를 recent_ingredient_batch 테이블에 upsert
- 조회 시 최신 batchId에 해당하는 재료 목록 반환
- API 명세서 페이지: https://www.notion.so/MAIN01-3-3223f76f87248094b728f8416bba7c4c?v=2dd3f76f872481de9fac000c187b217a&source=copy_link

# Changes
Entity
- UserIngredient : batchId 필드 추가 (기존 데이터 호환을 위해 nullable)
- RecentIngredientBatch: 유저당 최신 batchId를 저장하는 신규 Entity

Repository
- UserIngredientRepository: findByUserIdAndBatchId 쿼리 추가
- RecentIngredientBatchRepository: findByUser_UserId 쿼리 추가

Service
- UserIngredientServiceImpl.createAll(): createAll() 에 batchId 생성 및 saveBatch() 호출 추가
- RecentIngredientService: 조회(getRecentIngredients), 배치 저장(saveBatch) 메서드 구현

Controller / DTO
- RecentIngredientController: GET /api/users/me/ingredients/recent
- RecentIngredientsResponseDto: [{ingredientId, type, name, imageUrl}] 응답 DTO

# Test Checklist
- [x] 한 번도 재료를 추가하지 않은 유저는 빈 리스트 반환
- [x] 재료를 처음 추가한 뒤 /recent 호출 시 해당 재료 목록 반환
- [x] 재료를 다시 추가한 뒤 /recent 호출 시 직전 배치의 재료 목록으로 교체되어 반환
- [x] DEFAULT / CUSTOM 타입 재료가 혼합된 배치 정상 반환