### PR TITLE
Feat: weekly goal weeklyGoalAchieved 필드 추가

### DIFF
--- a/src/main/java/com/cookeep/cookeep/api/dto/response/AiRecipeAdoptResponseDto.java
+++ b/src/main/java/com/cookeep/cookeep/api/dto/response/AiRecipeAdoptResponseDto.java
@@ -44,7 +44,9 @@ public class AiRecipeAdoptResponseDto {
     )
     private LocalDateTime completedAt;
 
-    @Schema(description = "이번 채택으로 주간 목표 달성 여부", example = "false")
+    @Schema(
+            description = "이번 채택으로 주간 목표 달성 여부 (COOKING / USE_EXPIRING_INGREDIENT)",
+            example = "false"
+    )
     private boolean weeklyGoalAchieved;
-
 }

--- a/src/main/java/com/cookeep/cookeep/api/dto/response/ConsumeIngredientsResponseDto.java
+++ b/src/main/java/com/cookeep/cookeep/api/dto/response/ConsumeIngredientsResponseDto.java
@@ -23,7 +23,7 @@ public class ConsumeIngredientsResponseDto {
     )
     private RewardInfo reward;
 
-    @Schema(description = "이번 소비로 주간 목표(유통기한 임박 재료 사용하기) 달성 여부", example = "false")
+    @Schema(description = "이번 소비로 주간 목표(COOKING) 달성 여부", example = "false")
     private boolean weeklyGoalAchieved;
 
     @Getter
@@ -52,19 +52,11 @@ public class ConsumeIngredientsResponseDto {
         private List<CookieLog.CookieLogType> grantedTypes;
     }
 
-    public static ConsumeIngredientsResponseDto of(boolean granted, int points, List<CookieLog.CookieLogType> grantedTypes) {
-        return ConsumeIngredientsResponseDto.builder()
-                .reward(RewardInfo.builder()
-                        .granted(granted)
-                        .points(points)
-                        .grantedTypes(grantedTypes)
-                        .build())
-                .weeklyGoalAchieved(false)
-                .build();
-    }
-
-    public static ConsumeIngredientsResponseDto of(boolean granted, int points,
-                                                   List<CookieLog.CookieLogType> grantedTypes, boolean weeklyGoalAchieved) {
+    public static ConsumeIngredientsResponseDto of(
+            boolean granted,
+            int points,
+            List<CookieLog.CookieLogType> grantedTypes,
+            boolean weeklyGoalAchieved) {
         return ConsumeIngredientsResponseDto.builder()
                 .reward(RewardInfo.builder()
                         .granted(granted)

--- a/src/main/java/com/cookeep/cookeep/domain/ingredient/useringredient/application/ConsumeIngredientService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/ingredient/useringredient/application/ConsumeIngredientService.java
@@ -26,6 +26,8 @@ import java.util.List;
 @Transactional(readOnly = true)
 public class ConsumeIngredientService {
 
+    private static final int URGENT = 0;
+
     private final UserIngredientRepository userIngredientRepository;
     private final CookieService cookieService;
     private final ConsumptionReportService consumptionReportService;
@@ -75,7 +77,7 @@ public class ConsumeIngredientService {
 
         // 6. 임박 재료(leftDays=0) 개수만큼 주간 목표(USE_EXPIRING_INGREDIENT) 카운트 증가
         long urgentCount = userIngredients.stream()
-                .filter(ui -> ui.getLeftDays() == 0)
+                .filter(ui -> ui.getLeftDays() == URGENT)
                 .count();
 
         boolean weeklyGoalAchieved = false;

--- a/src/main/java/com/cookeep/cookeep/domain/ingredient/useringredient/application/ConsumeIngredientService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/ingredient/useringredient/application/ConsumeIngredientService.java
@@ -73,24 +73,24 @@ public class ConsumeIngredientService {
         // 5. 재료 삭제
         userIngredientRepository.deleteAll(userIngredients);
 
-        // 임박 재료 1개 소비 시 카운트 증가 (주간 목표: 유통기한 임박 재료 n개 사용하기)
+        // 6. 임박 재료(leftDays=0) 개수만큼 주간 목표(USE_EXPIRING_INGREDIENT) 카운트 증가
         long urgentCount = userIngredients.stream()
                 .filter(ui -> ui.getLeftDays() == 0)
                 .count();
 
         boolean weeklyGoalAchieved = false;
-        // 재료 소비(1개) n(소비 재료 수)번 호출하여 카운트
         for (int i = 0; i < urgentCount; i++) {
-            // 목표 달성 시점에 true로 갱신
+            // handleGoalProgress는 이미 달성된 경우 false를 반환하므로 중복 지급 없음
             if (weeklyGoalService.handleGoalProgress(userId, GoalActionType.USE_EXPIRING_INGREDIENT)) {
                 weeklyGoalAchieved = true;
             }
         }
 
-        log.info("User {} consumed {} ingredients via manual action. Reward granted: {}, points: {}, urgentCount: {}",
-                userId, userIngredients.size(), granted, points, urgentCount);
+        log.info("User {} consumed {} ingredients via manual action. " +
+                        "Reward granted: {}, points: {}, urgentCount: {}, weeklyGoalAchieved: {}",
+                userId, userIngredients.size(), granted, points, urgentCount, weeklyGoalAchieved);
 
-        return ConsumeIngredientsResponseDto.of(granted, points, grantedTypes);
+        return ConsumeIngredientsResponseDto.of(granted, points, grantedTypes, weeklyGoalAchieved);
     }
 
 }

--- a/src/main/java/com/cookeep/cookeep/domain/recipe/application/AiRecipeService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/recipe/application/AiRecipeService.java
@@ -235,16 +235,16 @@ public class AiRecipeService {
         String rawContent = getLastAiMessage(session).getContent();
         AiRecipe savedRecipe = saveAdoptedRecipe(session, rawContent, userId);
 
-        // 5. USER 채택 메시지 저장
+        // 3. USER 채택 메시지 저장
         saveSimpleUserMessage(session, MessageType.ADOPT_RECIPE);
 
-        // 6. 세션 완료 처리
+        // 4. 세션 완료 처리
         session.complete();
 
-        // 레시피 채택 시 카운트 증가 (주간 목표: 주 n회 요리하기)
+        // 5. 레시피 채택 시 COOKING 목표 카운트 증가
         boolean cookingGoalAchieved = weeklyGoalService.handleGoalProgress(userId, GoalActionType.COOKING);
 
-        // 7. 세션의 ingredientIds 조회
+        // 6. 세션의 ingredientIds 조회
         List<Long> ingredientIds;
         try {
             ingredientIds = objectMapper.readValue(
@@ -256,18 +256,21 @@ public class AiRecipeService {
             throw new AppException(ErrorCode.INTERNAL_SERVER_ERROR);
         }
 
-        // 8. 임박 재료(leftDays=0) 포함 세션이면 쿠키 지급 (하루 1회)
+        // 7. 임박 재료(leftDays=0) 포함 세션이면 쿠키 지급 (하루 1회)
         grantUrgentCookieRewardIfEligible(userId, ingredientIds);
 
-        // 9. 요청 재료 전체 수량 -1 (단위 무관, 0이 되면 삭제)
-        consumeIngredients(userId, ingredientIds);
+        // 8. 요청 재료 소비 처리 후 USE_EXPIRING_INGREDIENT 주간 목표 카운트 증가
+        boolean expiringGoalAchieved = consumeIngredientsAndTrackExpiringGoal(userId, ingredientIds);
+
+        // 9. COOKING / USE_EXPIRING_INGREDIENT 중 하나라도 달성되면 weeklyGoalAchieved = true
+        boolean weeklyGoalAchieved = cookingGoalAchieved || expiringGoalAchieved;
 
         return AiRecipeAdoptResponseDto.builder()
                 .sessionId(session.getId())
                 .recipeId(savedRecipe.getId())
                 .message("레시피가 성공적으로 채택되었습니다.")
                 .completedAt(session.getCompletedAt())
-                .weeklyGoalAchieved(cookingGoalAchieved)
+                .weeklyGoalAchieved(weeklyGoalAchieved)
                 .build();
     }
 
@@ -601,11 +604,10 @@ public class AiRecipeService {
 
     }
 
-    // 재료 차감 로직. (단위 상관없이 무조건 -1)
-    private void consumeIngredients(Long userId, List<Long> ingredientIds) {
+    private boolean consumeIngredientsAndTrackExpiringGoal(Long userId, List<Long> ingredientIds) {
         if (ingredientIds == null || ingredientIds.isEmpty()) {
             log.info("재료 차감 생략 - ingredientIds 없음: userId={}", userId);
-            return;
+            return false;
         }
 
         List<UserIngredient> targets = userIngredientRepository
@@ -613,12 +615,18 @@ public class AiRecipeService {
 
         if (targets.isEmpty()) {
             log.warn("재료 차감 생략 - 유효한 재료 없음: userId={}", userId);
-            return;
+            return false;
         }
 
         // 주간 소비 리포트 기록 (차감/삭제 전에 호출해야 leftDays 읽기 가능)
         consumptionReportService.markConsumed(userId, targets);
 
+        // 임박 재료(leftDays=0) 개수 계산 (차감/삭제 전)
+        long urgentCount = targets.stream()
+                .filter(ui -> ui.getLeftDays() == URGENT)
+                .count();
+
+        // 재료 수량 차감 또는 삭제
         for (UserIngredient ui : targets) {
             int currentQty = ui.getQuantity();
             if (currentQty > 1) {
@@ -631,6 +639,19 @@ public class AiRecipeService {
                 log.info("재료 삭제(수량 0): ingredientId={}", ui.getIngredientId());
             }
         }
+
+        // USE_EXPIRING_INGREDIENT 목표 카운트 증가 (임박 재료 개수만큼)
+        boolean expiringGoalAchieved = false;
+        for (int i = 0; i < urgentCount; i++) {
+            if (weeklyGoalService.handleGoalProgress(userId, GoalActionType.USE_EXPIRING_INGREDIENT)) {
+                expiringGoalAchieved = true;
+            }
+        }
+
+        log.info("재료 소비 완료: userId={}, urgentCount={}, expiringGoalAchieved={}",
+                userId, urgentCount, expiringGoalAchieved);
+
+        return expiringGoalAchieved;
     }
 
     // AI 응답 에러 확인

--- a/src/test/java/com/cookeep/cookeep/domain/ingredient/application/ConsumeIngredientServiceTest.java
+++ b/src/test/java/com/cookeep/cookeep/domain/ingredient/application/ConsumeIngredientServiceTest.java
@@ -54,6 +54,7 @@ public class ConsumeIngredientServiceTest {
         user = User.builder().nickname("테스터").build();
         // 쿠키 지급은 기본 false
         given(cookieService.grantDailyCookie(anyLong(), any())).willReturn(false);
+        given(weeklyGoalService.handleGoalProgress(anyLong(), any())).willReturn(false);
     }
 
     // 유통기한 임박(leftDays=0) 재료 생성 헬퍼
@@ -153,20 +154,57 @@ public class ConsumeIngredientServiceTest {
         }
 
         @Test
-        @DisplayName("목표 달성 이후에도 handleGoalProgress는 호출되지만 내부에서 false를 반환한다")
-        void 목표달성후_추가소비_호출은하되_false반환() {
-            // handleGoalProgress 내부에서 isAchieved=true이면 false 반환 (WeeklyGoalService 로직)
-            // ConsumeIngredientService는 반환값과 무관하게 임박 재료 수만큼 호출하도록 함
-            given(weeklyGoalService.handleGoalProgress(anyLong(), any())).willReturn(false);
-
-            UserIngredient urgent = buildUrgentIngredient();
+        @DisplayName("임박 재료 소비로 목표 달성 시 weeklyGoalAchieved=true를 반환한다")
+        void 임박재료_소비_목표달성_weeklyGoalAchieved_true() {
             given(userIngredientRepository.findAllByIngredientIdInAndUser_UserId(anyList(), anyLong()))
-                    .willReturn(List.of(urgent));
+                    .willReturn(List.of(buildUrgentIngredient()));
+            given(weeklyGoalService.handleGoalProgress(1L, GoalActionType.USE_EXPIRING_INGREDIENT))
+                    .willReturn(true);
 
-            consumeIngredientService.consumeIngredients(1L, buildRequest(List.of(1L)));
+            ConsumeIngredientsResponseDto result =
+                    consumeIngredientService.consumeIngredients(1L, buildRequest(List.of(1L)));
 
-            verify(weeklyGoalService, times(1))
-                    .handleGoalProgress(1L, GoalActionType.USE_EXPIRING_INGREDIENT);
+            assertThat(result.isWeeklyGoalAchieved()).isTrue();
+        }
+
+        @Test
+        @DisplayName("임박 재료 소비했지만 목표 미달성 시 weeklyGoalAchieved=false를 반환한다")
+        void 임박재료_소비_목표미달성_weeklyGoalAchieved_false() {
+            given(userIngredientRepository.findAllByIngredientIdInAndUser_UserId(anyList(), anyLong()))
+                    .willReturn(List.of(buildUrgentIngredient()));
+            given(weeklyGoalService.handleGoalProgress(1L, GoalActionType.USE_EXPIRING_INGREDIENT))
+                    .willReturn(false);
+
+            ConsumeIngredientsResponseDto result =
+                    consumeIngredientService.consumeIngredients(1L, buildRequest(List.of(1L)));
+
+            assertThat(result.isWeeklyGoalAchieved()).isFalse();
+        }
+
+        @Test
+        @DisplayName("일반 재료만 소비 시 weeklyGoalAchieved=false를 반환한다")
+        void 일반재료만_소비_weeklyGoalAchieved_false() {
+            given(userIngredientRepository.findAllByIngredientIdInAndUser_UserId(anyList(), anyLong()))
+                    .willReturn(List.of(buildNormalIngredient()));
+
+            ConsumeIngredientsResponseDto result =
+                    consumeIngredientService.consumeIngredients(1L, buildRequest(List.of(1L)));
+
+            assertThat(result.isWeeklyGoalAchieved()).isFalse();
+        }
+
+        @Test
+        @DisplayName("임박 재료 3개 중 마지막 호출에서 목표 달성되면 weeklyGoalAchieved=true를 반환한다")
+        void 임박재료_3개_마지막호출_목표달성_true() {
+            given(userIngredientRepository.findAllByIngredientIdInAndUser_UserId(anyList(), anyLong()))
+                    .willReturn(List.of(buildUrgentIngredient(), buildUrgentIngredient(), buildUrgentIngredient()));
+            given(weeklyGoalService.handleGoalProgress(1L, GoalActionType.USE_EXPIRING_INGREDIENT))
+                    .willReturn(false, false, true);
+
+            ConsumeIngredientsResponseDto result =
+                    consumeIngredientService.consumeIngredients(1L, buildRequest(List.of(1L, 2L, 3L)));
+
+            assertThat(result.isWeeklyGoalAchieved()).isTrue();
         }
     }
 
@@ -175,11 +213,10 @@ public class ConsumeIngredientServiceTest {
     class BasicCookieGrant {
 
         @Test
-        @DisplayName("하루 첫 소비 시 쿠키가 지급된다")
+        @DisplayName("하루 첫 소비 시 쿠키가 지급되고 granted=true, points=1을 반환한다")
         void 첫소비_쿠키지급() {
-            UserIngredient normal = buildNormalIngredient();
             given(userIngredientRepository.findAllByIngredientIdInAndUser_UserId(anyList(), anyLong()))
-                    .willReturn(List.of(normal));
+                    .willReturn(List.of(buildNormalIngredient()));
             given(cookieService.grantDailyCookie(1L, CookieLog.CookieLogType.BASIC_DAILY_FIRST_CONSUME))
                     .willReturn(true);
 
@@ -191,11 +228,10 @@ public class ConsumeIngredientServiceTest {
         }
 
         @Test
-        @DisplayName("당일 이미 지급된 경우 쿠키가 지급되지 않는다")
+        @DisplayName("당일 이미 지급된 경우 granted=false, points=0을 반환한다")
         void 중복소비_쿠키미지급() {
-            UserIngredient normal = buildNormalIngredient();
             given(userIngredientRepository.findAllByIngredientIdInAndUser_UserId(anyList(), anyLong()))
-                    .willReturn(List.of(normal));
+                    .willReturn(List.of(buildNormalIngredient()));
             given(cookieService.grantDailyCookie(1L, CookieLog.CookieLogType.BASIC_DAILY_FIRST_CONSUME))
                     .willReturn(false);
 
@@ -204,6 +240,21 @@ public class ConsumeIngredientServiceTest {
 
             assertThat(result.getReward().getGranted()).isFalse();
             assertThat(result.getReward().getPoints()).isZero();
+        }
+
+        @Test
+        @DisplayName("쿠키 지급되더라도 임박 재료 없으면 weeklyGoalAchieved=false를 반환한다")
+        void 쿠키지급O_임박재료없음_weeklyGoalAchieved_false() {
+            given(userIngredientRepository.findAllByIngredientIdInAndUser_UserId(anyList(), anyLong()))
+                    .willReturn(List.of(buildNormalIngredient()));
+            given(cookieService.grantDailyCookie(1L, CookieLog.CookieLogType.BASIC_DAILY_FIRST_CONSUME))
+                    .willReturn(true);
+
+            ConsumeIngredientsResponseDto result =
+                    consumeIngredientService.consumeIngredients(1L, buildRequest(List.of(1L)));
+
+            assertThat(result.getReward().getGranted()).isTrue();
+            assertThat(result.isWeeklyGoalAchieved()).isFalse();
         }
     }
 

--- a/src/test/java/com/cookeep/cookeep/domain/recipe/application/AiRecipeServiceTest.java
+++ b/src/test/java/com/cookeep/cookeep/domain/recipe/application/AiRecipeServiceTest.java
@@ -1,6 +1,7 @@
 package com.cookeep.cookeep.domain.recipe.application;
 
 import com.cookeep.cookeep.api.dto.response.AiRecipeAdoptResponseDto;
+import com.cookeep.cookeep.common.exception.AppException;
 import com.cookeep.cookeep.domain.cookie.application.CookieService;
 import com.cookeep.cookeep.domain.dailyrecipe.dao.DailyRecipeRepository;
 import com.cookeep.cookeep.domain.ingredient.common.domain.Storage;
@@ -64,7 +65,7 @@ public class AiRecipeServiceTest {
     @InjectMocks
     private AiRecipeService aiRecipeService;
 
-    private AiSession completableSession;
+    private AiSession session;
     private AiMessage lastAiMessage;
     private AiRecipe savedAiRecipe;
     private User user;
@@ -87,7 +88,7 @@ public class AiRecipeServiceTest {
     void setUp() throws Exception {
         user = User.builder().nickname("테스터").build();
 
-        completableSession = AiSession.builder()
+        session = AiSession.builder()
                 .userId(1L)
                 .difficulty(Difficulty.EASY)
                 .attemptNumber(1)
@@ -97,7 +98,7 @@ public class AiRecipeServiceTest {
                 .build();
 
         lastAiMessage = AiMessage.builder()
-                .session(completableSession)
+                .session(session)
                 .role(Role.AI)
                 .messageType(MessageType.INITIAL_REQUEST)
                 .content(VALID_AI_RESPONSE_JSON)
@@ -106,25 +107,29 @@ public class AiRecipeServiceTest {
         savedAiRecipe = AiRecipe.builder()
                 .id(99L)
                 .title("테스트 레시피")
-                .session(completableSession)
+                .session(session)
                 .userId(1L)
                 .ingredientsJson("[]")
                 .stepsJson("[]")
                 .build();
 
-        // 공통 stub
         given(aiSessionRepository.findByIdAndUserId(anyLong(), eq(1L)))
-                .willReturn(Optional.of(completableSession));
+                .willReturn(Optional.of(session));
         given(aiMessageRepository.findTopBySessionAndRoleOrderByCreatedAtDesc(any(), eq(Role.AI)))
                 .willReturn(Optional.of(lastAiMessage));
         given(aiRecipeRepository.save(any(AiRecipe.class))).willReturn(savedAiRecipe);
         given(aiMessageRepository.save(any(AiMessage.class))).willAnswer(inv -> inv.getArgument(0));
         willDoNothing().given(aiMessageRepository).flush();
         given(dailyRecipeRepository.existsByAiRecipe_Session_Id(anyLong())).willReturn(false);
+
+        // 기본값: 모든 목표 진행 false (미달성)
+        given(weeklyGoalService.handleGoalProgress(anyLong(), any())).willReturn(false);
+        // 기본값: 쿠키 지급 false
+        given(cookieService.grantDailyCookie(anyLong(), any())).willReturn(false);
     }
 
     // 유통기한 임박(leftDays=0) 재료 생성 헬퍼
-    private UserIngredient buildUrgentIngredient(Long id) {
+    private UserIngredient buildUrgentIngredient() {
         return spy(UserIngredient.builder()
                 .type(Type.DEFAULT)
                 .referenceId(1L)
@@ -137,7 +142,7 @@ public class AiRecipeServiceTest {
     }
 
     // 유통기한 여유 있는 재료 생성 헬퍼
-    private UserIngredient buildNormalIngredient(Long id) {
+    private UserIngredient buildNormalIngredient() {
         return spy(UserIngredient.builder()
                 .type(Type.DEFAULT)
                 .referenceId(1L)
@@ -154,24 +159,21 @@ public class AiRecipeServiceTest {
     class AdoptRecipeCookingGoal {
 
         @Test
-        @DisplayName("레시피 채택 시 COOKING 목표 진행을 호출한다")
-        void 레시피채택_COOKING_목표진행_호출() {
-            UserIngredient ingredient = buildNormalIngredient(1L);
+        @DisplayName("레시피 채택 시 COOKING 목표 진행을 반드시 1회 호출한다")
+        void 채택시_COOKING_목표_1회_호출() {
             given(userIngredientRepository.findAllByIngredientIdInAndUser_UserId(anyList(), eq(1L)))
-                    .willReturn(List.of(ingredient));
-            given(weeklyGoalService.handleGoalProgress(1L, GoalActionType.COOKING)).willReturn(false);
+                    .willReturn(List.of(buildNormalIngredient()));
 
             aiRecipeService.adoptRecipe(1L, 10L);
 
-            verify(weeklyGoalService).handleGoalProgress(1L, GoalActionType.COOKING);
+            verify(weeklyGoalService, times(1)).handleGoalProgress(1L, GoalActionType.COOKING);
         }
 
         @Test
-        @DisplayName("채택 시 COOKING 목표 달성이면 weeklyGoalAchieved=true를 반환한다")
-        void 레시피채택_COOKING_목표달성_true반환() {
-            UserIngredient ingredient = buildNormalIngredient(1L);
+        @DisplayName("COOKING 목표 달성 시 weeklyGoalAchieved=true를 반환한다")
+        void COOKING_달성_true() {
             given(userIngredientRepository.findAllByIngredientIdInAndUser_UserId(anyList(), eq(1L)))
-                    .willReturn(List.of(ingredient));
+                    .willReturn(List.of(buildNormalIngredient()));
             given(weeklyGoalService.handleGoalProgress(1L, GoalActionType.COOKING)).willReturn(true);
 
             AiRecipeAdoptResponseDto result = aiRecipeService.adoptRecipe(1L, 10L);
@@ -180,12 +182,11 @@ public class AiRecipeServiceTest {
         }
 
         @Test
-        @DisplayName("채택 시 COOKING 목표 미달성이면 weeklyGoalAchieved=false를 반환한다")
-        void 레시피채택_COOKING_목표미달성_false반환() {
-            UserIngredient ingredient = buildNormalIngredient(1L);
+        @DisplayName("COOKING 미달성 + 임박 재료 없으면 weeklyGoalAchieved=false를 반환한다")
+        void COOKING_미달성_임박없음_false() {
             given(userIngredientRepository.findAllByIngredientIdInAndUser_UserId(anyList(), eq(1L)))
-                    .willReturn(List.of(ingredient));
-            given(weeklyGoalService.handleGoalProgress(1L, GoalActionType.COOKING)).willReturn(false);
+                    .willReturn(List.of(buildNormalIngredient()));
+            // weeklyGoalService 기본값이 false이므로 별도 stubbing 불필요
 
             AiRecipeAdoptResponseDto result = aiRecipeService.adoptRecipe(1L, 10L);
 
@@ -193,16 +194,124 @@ public class AiRecipeServiceTest {
         }
 
         @Test
-        @DisplayName("이미 완료된 세션을 채택하면 COOKING 목표 진행을 호출하지 않는다")
-        void 이미완료된세션_COOKING_목표_미호출() {
-            completableSession.complete(); // isCompleted=true
-            // 이미 완료 → AppException 발생 → verify 전에 예외가 던져짐
-            // 예외 발생 자체가 목표 미호출의 증거
+        @DisplayName("이미 완료된 세션 채택 시 예외가 발생하고 목표 진행을 호출하지 않는다")
+        void 완료된세션_예외_목표_미호출() {
+            session.complete();
+
             try {
                 aiRecipeService.adoptRecipe(1L, 10L);
-            } catch (Exception ignored) {}
+            } catch (AppException ignored) {}
 
             verify(weeklyGoalService, never()).handleGoalProgress(any(), any());
+        }
+    }
+
+    @Nested
+    @DisplayName("adoptRecipe - USE_EXPIRING_INGREDIENT 목표 연동")
+    class ExpiringIngredientGoal {
+
+        @Test
+        @DisplayName("임박 재료 1개 포함 채택 시 USE_EXPIRING_INGREDIENT 목표 진행을 1회 호출한다")
+        void 임박재료_1개_채택_목표_1회_호출() {
+            given(userIngredientRepository.findAllByIngredientIdInAndUser_UserId(anyList(), eq(1L)))
+                    .willReturn(List.of(buildUrgentIngredient()));
+
+            aiRecipeService.adoptRecipe(1L, 10L);
+
+            verify(weeklyGoalService, times(1))
+                    .handleGoalProgress(1L, GoalActionType.USE_EXPIRING_INGREDIENT);
+        }
+
+        @Test
+        @DisplayName("임박 재료 없는 채택 시 USE_EXPIRING_INGREDIENT 목표 진행을 호출하지 않는다")
+        void 임박재료_없음_채택_목표_미호출() {
+            given(userIngredientRepository.findAllByIngredientIdInAndUser_UserId(anyList(), eq(1L)))
+                    .willReturn(List.of(buildNormalIngredient()));
+
+            aiRecipeService.adoptRecipe(1L, 10L);
+
+            verify(weeklyGoalService, never())
+                    .handleGoalProgress(1L, GoalActionType.USE_EXPIRING_INGREDIENT);
+        }
+
+        @Test
+        @DisplayName("임박 재료 포함 채택으로 USE_EXPIRING 달성 시 weeklyGoalAchieved=true를 반환한다")
+        void 임박재료_USE_EXPIRING_달성_true() {
+            given(userIngredientRepository.findAllByIngredientIdInAndUser_UserId(anyList(), eq(1L)))
+                    .willReturn(List.of(buildUrgentIngredient()));
+            given(weeklyGoalService.handleGoalProgress(1L, GoalActionType.COOKING)).willReturn(false);
+            given(weeklyGoalService.handleGoalProgress(1L, GoalActionType.USE_EXPIRING_INGREDIENT)).willReturn(true);
+
+            AiRecipeAdoptResponseDto result = aiRecipeService.adoptRecipe(1L, 10L);
+
+            assertThat(result.isWeeklyGoalAchieved()).isTrue();
+        }
+
+        @Test
+        @DisplayName("임박 재료 있지만 USE_EXPIRING 미달성 + COOKING 미달성이면 weeklyGoalAchieved=false를 반환한다")
+        void 임박재료_USE_EXPIRING_미달성_COOKING_미달성_false() {
+            given(userIngredientRepository.findAllByIngredientIdInAndUser_UserId(anyList(), eq(1L)))
+                    .willReturn(List.of(buildUrgentIngredient()));
+
+            // 기본값이 false이므로 별도 stubbing 불필요
+            AiRecipeAdoptResponseDto result = aiRecipeService.adoptRecipe(1L, 10L);
+
+            assertThat(result.isWeeklyGoalAchieved()).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("adoptRecipe - COOKING + USE_EXPIRING_INGREDIENT 조합")
+    class BothGoals {
+
+        @Test
+        @DisplayName("COOKING만 달성 시 weeklyGoalAchieved=true를 반환한다")
+        void COOKING만_달성_true() {
+            given(userIngredientRepository.findAllByIngredientIdInAndUser_UserId(anyList(), eq(1L)))
+                    .willReturn(List.of(buildNormalIngredient()));
+            given(weeklyGoalService.handleGoalProgress(1L, GoalActionType.COOKING)).willReturn(true);
+
+            AiRecipeAdoptResponseDto result = aiRecipeService.adoptRecipe(1L, 10L);
+
+            assertThat(result.isWeeklyGoalAchieved()).isTrue();
+        }
+
+        @Test
+        @DisplayName("USE_EXPIRING만 달성 시 weeklyGoalAchieved=true를 반환한다")
+        void USE_EXPIRING만_달성_true() {
+            given(userIngredientRepository.findAllByIngredientIdInAndUser_UserId(anyList(), eq(1L)))
+                    .willReturn(List.of(buildUrgentIngredient()));
+            given(weeklyGoalService.handleGoalProgress(1L, GoalActionType.COOKING)).willReturn(false);
+            given(weeklyGoalService.handleGoalProgress(1L, GoalActionType.USE_EXPIRING_INGREDIENT)).willReturn(true);
+
+            AiRecipeAdoptResponseDto result = aiRecipeService.adoptRecipe(1L, 10L);
+
+            assertThat(result.isWeeklyGoalAchieved()).isTrue();
+        }
+
+        @Test
+        @DisplayName("COOKING과 USE_EXPIRING 모두 달성 시 weeklyGoalAchieved=true를 반환한다")
+        void 둘다_달성_true() {
+            given(userIngredientRepository.findAllByIngredientIdInAndUser_UserId(anyList(), eq(1L)))
+                    .willReturn(List.of(buildUrgentIngredient()));
+            given(weeklyGoalService.handleGoalProgress(1L, GoalActionType.COOKING)).willReturn(true);
+            given(weeklyGoalService.handleGoalProgress(1L, GoalActionType.USE_EXPIRING_INGREDIENT)).willReturn(true);
+
+            AiRecipeAdoptResponseDto result = aiRecipeService.adoptRecipe(1L, 10L);
+
+            assertThat(result.isWeeklyGoalAchieved()).isTrue();
+        }
+
+        @Test
+        @DisplayName("COOKING과 USE_EXPIRING 모두 미달성 시 weeklyGoalAchieved=false를 반환한다")
+        void 둘다_미달성_false() {
+            given(userIngredientRepository.findAllByIngredientIdInAndUser_UserId(anyList(), eq(1L)))
+                    .willReturn(List.of(buildNormalIngredient()));
+            // 기본값이 false이므로 별도 stubbing 불필요
+
+            AiRecipeAdoptResponseDto result = aiRecipeService.adoptRecipe(1L, 10L);
+
+            assertThat(result.isWeeklyGoalAchieved()).isFalse();
         }
     }
 


### PR DESCRIPTION
# Issue
#173 

# Description
 1. POST /api/users/me/ingredients/consume (섭취 완료)
응답에 weeklyGoalAchieved 필드가 누락되어 있던 문제를 수정
**변경 내용**
- `ConsumeIngredientsResponseDto`에 `weeklyGoalAchieved: boolean` 필드 추가
- `of(granted, points, grantedTypes, weeklyGoalAchieved)` 4개 인자 버전으로 통일
- 섭취한 재료 중 `leftDays == 0`인 임박 재료 개수만큼 `USE_EXPIRING_INGREDIENT` 목표 카운트를 증가시키고, 달성 여부를 응답에 반환
**응답 예시**

```json
{
  "reward": {
    "granted": true,
    "points": 1,
    "grantedTypes": ["BASIC_DAILY_FIRST_CONSUME"]
  },
  "weeklyGoalAchieved": true
}
```

 2. POST /api/users/me/ai/recipes/{sessionId}/complete (레시피 채택)
 응답의 weeklyGoalAchieved가 항상 직렬화되지 않던 문제와, USE_EXPIRING_INGREDIENT 목표 카운트 로직이 누락되어 있던 문제 수정
**변경 내용**
- `AiRecipeAdoptResponseDto`에 `@Getter` 추가
- `adoptRecipe()` 내 기존 `consumeIngredients()` → `consumeIngredientsAndTrackExpiringGoal()`로 교체
    - 재료 차감 처리 후 `leftDays == 0`인 임박 재료 개수만큼 `USE_EXPIRING_INGREDIENT` 목표 카운트 증가
- 최종 `weeklyGoalAchieved = cookingGoalAchieved || expiringGoalAchieved`

**목표 달성 판정 로직**
weeklyGoalAchieved = COOKING 달성 여부 || USE_EXPIRING_INGREDIENT 달성 여부

시나리오 | weeklyGoalAchieved
-- | --
COOKING만 달성 | true
USE_EXPIRING만 달성 | true
둘 다 달성 | true
둘 다 미달성 | false
이미 달성된 목표(isAchieved=true) | false (WeeklyGoalService 내부에서 처리)

**응답 예시**

```json
{
  "sessionId": 12,
  "recipeId": 45,
  "message": "레시피가 성공적으로 채택되었습니다.",
  "completedAt": "2026-01-27T14:30:00",
  "weeklyGoalAchieved": true
}
```

# Changes

파일 | 변경 유형
-- | --
ConsumeIngredientsResponseDto | weeklyGoalAchieved 필드 추가, of() 메서드 4개 인자로 통일
AiRecipeAdoptResponseDto | @Getter 누락으로 인한 응답 직렬화 버그 수정
ConsumeIngredientService | weeklyGoalAchieved 응답 반환 로직 추가
AiRecipeService | adoptRecipe에 USE_EXPIRING_INGREDIENT 목표 카운트 로직 추가
ConsumeIngredientServiceTest | 신규 테스트 케이스 추가
AiRecipeServiceTest | 신규 테스트 케이스 추가


<!-- notionvc: 717251c7-660f-4e11-a122-46b89649eeb7 -->

# Test Checklist
- [x] 응답에 weeklyGoalAchieved 포함 여부 확인
- [x] ConsumeIngredientTest 테스트 통과 확인
- [x] AiRecipeServiceTest 테스트 통과 확인