### PR TITLE
feat: 쿠킵스 온보딩 모달 확인 여부를 서버에서 관리하도록 변경

### DIFF
--- a/src/main/java/com/cookeep/cookeep/api/controller/CookeepsController.java
+++ b/src/main/java/com/cookeep/cookeep/api/controller/CookeepsController.java
@@ -1,5 +1,6 @@
 package com.cookeep.cookeep.api.controller;
 
+import com.cookeep.cookeep.api.dto.response.CookeepsOnboardingResponseDto;
 import com.cookeep.cookeep.api.dto.response.CookeepsRecipeDetailResponseDto;
 import com.cookeep.cookeep.api.dto.response.RankingResponseDto;
 import com.cookeep.cookeep.api.dto.response.WeeklyRecipeResponseDto;
@@ -32,6 +33,27 @@ public class CookeepsController {
 	public ResponseEntity<DataResponse<RankingResponseDto>> getRanking(
 			@AuthenticationPrincipal(expression = "userId") Long userId) {
 		return ResponseEntity.ok(DataResponse.from(cookeepsService.getRanking(userId)));
+	}
+
+	@Operation(summary = "쿠킵스 온보딩 완료 여부 조회", description = "유저의 쿠킵스 온보딩 모달 확인 여부를 조회합니다.")
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200", description = "조회 성공")
+	})
+	@GetMapping("/onboarding")
+	public ResponseEntity<DataResponse<CookeepsOnboardingResponseDto>> getOnboardingStatus(
+			@AuthenticationPrincipal(expression = "userId") Long userId) {
+		return ResponseEntity.ok(DataResponse.from(cookeepsService.getOnboardingStatus(userId)));
+	}
+
+	@Operation(summary = "쿠킵스 온보딩 완료 처리", description = "유저의 쿠킵스 온보딩 모달 확인 여부를 true로 업데이트합니다.")
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200", description = "업데이트 성공")
+	})
+	@PatchMapping("/onboarding")
+	public ResponseEntity<DataResponse<Void>> confirmOnboarding(
+			@AuthenticationPrincipal(expression = "userId") Long userId) {
+		cookeepsService.confirmOnboarding(userId);
+		return ResponseEntity.ok(DataResponse.from(null));
 	}
 
 	@Operation(summary = "이번 주 레시피 전체보기", description = "이번 주차에 올라온 레시피들을 정렬 필터와 함께 조회합니다.")

--- a/src/main/java/com/cookeep/cookeep/api/dto/response/CookeepsOnboardingResponseDto.java
+++ b/src/main/java/com/cookeep/cookeep/api/dto/response/CookeepsOnboardingResponseDto.java
@@ -1,0 +1,10 @@
+package com.cookeep.cookeep.api.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class CookeepsOnboardingResponseDto {
+	private boolean isCookeepsOnboarded;
+}

--- a/src/main/java/com/cookeep/cookeep/domain/cookeeps/application/CookeepsService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/cookeeps/application/CookeepsService.java
@@ -1,5 +1,6 @@
 package com.cookeep.cookeep.domain.cookeeps.application;
 
+import com.cookeep.cookeep.api.dto.response.CookeepsOnboardingResponseDto;
 import com.cookeep.cookeep.api.dto.response.CookeepsRecipeDetailResponseDto;
 import com.cookeep.cookeep.api.dto.response.RankingResponseDto;
 import com.cookeep.cookeep.api.dto.response.RankingResponseDto.RecipeRankDto;
@@ -12,6 +13,8 @@ import com.cookeep.cookeep.domain.dailyrecipe.dao.DailyRecipeRepository;
 
 import com.cookeep.cookeep.domain.dailyrecipe.entity.DailyRecipe;
 import com.cookeep.cookeep.domain.plant.dao.WateringLogRepository;
+import com.cookeep.cookeep.domain.user.application.UserReader;
+import com.cookeep.cookeep.domain.user.dao.UserRepository;
 import com.cookeep.cookeep.domain.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -32,8 +35,10 @@ import java.util.stream.IntStream;
 @RequiredArgsConstructor
 public class CookeepsService {
 
+	private final UserReader userReader;
 	private final WateringLogRepository wateringLogRepository;
 	private final DailyRecipeRepository dailyRecipeRepository;
+	private final UserRepository userRepository;
 
 	@Transactional(readOnly = true)
 	public RankingResponseDto getRanking(Long userId) {
@@ -136,6 +141,21 @@ public class CookeepsService {
 					.recipeImageUrl(recipe.getRecipeImageUrl())
 					.build();
 		});
+	}
+
+	@Transactional(readOnly = true)
+	public CookeepsOnboardingResponseDto getOnboardingStatus(Long userId) {
+		User user = userReader.readById(userId);
+
+		return CookeepsOnboardingResponseDto.builder()
+			.isCookeepsOnboarded(user.isCookeepsOnboarded())
+			.build();
+	}
+
+	@Transactional
+	public void confirmOnboarding(Long userId) {
+		User user = userReader.readById(userId);
+		user.confirmCookeepsOnboarding();
 	}
 
 	@Transactional(readOnly = true)

--- a/src/main/java/com/cookeep/cookeep/domain/user/entity/User.java
+++ b/src/main/java/com/cookeep/cookeep/domain/user/entity/User.java
@@ -100,6 +100,10 @@ public class User extends BaseEntity {
 	@Column(nullable = false)
 	private boolean isProfileAutoUpdate = true; // 프로필 식물 변경을 자동 or 수동 모드 관리
 
+	@Builder.Default
+	@Column(nullable = false)
+	private boolean isCookeepsOnboarded = false; // 쿠킵스 온보딩 모달 확인 여부
+
 	// 유저가 API를 통해 직접 프로필을 변경할 때 호출
 	public void updateProfilePlant(UserPlant nesUserPlant) {
 		this.profilePlant = nesUserPlant;
@@ -161,5 +165,9 @@ public class User extends BaseEntity {
 
 	public void updateUserStatus(UserStatus userStatus) {
 		this.userStatus = userStatus;
+	}
+
+	public void confirmCookeepsOnboarding() {
+		this.isCookeepsOnboarded = true;
 	}
 }

--- a/src/test/java/com/cookeep/cookeep/domain/cookeeps/application/CookeepsServiceTest.java
+++ b/src/test/java/com/cookeep/cookeep/domain/cookeeps/application/CookeepsServiceTest.java
@@ -1,8 +1,11 @@
 package com.cookeep.cookeep.domain.cookeeps.application;
 
+import com.cookeep.cookeep.api.dto.response.CookeepsOnboardingResponseDto;
 import com.cookeep.cookeep.api.dto.response.RankingResponseDto;
 import com.cookeep.cookeep.domain.dailyrecipe.dao.DailyRecipeRepository;
 import com.cookeep.cookeep.domain.plant.dao.WateringLogRepository;
+import com.cookeep.cookeep.domain.user.application.UserReader;
+import com.cookeep.cookeep.domain.user.dao.UserRepository;
 import com.cookeep.cookeep.domain.user.entity.User;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -13,6 +16,8 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 import org.springframework.data.domain.Pageable;
 
 import java.time.LocalDate;
@@ -26,8 +31,11 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 class CookeepsServiceTest {
 
+    @Mock private UserReader userReader;
+    @Mock private UserRepository userRepository;
     @Mock private WateringLogRepository wateringLogRepository;
     @Mock private DailyRecipeRepository dailyRecipeRepository;
 
@@ -169,6 +177,60 @@ class CookeepsServiceTest {
                     startCaptor.capture(), endCaptor.capture(), any(Pageable.class));
 
             assertThat(endCaptor.getValue()).isEqualTo(startCaptor.getValue().plusDays(7));
+        }
+    }
+
+    @Nested
+    @DisplayName("getOnboardingStatus - 쿠킵스 온보딩 상태 조회")
+    class GetOnboardingStatus {
+
+        @Test
+        @DisplayName("온보딩 미완료 유저는 isCookeepsOnboarded가 false로 반환된다")
+        void 온보딩_미완료_유저_false_반환() {
+            User user = User.builder().nickname("유저").build();
+            given(userReader.readById(USER_ID)).willReturn(user);
+
+            CookeepsOnboardingResponseDto result = cookeepsService.getOnboardingStatus(USER_ID);
+
+            assertThat(result.isCookeepsOnboarded()).isFalse();
+        }
+
+        @Test
+        @DisplayName("온보딩 완료 유저는 isCookeepsOnboarded가 true로 반환된다")
+        void 온보딩_완료_유저_true_반환() {
+            User user = User.builder().nickname("유저").isCookeepsOnboarded(true).build();
+            given(userReader.readById(USER_ID)).willReturn(user);
+
+            CookeepsOnboardingResponseDto result = cookeepsService.getOnboardingStatus(USER_ID);
+
+            assertThat(result.isCookeepsOnboarded()).isTrue();
+        }
+    }
+
+    @Nested
+    @DisplayName("confirmOnboarding - 쿠킵스 온보딩 완료 처리")
+    class ConfirmOnboarding {
+
+        @Test
+        @DisplayName("온보딩 완료 처리 시 isCookeepsOnboarded가 true로 변경된다")
+        void 온보딩_완료처리_후_true로_변경() {
+            User user = User.builder().nickname("유저").build();
+            given(userReader.readById(USER_ID)).willReturn(user);
+
+            cookeepsService.confirmOnboarding(USER_ID);
+
+            assertThat(user.isCookeepsOnboarded()).isTrue();
+        }
+
+        @Test
+        @DisplayName("이미 온보딩 완료 상태여도 완료 처리 시 true로 유지된다")
+        void 이미_완료상태에서_완료처리_true_유지() {
+            User user = User.builder().nickname("유저").isCookeepsOnboarded(true).build();
+            given(userReader.readById(USER_ID)).willReturn(user);
+
+            cookeepsService.confirmOnboarding(USER_ID);
+
+            assertThat(user.isCookeepsOnboarded()).isTrue();
         }
     }
 }


### PR DESCRIPTION
# Related Issue
CLOSE #182 

# Description                                                                                                                                                          
                                                                                                                                                                       
쿠킵스 온보딩 모달 확인 여부를 프론트 로컬스토리지 대신 서버에서 관리하도록 변경했습니다.                                                                          
기존에는 기기 단위로 관리되어 기기가 바뀌면 온보딩 모달이 다시 노출되는 문제가 있어,
유저 테이블에 확인 여부 필드를 추가하고, 전용 API를 통해 상태를 조회/업데이트할 수 있도록 합니다.  

# Changes                                                                                                                                                            
                                                                                                                                                                       
**API**
- `GET` `/api/cookeeps/onboarding` : 로그인한 유저의 쿠킵스 온보딩 완료 여부 조회                                                                                        
- `PATCH` `/api/cookeeps/onboarding` : 온보딩 완료 처리 (확인 여부를 true로 업데이트)                                                                                    
   
**도메인**                                                                                                                                                               
- `User` 엔티티에 `isCookeepsOnboarded` 필드 추가 (default false)                                                                                                      
- `CookeepsOnboardingResponseDto` 신규 생성                                                                                                                            
                                                                                                                                                                     
**Test**                                                                                                                                                                 
  - `CookeepsServiceTest`에 `getOnboardingStatus`, `confirmOnboarding` 단위 테스트 추가 

# 참고 사항
- 기존 유저는 이미 서비스 이용 경험이 있으므로 true로 일괄 설정했습니다.
- 이후 신규 가입 유저는 DEFAULT값 0으로 `isCookeepsOnboarded` 필드가 채워집니다.

## DB 마이그레이션
user 테이블에 `is_cookeeps_onboarded` 컬럼이 추가된 관계로,

```sql
ALTER TABLE user ADD COLUMN is_cookeeps_onboarded TINYINT(1) NOT NULL DEFAULT 0;
UPDATE user SET is_cookeeps_onboarded = 1;  -- 기존 유저 전체 true로 설정
```

위 명령어를 로컬 DB에서 실행해주시면 감사하겠습니다!! RDS에는 제가 수정해놓겠습니답.