### PR TITLE
fix: 식재료 리스트 수정

### DIFF
--- a/src/main/java/com/cookeep/cookeep/api/dto/response/IngredientListResponseDto.java
+++ b/src/main/java/com/cookeep/cookeep/api/dto/response/IngredientListResponseDto.java
@@ -99,23 +99,6 @@ public class IngredientListResponseDto {
         )
         private Category category;
 
-        @Schema(
-                description = "기본 단위",
-                example = "개",
-                requiredMode = Schema.RequiredMode.NOT_REQUIRED
-        )
-        private String unit;
-
-        @Schema(description = "유통기한 (일)",
-                example = "7",
-                requiredMode = Schema.RequiredMode.REQUIRED)
-        private Integer expirationDays;
-
-        @Schema(description = "보관 장소",
-                example = "FRIDGE",
-                requiredMode = Schema.RequiredMode.REQUIRED)
-        private Storage storage;
-
     }
 
 }

--- a/src/main/java/com/cookeep/cookeep/domain/ingredient/common/application/IngredientListService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/ingredient/common/application/IngredientListService.java
@@ -4,7 +4,6 @@ import com.cookeep.cookeep.api.dto.response.IngredientListResponseDto;
 import com.cookeep.cookeep.common.exception.AppException;
 import com.cookeep.cookeep.common.exception.ErrorCode;
 import com.cookeep.cookeep.domain.ingredient.common.domain.Category;
-import com.cookeep.cookeep.domain.ingredient.common.domain.Unit;
 import com.cookeep.cookeep.domain.ingredient.customingredient.dao.CustomIngredientRepository;
 import com.cookeep.cookeep.domain.ingredient.customingredient.entity.CustomIngredient;
 import com.cookeep.cookeep.domain.ingredient.defaultingredient.dao.DefaultIngredientRepository;
@@ -63,9 +62,6 @@ public class IngredientListService {
                         .name(ingredient.getIngredient())
                         .imageUrl(ingredient.getImageUrl())
                         .category(ingredient.getCategory())
-                        .unit(ingredient.getUnit() != null ? ingredient.getUnit().name() : Unit.PIECE.name())
-                        .expirationDays(ingredient.getDefaultExpirationDays())
-                        .storage(ingredient.getDefaultStorage())
                         .build())
         );
         customIngredients.forEach(ingredient ->
@@ -75,9 +71,6 @@ public class IngredientListService {
                         .name(ingredient.getName())
                         .imageUrl(ingredient.getImageUrl())
                         .category(ingredient.getCategory())
-                        .unit(Unit.PIECE.name())
-                        .expirationDays(ingredient.getExpirationDays())
-                        .storage(ingredient.getStorage())
                         .build())
         );
 


### PR DESCRIPTION
# Issue
#179 

# Description
- 현재 응답 필드: id, type, name, imageUrl, category, unit, expirationDate, storage 포함됨
- 수정: id, type, name, imageUrl, category 만 뜨도록 수정

# Changes
- IngredientListResponseDto.java — IngredientItem 클래스에서 3개 필드 제거
- - unit, expirationDays, storage 필드 제거
- IngredientListService.java — 빌더 호출부에서 3개 필드 제거
- - buildCategoryGroup 메서드 내 items.add(...) 두 곳 모두에서 unit, expirationDays, storage 필드 제거

# Test Checklist
- [x] 재료 리스트 응답 정상 동작 확인