### PR TITLE
fix: 쿠킵스 식물 돌봄 랭킹 관련 수정

### DIFF
--- a/src/main/java/com/cookeep/cookeep/api/controller/CookeepsController.java
+++ b/src/main/java/com/cookeep/cookeep/api/controller/CookeepsController.java
@@ -13,6 +13,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "쿠킵스", description = "쿠킵스 관련 API")
@@ -28,8 +29,9 @@ public class CookeepsController {
 		@ApiResponse(responseCode = "200", description = "조회 성공")
 	})
 	@GetMapping("/ranking")
-	public ResponseEntity<DataResponse<RankingResponseDto>> getRanking() {
-		return ResponseEntity.ok(DataResponse.from(cookeepsService.getRanking()));
+	public ResponseEntity<DataResponse<RankingResponseDto>> getRanking(
+			@AuthenticationPrincipal(expression = "userId") Long userId) {
+		return ResponseEntity.ok(DataResponse.from(cookeepsService.getRanking(userId)));
 	}
 
 	@Operation(summary = "이번 주 레시피 전체보기", description = "이번 주차에 올라온 레시피들을 정렬 필터와 함께 조회합니다.")

--- a/src/main/java/com/cookeep/cookeep/api/controller/CookeepsController.java
+++ b/src/main/java/com/cookeep/cookeep/api/controller/CookeepsController.java
@@ -24,7 +24,7 @@ public class CookeepsController {
 
 	private final CookeepsService cookeepsService;
 
-	@Operation(summary = "이번 주 랭킹 조회", description = "이번 주 물주기 횟수 Top 3 유저와 좋아요 Top 3 레시피를 조회합니다.")
+	@Operation(summary = "쿠킵스 랭킹 조회", description = "이번 달 물주기 횟수 Top 3 유저와 이번주 좋아요 Top 3 레시피를 조회합니다.")
 	@ApiResponses(value = {
 		@ApiResponse(responseCode = "200", description = "조회 성공")
 	})

--- a/src/main/java/com/cookeep/cookeep/api/dto/response/RankingResponseDto.java
+++ b/src/main/java/com/cookeep/cookeep/api/dto/response/RankingResponseDto.java
@@ -10,6 +10,7 @@ import java.util.List;
 public class RankingResponseDto {
 	private List<WateringRankDto> wateringRanking;
 	private List<RecipeRankDto> recipeRanking;
+	private Long myWateringCount;
 
 	@Getter
 	@Builder

--- a/src/main/java/com/cookeep/cookeep/domain/cookeeps/application/CookeepsService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/cookeeps/application/CookeepsService.java
@@ -36,7 +36,7 @@ public class CookeepsService {
 	private final DailyRecipeRepository dailyRecipeRepository;
 
 	@Transactional(readOnly = true)
-	public RankingResponseDto getRanking() {
+	public RankingResponseDto getRanking(Long userId) {
 		LocalDateTime monthStart = LocalDate.now().withDayOfMonth(1).atStartOfDay();
 		LocalDateTime monthEnd = monthStart.plusMonths(1);
 
@@ -47,10 +47,12 @@ public class CookeepsService {
 
 		List<WateringRankDto> wateringRanking = getWateringRanking(monthStart, monthEnd);
 		List<RecipeRankDto> recipeRanking = getRecipeRanking(weekStart, weekEnd);
+		Long myWateringCount = wateringLogRepository.countByUserAndMonth(userId, monthStart, monthEnd);
 
 		return RankingResponseDto.builder()
 			.wateringRanking(wateringRanking)
 			.recipeRanking(recipeRanking)
+			.myWateringCount(myWateringCount)
 			.build();
 	}
 

--- a/src/main/java/com/cookeep/cookeep/domain/cookeeps/application/CookeepsService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/cookeeps/application/CookeepsService.java
@@ -37,12 +37,15 @@ public class CookeepsService {
 
 	@Transactional(readOnly = true)
 	public RankingResponseDto getRanking() {
+		LocalDateTime monthStart = LocalDate.now().withDayOfMonth(1).atStartOfDay();
+		LocalDateTime monthEnd = monthStart.plusMonths(1);
+
 		LocalDateTime weekStart = LocalDate.now()
 			.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY))
 			.atStartOfDay();
 		LocalDateTime weekEnd = weekStart.plusDays(7);
 
-		List<WateringRankDto> wateringRanking = getWateringRanking(weekStart, weekEnd);
+		List<WateringRankDto> wateringRanking = getWateringRanking(monthStart, monthEnd);
 		List<RecipeRankDto> recipeRanking = getRecipeRanking(weekStart, weekEnd);
 
 		return RankingResponseDto.builder()
@@ -51,10 +54,10 @@ public class CookeepsService {
 			.build();
 	}
 
-	private List<WateringRankDto> getWateringRanking(LocalDateTime weekStart, LocalDateTime weekEnd) {
-		// 1단계: 이번 주 물주기 상위 3명 조회
+	private List<WateringRankDto> getWateringRanking(LocalDateTime monthStart, LocalDateTime monthEnd) {
+		// 1단계: 이번 달 물주기 상위 3명 조회
 		List<Object[]> results = wateringLogRepository.findTopWateringUsers(
-			weekStart, weekEnd, PageRequest.of(0, 3));
+			monthStart, monthEnd, PageRequest.of(0, 3));
 		
 		// 2단계: 인덱스를 포함한 스트림 처리
 		return IntStream.range(0, results.size()) // 0부터 results 크기-1까지

--- a/src/main/java/com/cookeep/cookeep/domain/plant/dao/WateringLogRepository.java
+++ b/src/main/java/com/cookeep/cookeep/domain/plant/dao/WateringLogRepository.java
@@ -14,6 +14,15 @@ import java.util.List;
 public interface WateringLogRepository extends JpaRepository<WateringLog, Long> {
     boolean existsByUserUserId(Long userId);
 
+    // 특정 유저의 이번 달 물주기 횟수 조회
+    @Query("SELECT COUNT(w) FROM WateringLog w " +
+           "WHERE w.user.userId = :userId " +
+           "AND w.createdAt >= :monthStart AND w.createdAt < :monthEnd")
+    Long countByUserAndMonth(
+            @Param("userId") Long userId,
+            @Param("monthStart") LocalDateTime monthStart,
+            @Param("monthEnd") LocalDateTime monthEnd);
+
     // 이번 달 물주기 횟수 Top N 유저 조회
     @Query("SELECT w.user, COUNT(w) FROM WateringLog w " +
            "WHERE w.createdAt >= :monthStart AND w.createdAt < :monthEnd " +

--- a/src/main/java/com/cookeep/cookeep/domain/plant/dao/WateringLogRepository.java
+++ b/src/main/java/com/cookeep/cookeep/domain/plant/dao/WateringLogRepository.java
@@ -14,12 +14,12 @@ import java.util.List;
 public interface WateringLogRepository extends JpaRepository<WateringLog, Long> {
     boolean existsByUserUserId(Long userId);
 
-    // 이번 주 물주기 횟수 Top N 유저 조회
+    // 이번 달 물주기 횟수 Top N 유저 조회
     @Query("SELECT w.user, COUNT(w) FROM WateringLog w " +
-           "WHERE w.createdAt >= :weekStart AND w.createdAt < :weekEnd " +
+           "WHERE w.createdAt >= :monthStart AND w.createdAt < :monthEnd " +
            "GROUP BY w.user ORDER BY COUNT(w) DESC")
     List<Object[]> findTopWateringUsers(
-            @Param("weekStart") LocalDateTime weekStart,
-            @Param("weekEnd") LocalDateTime weekEnd,
+            @Param("monthStart") LocalDateTime monthStart,
+            @Param("monthEnd") LocalDateTime monthEnd,
             Pageable pageable);
 }

--- a/src/test/java/com/cookeep/cookeep/domain/cookeeps/application/CookeepsServiceTest.java
+++ b/src/test/java/com/cookeep/cookeep/domain/cookeeps/application/CookeepsServiceTest.java
@@ -1,0 +1,174 @@
+package com.cookeep.cookeep.domain.cookeeps.application;
+
+import com.cookeep.cookeep.api.dto.response.RankingResponseDto;
+import com.cookeep.cookeep.domain.dailyrecipe.dao.DailyRecipeRepository;
+import com.cookeep.cookeep.domain.plant.dao.WateringLogRepository;
+import com.cookeep.cookeep.domain.user.entity.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Pageable;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class CookeepsServiceTest {
+
+    @Mock private WateringLogRepository wateringLogRepository;
+    @Mock private DailyRecipeRepository dailyRecipeRepository;
+
+    @InjectMocks
+    private CookeepsService cookeepsService;
+
+    private static final Long USER_ID = 1L;
+
+    @BeforeEach
+    void setUp() {
+        given(wateringLogRepository.findTopWateringUsers(any(), any(), any())).willReturn(List.of());
+        given(wateringLogRepository.countByUserAndMonth(any(), any(), any())).willReturn(0L);
+        given(dailyRecipeRepository.findTopRankedRecipes(any(), any(), any())).willReturn(List.of());
+    }
+
+    @Nested
+    @DisplayName("getRanking - 물주기 랭킹 월별 기준")
+    class WateringRanking {
+
+        @Test
+        @DisplayName("물주기 랭킹 조회 시 이번 달 1일 00:00:00부터 다음 달 1일 00:00:00 범위로 조회한다")
+        void 물주기_랭킹_이번달_범위로_조회() {
+            cookeepsService.getRanking(USER_ID);
+
+            ArgumentCaptor<LocalDateTime> startCaptor = ArgumentCaptor.forClass(LocalDateTime.class);
+            ArgumentCaptor<LocalDateTime> endCaptor = ArgumentCaptor.forClass(LocalDateTime.class);
+            verify(wateringLogRepository).findTopWateringUsers(
+                    startCaptor.capture(), endCaptor.capture(), any(Pageable.class));
+
+            LocalDateTime expectedStart = LocalDate.now().withDayOfMonth(1).atStartOfDay();
+            LocalDateTime expectedEnd = expectedStart.plusMonths(1);
+
+            assertThat(startCaptor.getValue()).isEqualTo(expectedStart);
+            assertThat(endCaptor.getValue()).isEqualTo(expectedEnd);
+        }
+
+        @Test
+        @DisplayName("물주기 랭킹은 상위 3명을 1~3위 순위와 함께 반환한다")
+        void 물주기_랭킹_상위3명_순위반환() {
+            User user1 = User.builder().nickname("유저1").build();
+            User user2 = User.builder().nickname("유저2").build();
+            User user3 = User.builder().nickname("유저3").build();
+
+            List<Object[]> rows = new ArrayList<>();
+            rows.add(new Object[]{user1, 10L});
+            rows.add(new Object[]{user2, 7L});
+            rows.add(new Object[]{user3, 5L});
+            given(wateringLogRepository.findTopWateringUsers(any(), any(), any())).willReturn(rows);
+
+            RankingResponseDto result = cookeepsService.getRanking(USER_ID);
+
+            List<RankingResponseDto.WateringRankDto> ranking = result.getWateringRanking();
+            assertThat(ranking).hasSize(3);
+            assertThat(ranking.get(0).getRank()).isEqualTo(1);
+            assertThat(ranking.get(0).getNickname()).isEqualTo("유저1");
+            assertThat(ranking.get(0).getWateringCount()).isEqualTo(10L);
+            assertThat(ranking.get(1).getRank()).isEqualTo(2);
+            assertThat(ranking.get(1).getNickname()).isEqualTo("유저2");
+            assertThat(ranking.get(2).getRank()).isEqualTo(3);
+            assertThat(ranking.get(2).getNickname()).isEqualTo("유저3");
+        }
+
+        @Test
+        @DisplayName("이번 달 물주기 기록이 없으면 빈 리스트를 반환한다")
+        void 물주기_없는경우_빈리스트_반환() {
+            RankingResponseDto result = cookeepsService.getRanking(USER_ID);
+
+            assertThat(result.getWateringRanking()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("프로필 식물이 없는 유저는 profileImageUrl이 null로 반환된다")
+        void 프로필식물_없는유저_profileImageUrl_null() {
+            User user = User.builder().nickname("유저").build();
+
+            List<Object[]> rows = new ArrayList<>();
+            rows.add(new Object[]{user, 5L});
+            given(wateringLogRepository.findTopWateringUsers(any(), any(), any())).willReturn(rows);
+
+            RankingResponseDto result = cookeepsService.getRanking(USER_ID);
+
+            assertThat(result.getWateringRanking().get(0).getProfileImageUrl()).isNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("getRanking - 나의 이번달 물주기 횟수")
+    class MyWateringCount {
+
+        @Test
+        @DisplayName("나의 이번달 물주기 횟수를 반환한다")
+        void 나의_이번달_물주기_횟수_반환() {
+            given(wateringLogRepository.countByUserAndMonth(any(), any(), any())).willReturn(12L);
+
+            RankingResponseDto result = cookeepsService.getRanking(USER_ID);
+
+            assertThat(result.getMyWateringCount()).isEqualTo(12L);
+        }
+
+        @Test
+        @DisplayName("나의 물주기 횟수 조회 시 이번 달 1일 00:00:00부터 다음 달 1일 00:00:00 범위와 userId로 조회한다")
+        void 나의_물주기_횟수_이번달_범위_및_userId로_조회() {
+            cookeepsService.getRanking(USER_ID);
+
+            ArgumentCaptor<Long> userIdCaptor = ArgumentCaptor.forClass(Long.class);
+            ArgumentCaptor<LocalDateTime> startCaptor = ArgumentCaptor.forClass(LocalDateTime.class);
+            ArgumentCaptor<LocalDateTime> endCaptor = ArgumentCaptor.forClass(LocalDateTime.class);
+            verify(wateringLogRepository).countByUserAndMonth(
+                    userIdCaptor.capture(), startCaptor.capture(), endCaptor.capture());
+
+            LocalDateTime expectedStart = LocalDate.now().withDayOfMonth(1).atStartOfDay();
+
+            assertThat(userIdCaptor.getValue()).isEqualTo(USER_ID);
+            assertThat(startCaptor.getValue()).isEqualTo(expectedStart);
+            assertThat(endCaptor.getValue()).isEqualTo(expectedStart.plusMonths(1));
+        }
+
+        @Test
+        @DisplayName("이번 달 물주기 기록이 없으면 0을 반환한다")
+        void 이번달_물주기_없으면_0_반환() {
+            RankingResponseDto result = cookeepsService.getRanking(USER_ID);
+
+            assertThat(result.getMyWateringCount()).isEqualTo(0L);
+        }
+    }
+
+    @Nested
+    @DisplayName("getRanking - 레시피 랭킹 주별 기준 유지")
+    class RecipeRanking {
+
+        @Test
+        @DisplayName("레시피 랭킹 조회 시 이번 주 월요일 00:00:00부터 정확히 7일 범위로 조회한다")
+        void 레시피_랭킹_이번주_7일_범위로_조회() {
+            cookeepsService.getRanking(USER_ID);
+
+            ArgumentCaptor<LocalDateTime> startCaptor = ArgumentCaptor.forClass(LocalDateTime.class);
+            ArgumentCaptor<LocalDateTime> endCaptor = ArgumentCaptor.forClass(LocalDateTime.class);
+            verify(dailyRecipeRepository).findTopRankedRecipes(
+                    startCaptor.capture(), endCaptor.capture(), any(Pageable.class));
+
+            assertThat(endCaptor.getValue()).isEqualTo(startCaptor.getValue().plusDays(7));
+        }
+    }
+}


### PR DESCRIPTION
# Related Issue
CLOSE #170 

# Description
`GET` `/api/cookeeps/ranking`의 물주기 랭킹 집계 기준을 이번 주에서 이번 달로 변경하고, 응답에 나의 이번달 물주기 횟수를 추가합니다.
매달 1일 00:00:00을 기준으로 자동 초기화됩니다.   

# Changes
  - 물주기 랭킹 기준 변경 (CookeepsService, WateringLogRepository)                                                                                                     
    - Top 3 유저 집계 범위: 이번 주 → 이번 달 1일 00:00:00 ~ 다음 달 1일 00:00:00
    - Repository JPQL 파라미터명 weekStart/weekEnd → monthStart/monthEnd 로 변경                                                                                       
  - 나의 이번달 물주기 횟수 추가 (RankingResponseDto, WateringLogRepository, CookeepsService, CookeepsController)                                                      
    - RankingResponseDto에 myWateringCount 필드 추가                                                                                                                   
    - WateringLogRepository에 countByUserAndMonth() 쿼리 추가                                                                                                          
    - CookeepsService.getRanking()에 userId 파라미터 추가                                                                                                              
    - CookeepsController에서 @AuthenticationPrincipal(expression = "userId")로 userId 주입

# Test

`CookeepsServiceTest` 신규 작성 (8개)              
                                                                                                                  
- 물주기 랭킹 조회 시 이번 달 1일 ~ 다음 달 1일 범위로 쿼리 호출 검증
- 상위 3명 1~3위 순위·닉네임·횟수 정확히 반환 검증                                                                                                                 
- 이번 달 기록 없을 때 빈 리스트 반환 검증                                                                                                                         
- 프로필 식물 없는 유저의 profileImageUrl null 검증                                                                                                                
- 나의 물주기 횟수 조회 시 올바른 userId·월별 범위로 쿼리 호출 검증                                                                                                
- 나의 물주기 횟수 정상 반환 검증                                                                                                                                  
- 이번 달 기록 없을 때 myWateringCount = 0 반환 검증                                                                                                               
- 레시피 랭킹 조회 범위는 기존처럼 7일(주간)임을 검증 