### PR TITLE
Fix: 최근 추가한 재료 6개 조회

### DIFF
--- a/src/main/java/com/cookeep/cookeep/domain/ingredient/useringredient/application/RecentIngredientService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/ingredient/useringredient/application/RecentIngredientService.java
@@ -76,9 +76,7 @@ public class RecentIngredientService {
         }
 
         // 3단계: DTO 변환
-        List<RecentIngredientsResponseDto.RecentIngredientItem> items = deduplicated.stream()
-                .map(this::toItem)
-                .toList();
+        List<RecentIngredientsResponseDto.RecentIngredientItem> items = toItems(deduplicated);
 
         return RecentIngredientsResponseDto.builder()
                 .ingredients(items)
@@ -106,44 +104,54 @@ public class RecentIngredientService {
         return UUID.randomUUID().toString();
     }
 
-    // 내부 메서드
-    private RecentIngredientsResponseDto buildResponse(Long userId, String batchId) {
-        List<UserIngredient> ingredients =
-                userIngredientRepository.findByUserIdAndBatchId(userId, batchId);
+    private List<RecentIngredientsResponseDto.RecentIngredientItem> toItems(List<UserIngredient> ingredients) {
 
-        List<RecentIngredientsResponseDto.RecentIngredientItem> items = ingredients.stream()
-                .map(this::toItem)
+        // referenceId를 타입별로 분리
+        List<Long> defaultIds = ingredients.stream()
+                .filter(ui -> ui.getType() == Type.DEFAULT)
+                .map(UserIngredient::getReferenceId)
+                .distinct()
                 .toList();
 
-        return RecentIngredientsResponseDto.builder()
-                .ingredients(items)
-                .build();
-    }
+        List<Long> customIds = ingredients.stream()
+                .filter(ui -> ui.getType() == Type.CUSTOM)
+                .map(UserIngredient::getReferenceId)
+                .distinct()
+                .toList();
 
-    private RecentIngredientsResponseDto.RecentIngredientItem toItem(UserIngredient ui) {
-        String name;
-        String imageUrl;
+        // 타입별 1번씩만 조회 후 Map으로 변환
+        Map<Long, DefaultIngredient> defaultMap = defaultIngredientRepository
+                .findAllById(defaultIds).stream()
+                .collect(Collectors.toMap(DefaultIngredient::getId, d -> d));
 
-        if (ui.getType() == Type.DEFAULT) {
-            DefaultIngredient ref = defaultIngredientRepository
-                    .findById(ui.getReferenceId())
-                    .orElse(null);
-            name = ref != null ? ref.getIngredient() : "Unknown";
-            imageUrl = ref != null ? ref.getImageUrl() : "";
-        } else {
-            CustomIngredient ref = customIngredientRepository
-                    .findById(ui.getReferenceId())
-                    .orElse(null);
-            name = ref != null ? ref.getName() : "Unknown";
-            imageUrl = ref != null ? ref.getImageUrl() : "";
-        }
+        Map<Long, CustomIngredient> customMap = customIngredientRepository
+                .findAllById(customIds).stream()
+                .collect(Collectors.toMap(CustomIngredient::getId, c -> c));
 
-        return RecentIngredientsResponseDto.RecentIngredientItem.builder()
-                .ingredientId(ui.getIngredientId())
-                .type(ui.getType().name())
-                .name(name)
-                .imageUrl(imageUrl)
-                .build();
+        // 매핑
+        return ingredients.stream()
+                .map(ui -> {
+                    String name;
+                    String imageUrl;
+
+                    if (ui.getType() == Type.DEFAULT) {
+                        DefaultIngredient ref = defaultMap.get(ui.getReferenceId());
+                        imageUrl = ref.getImageUrl();
+                        name = ref.getIngredient();
+                    } else {
+                        CustomIngredient ref = customMap.get(ui.getReferenceId());
+                        name = ref.getName();
+                        imageUrl = ref.getImageUrl();
+                    }
+
+                    return RecentIngredientsResponseDto.RecentIngredientItem.builder()
+                            .ingredientId(ui.getIngredientId())
+                            .type(ui.getType().name())
+                            .name(name)
+                            .imageUrl(imageUrl)
+                            .build();
+                })
+                .toList();
     }
 
 }

--- a/src/main/java/com/cookeep/cookeep/domain/ingredient/useringredient/application/RecentIngredientService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/ingredient/useringredient/application/RecentIngredientService.java
@@ -18,13 +18,15 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
-import java.util.UUID;
+import java.util.*;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class RecentIngredientService {
+
+    private static final int MAX_RECENT_COUNT = 6;
 
     private final RecentIngredientBatchRepository batchRepository;
     private final UserIngredientRepository userIngredientRepository;
@@ -38,31 +40,64 @@ public class RecentIngredientService {
             throw new AppException(ErrorCode.UNAUTHORIZED);
         }
 
-        // 최신 batchId 조회; 없으면 빈 결과 반환
-        return batchRepository.findByUser_UserId(userId)
-                .map(batch -> buildResponse(userId, batch.getBatchId()))
-                .orElseGet(() -> RecentIngredientsResponseDto.builder()
-                        .ingredients(List.of())
-                        .build());
+        // 1. 유저의 배치 이력을 최신순으로 조회
+        List<RecentIngredientBatch> batches =
+                batchRepository.findByUser_UserIdOrderByCreatedAtDesc(userId);
+
+        if (batches.isEmpty()) {
+            return RecentIngredientsResponseDto.builder()
+                    .ingredients(List.of())
+                    .build();
+        }
+
+        // 결과 담을 리스트 (순서 유지)
+        List<UserIngredient> resultIngredients = new ArrayList<>();
+        // 2. 중복 체크: type + referenceId 조합으로 판단
+        Set<String> seenKeys = new LinkedHashSet<>();
+
+        for (RecentIngredientBatch batch : batches) {
+            if (seenKeys.size() >= MAX_RECENT_COUNT) break;
+
+            // 해당 배치의 재료 ID 목록 조회 (등록 순서 오름차순)
+            List<UserIngredient> batchIngredients =
+                    userIngredientRepository.findByUserIdAndBatchId(userId, batch.getBatchId());
+
+            // 배치 내 재료를 앞에서부터 추가 (LinkedHashSet가 중복 제거)
+            for (UserIngredient ui : batchIngredients) {
+                String key = ui.getType().name() + "_" + ui.getReferenceId(); // 중복 기준
+                if (!seenKeys.contains(key)) {
+                    seenKeys.add(key);
+                    resultIngredients.add(ui);
+                }
+                // 6개 초과하면 중단
+                if (seenKeys.size() >= MAX_RECENT_COUNT) break;
+            }
+        }
+
+        // 3. 수집된 ID 목록으로 재료 정보 조회 및 DTO 변환
+        List<RecentIngredientsResponseDto.RecentIngredientItem> items = resultIngredients.stream()
+                .map(this::toItem)
+                .toList();
+
+        return RecentIngredientsResponseDto.builder()
+                .ingredients(items)
+                .build();
     }
 
     // 배치 저장: 재료 등록 완료 후 호출하여 최신 batchId를 업데이트
     @Transactional
     public void saveBatch(Long userId, String batchId) {
-        batchRepository.findByUser_UserId(userId)
-                .ifPresentOrElse(
-                        existing -> existing.updateBatchId(batchId),
-                        () -> {
-                            User user = userRepository.findById(userId)
-                                    .orElseThrow(() -> new AppException(ErrorCode.USER_NOT_FOUND));
-                            batchRepository.save(
-                                    RecentIngredientBatch.builder()
-                                            .user(user)
-                                            .batchId(batchId)
-                                            .build()
-                            );
-                        }
-                );
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new AppException(ErrorCode.USER_NOT_FOUND));
+
+        // 기존 upsert 방식에서 항상 새 행 INSERT로 변경
+        batchRepository.save(
+                RecentIngredientBatch.builder()
+                        .user(user)
+                        .batchId(batchId)
+                        .build()
+        );
     }
 
     // UUID 생성하여 반환. createAll() 에서 배치 시작 시 호출

--- a/src/main/java/com/cookeep/cookeep/domain/ingredient/useringredient/application/RecentIngredientService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/ingredient/useringredient/application/RecentIngredientService.java
@@ -34,13 +34,12 @@ public class RecentIngredientService {
     private final CustomIngredientRepository customIngredientRepository;
     private final UserRepository userRepository;
 
-    // 유저의 직전 배치에 해당하는 재료 목록 반환 (첫 등록은 빈 리스트)
+    // 최근 추가한 순으로 최대 6개 재료 목록 반환 (첫 등록은 빈 리스트)
     public RecentIngredientsResponseDto getRecentIngredients(Long userId) {
         if (userId == null) {
             throw new AppException(ErrorCode.UNAUTHORIZED);
         }
 
-        // 1. 유저의 배치 이력을 최신순으로 조회
         List<RecentIngredientBatch> batches =
                 batchRepository.findByUser_UserIdOrderByCreatedAtDesc(userId);
 
@@ -50,32 +49,34 @@ public class RecentIngredientService {
                     .build();
         }
 
-        // 결과 담을 리스트 (순서 유지)
-        List<UserIngredient> resultIngredients = new ArrayList<>();
-        // 2. 중복 체크: type + referenceId 조합으로 판단
-        Set<String> seenKeys = new LinkedHashSet<>();
+        // 1단계: 최신 배치부터 역순으로 총 6개 행 수집 (중복 포함)
+        List<UserIngredient> collectedRaw = new ArrayList<>();
 
         for (RecentIngredientBatch batch : batches) {
-            if (seenKeys.size() >= MAX_RECENT_COUNT) break;
+            if (collectedRaw.size() >= MAX_RECENT_COUNT) break;
 
-            // 해당 배치의 재료 ID 목록 조회 (등록 순서 오름차순)
             List<UserIngredient> batchIngredients =
                     userIngredientRepository.findByUserIdAndBatchId(userId, batch.getBatchId());
 
-            // 배치 내 재료를 앞에서부터 추가 (LinkedHashSet가 중복 제거)
             for (UserIngredient ui : batchIngredients) {
-                String key = ui.getType().name() + "_" + ui.getReferenceId(); // 중복 기준
-                if (!seenKeys.contains(key)) {
-                    seenKeys.add(key);
-                    resultIngredients.add(ui);
-                }
-                // 6개 초과하면 중단
-                if (seenKeys.size() >= MAX_RECENT_COUNT) break;
+                collectedRaw.add(ui);
+                if (collectedRaw.size() >= MAX_RECENT_COUNT) break;
             }
         }
 
-        // 3. 수집된 ID 목록으로 재료 정보 조회 및 DTO 변환
-        List<RecentIngredientsResponseDto.RecentIngredientItem> items = resultIngredients.stream()
+        // 2단계: type + referenceId 기준 중복 제거 (순서 유지)
+        Set<String> seenKeys = new LinkedHashSet<>();
+        List<UserIngredient> deduplicated = new ArrayList<>();
+
+        for (UserIngredient ui : collectedRaw) {
+            String key = ui.getType().name() + "_" + ui.getReferenceId();
+            if (seenKeys.add(key)) { // add()는 중복이면 false 반환
+                deduplicated.add(ui);
+            }
+        }
+
+        // 3단계: DTO 변환
+        List<RecentIngredientsResponseDto.RecentIngredientItem> items = deduplicated.stream()
                 .map(this::toItem)
                 .toList();
 

--- a/src/main/java/com/cookeep/cookeep/domain/ingredient/useringredient/dao/RecentIngredientBatchRepository.java
+++ b/src/main/java/com/cookeep/cookeep/domain/ingredient/useringredient/dao/RecentIngredientBatchRepository.java
@@ -3,9 +3,13 @@ package com.cookeep.cookeep.domain.ingredient.useringredient.dao;
 import com.cookeep.cookeep.domain.ingredient.useringredient.entity.RecentIngredientBatch;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface RecentIngredientBatchRepository extends JpaRepository<RecentIngredientBatch, Long> {
 
     Optional<RecentIngredientBatch> findByUser_UserId(Long userId);
+
+    // 유저의 배치 목록 최신순 조회
+    List<RecentIngredientBatch> findByUser_UserIdOrderByCreatedAtDesc(Long userId);
 }

--- a/src/main/java/com/cookeep/cookeep/domain/ingredient/useringredient/entity/RecentIngredientBatch.java
+++ b/src/main/java/com/cookeep/cookeep/domain/ingredient/useringredient/entity/RecentIngredientBatch.java
@@ -18,8 +18,8 @@ public class RecentIngredientBatch extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id", nullable = false, unique = true)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
     // 마지막 등록 배치의 UUID


### PR DESCRIPTION
# Issue
#171 

# Description
- 최근 추가한 재료 조회 API의 응답 로직을 수정
여러 배치에 걸쳐 중복 없이 최대 6개의 재료를 반환하도록 변경합니다.

### 핵심 로직
- 최신 배치부터 역순으로 UserIngredient 행을 수집 (총 6개 행이 될 때까지)
- 6개 행을 모은 뒤 type + referenceId 기준으로 중복 제거
- 중복 제거된 결과를 응답으로 반환

### 예시:
[1,2] → [2,3] → [3,4,5,6] 순으로 추가 시, 최신 배치부터 6행 수집 → [3,4,5,6,2,3] → 중복 제거 → [3,4,5,6,2] 반환

# Changes
### RecentIngredientBatch
- User와의 관계를 @OneToOne (unique) → @ManyToOne으로 변경하여 유저당 여러 배치 이력 저장 가능하도록 수정

### RecentIngredientBatchRepository
- findByUser_UserIdOrderByCreatedAtDesc() 쿼리 추가 — 유저의 배치 이력을 최신순으로 전체 조회

### RecentIngredientService
- saveBatch(): 기존 upsert 방식 → 항상 새 행 INSERT로 변경 (배치 이력 누적)
- getRecentIngredients(): 최신 배치부터 역순 탐색하여 6개 행 수집 후 type + referenceId 기준 중복 제거 로직으로 교체

### DB 마이그레이션
- recent_ingredient_batch.user_id UNIQUE 제약 제거
- (user_id, created_at DESC) 조회 인덱스 추가
- 서버 DB 수정 완료

# Test Checklist
- [x] 최근 등록 재료 상황 별 정상 동작 확인