### PR TITLE
feat: 레시피 생성 시 비선호식재료 제한 추가

### DIFF
--- a/src/main/java/com/cookeep/cookeep/common/exception/ErrorCode.java
+++ b/src/main/java/com/cookeep/cookeep/common/exception/ErrorCode.java
@@ -52,6 +52,7 @@ public enum ErrorCode {
 	TITLE_INVALID_VALUE(HttpStatus.BAD_REQUEST, "레시피 제목을 입력해주세요.", "RECIPE-022"),
 	TITLE_TOO_LONG(HttpStatus.BAD_REQUEST, "레시피 제목은 최대 100글자입니다.", "RECIPE-023"),
 	RECIPE_DELETE_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "데일리레시피에 기록된 레시피는 삭제할 수 없습니다.", "RECIPE-024"),
+	DISLIKED_INGREDIENT_INCLUDED(HttpStatus.BAD_REQUEST, "제외 재료가 포함된 레시피입니다.", "RECIPE-026"),
 
 	// ONBOARDING
 	INVALID_FOOD_TYPE_COUNT(HttpStatus.BAD_REQUEST, "선호하는 음식 종류는 3개까지만 선택 가능합니다.", "ONBOARDING-001"),

--- a/src/main/java/com/cookeep/cookeep/common/exception/ErrorCode.java
+++ b/src/main/java/com/cookeep/cookeep/common/exception/ErrorCode.java
@@ -181,7 +181,7 @@ public enum ErrorCode {
 	SMS_TOO_MANY_ATTEMPTS(HttpStatus.TOO_MANY_REQUESTS, "인증 시도 횟수를 초과하였습니다. 잠시 후 다시 시도해주세요.", "SMS-006"),
 
 	// RECIPE
-	AI_RATE_LIMIT_EXCEEDED(HttpStatus.TOO_MANY_REQUESTS, "AI API rate limit exceeded", "RECIPE-25"),
+	AI_RATE_LIMIT_EXCEEDED(HttpStatus.TOO_MANY_REQUESTS, "AI API rate limit exceeded", "RECIPE-24"),
 
 	// ==============================
 	// 500 INTERNAL_SERVER_ERROR

--- a/src/main/java/com/cookeep/cookeep/domain/recipe/application/AiRecipeService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/recipe/application/AiRecipeService.java
@@ -8,12 +8,8 @@ import com.cookeep.cookeep.api.dto.response.AiSessionListResponseDto;
 import com.cookeep.cookeep.common.exception.AppException;
 import com.cookeep.cookeep.common.exception.ErrorCode;
 import com.cookeep.cookeep.domain.cookie.application.CookieService;
-import com.cookeep.cookeep.domain.cookie.dao.CookieLogRepository;
-import com.cookeep.cookeep.domain.cookie.dao.DailyCookieGrantRepository;
 import com.cookeep.cookeep.domain.cookie.entity.CookieLog;
-import com.cookeep.cookeep.domain.cookie.entity.DailyCookieGrant;
 import com.cookeep.cookeep.domain.dailyrecipe.dao.DailyRecipeRepository;
-import com.cookeep.cookeep.domain.ingredient.common.domain.Type;
 import com.cookeep.cookeep.domain.ingredient.customingredient.dao.CustomIngredientRepository;
 import com.cookeep.cookeep.domain.ingredient.customingredient.entity.CustomIngredient;
 import com.cookeep.cookeep.domain.ingredient.defaultingredient.dao.DefaultIngredientRepository;
@@ -32,19 +28,15 @@ import com.cookeep.cookeep.domain.user.dao.UserRepository;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDate;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static com.cookeep.cookeep.domain.recipe.entity.MessageType.*;
 
 @Slf4j
 @Service
@@ -68,6 +60,7 @@ public class AiRecipeService {
     private final ConsumptionReportService consumptionReportService;
     private final DailyRecipeRepository dailyRecipeRepository;
     private final WeeklyGoalService weeklyGoalService;
+    private final UserRepository userRepository;
 
     // sessionId 유무에 따라 신규/재요청 로직 분기
     public AiRecipeResponseDto generateRecipe(Long userId, AiRecipeRequestDto request) {

--- a/src/main/java/com/cookeep/cookeep/domain/recipe/application/AiRecipeService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/recipe/application/AiRecipeService.java
@@ -25,6 +25,7 @@ import com.cookeep.cookeep.domain.recipe.dao.AiSessionRepository;
 import com.cookeep.cookeep.domain.recipe.dto.*;
 import com.cookeep.cookeep.domain.recipe.entity.*;
 import com.cookeep.cookeep.domain.user.dao.UserRepository;
+import com.cookeep.cookeep.domain.user.entity.User;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -123,10 +124,13 @@ public class AiRecipeService {
         // 메시지 db에 저장
         saveInitialUserMessage(session, request);
 
+        List<String> dislikedIngredients = getDislikedIngredients(userId);
+
         // 3. AI 레시피 생성 (이름 + 단위만 전달, AI가 quantity 생성)
         GeminiRecipeResponseDto aiResponse = geminiService.generateRecipe(
                 enrichedIngredients,
-                request.getDifficulty()
+                request.getDifficulty(),
+                dislikedIngredients
         );
 
         // 4. 세션 제목 업데이트
@@ -183,11 +187,14 @@ public class AiRecipeService {
         // 4. 재요청 메시지 저장 (role=USER, RETRY_REQUEST)
         saveSimpleUserMessage(session, MessageType.RETRY_REQUEST);
 
+        List<String> dislikedIngredients = getDislikedIngredients(userId);
+
         // 5. AI 호출 (제외 리스트 포함)
         GeminiRecipeResponseDto aiResponse = geminiService.generateRecipeWithExclusion(
                 ingredients,
                 session.getDifficulty(),
-                excludedTitles
+                excludedTitles,
+                dislikedIngredients
         );
 
         // 6. 시도 횟수 증가 및 저장
@@ -769,5 +776,11 @@ public class AiRecipeService {
         }
     }
 
+    // 비선호 재료 리스트
+    private List<String> getDislikedIngredients(Long userId) {
+        return userRepository.findById(userId)
+                .map(User::getDislikedIngredients)
+                .orElse(List.of());
+    }
 
 }

--- a/src/main/java/com/cookeep/cookeep/domain/recipe/application/AiRecipeService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/recipe/application/AiRecipeService.java
@@ -764,11 +764,15 @@ public class AiRecipeService {
             }
 
             for (String ingredientName : aiGeneratedIngredients) {
-                String lowerName = ingredientName.toLowerCase();
 
-                for (String disliked : lowerDisliked) {
-                    if (lowerName.contains(disliked)) {
-                        log.error("❌ disliked ingredient 포함 (AI 생성 재료): {}", ingredientName);
+                String normalizedName = ingredientName.trim();
+
+                for (String disliked : dislikedIngredients) {
+
+                    if (disliked == null) continue;
+                    String normalizedDisliked = disliked.trim();
+                    if (normalizedName.equals(normalizedDisliked)) {
+                        log.error("❌ disliked ingredient 포함 (AI 생성 재료): {}", normalizedName);
                         throw new AppException(ErrorCode.DISLIKED_INGREDIENT_INCLUDED);
                     }
                 }

--- a/src/main/java/com/cookeep/cookeep/domain/recipe/application/AiRecipeService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/recipe/application/AiRecipeService.java
@@ -35,6 +35,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -141,7 +142,7 @@ public class AiRecipeService {
                 youtubeSearchService.searchVideos(aiResponse.getYoutubeSearchQueries());
 
         // 6. 레시피 저장
-        saveAiMessageWithYoutubeReferences(session, aiResponse, youtubeReferences, MessageType.INITIAL_REQUEST);
+        saveAiMessageWithYoutubeReferences(session, aiResponse, youtubeReferences, MessageType.INITIAL_REQUEST, dislikedIngredients);
 
 
         // 7. 응답 반환
@@ -209,7 +210,7 @@ public class AiRecipeService {
                 youtubeSearchService.searchVideos(aiResponse.getYoutubeSearchQueries());
 
         // 9. 재요청 레시피 저장
-        saveAiMessageWithYoutubeReferences(session, aiResponse, youtubeReferences, MessageType.RETRY_REQUEST);
+        saveAiMessageWithYoutubeReferences(session, aiResponse, youtubeReferences, MessageType.RETRY_REQUEST, dislikedIngredients);
 
 
         // 10. 응답 반환
@@ -655,7 +656,9 @@ public class AiRecipeService {
     }
 
     // AI 응답 에러 확인
-    private void validateAiResponse(GeminiRecipeResponseDto response) {
+    private void validateAiResponse(
+            GeminiRecipeResponseDto response,
+            List<String> dislikedIngredients) {
 
         if (response == null) {
             log.error("❌ AI 응답 자체가 null입니다.");
@@ -739,6 +742,39 @@ public class AiRecipeService {
             }
         }
 
+        // 3. dislikedIngredients 검증
+        if (dislikedIngredients != null && !dislikedIngredients.isEmpty()) {
+
+            List<String> lowerDisliked = dislikedIngredients.stream()
+                    .map(String::toLowerCase)
+                    .toList();
+
+            List<String> aiGeneratedIngredients = new ArrayList<>();
+
+            // additional_ingredients
+            if (ingredients.getAdditionalIngredients() != null) {
+                ingredients.getAdditionalIngredients()
+                        .forEach(i -> aiGeneratedIngredients.add(i.getName()));
+            }
+
+            // optional_ingredients
+            if (ingredients.getOptionalIngredients() != null) {
+                ingredients.getOptionalIngredients()
+                        .forEach(i -> aiGeneratedIngredients.add(i.getName()));
+            }
+
+            for (String ingredientName : aiGeneratedIngredients) {
+                String lowerName = ingredientName.toLowerCase();
+
+                for (String disliked : lowerDisliked) {
+                    if (lowerName.contains(disliked)) {
+                        log.error("❌ disliked ingredient 포함 (AI 생성 재료): {}", ingredientName);
+                        throw new AppException(ErrorCode.DISLIKED_INGREDIENT_INCLUDED);
+                    }
+                }
+            }
+        }
+
         log.info("✅ AI 응답 검증 통과");
     }
 
@@ -747,10 +783,11 @@ public class AiRecipeService {
             AiSession session,
             GeminiRecipeResponseDto response,
             List<YoutubeReferenceDto> youtubeReferences,
-            MessageType type
+            MessageType type,
+            List<String> dislikedIngredients
     ) {
         try {
-            validateAiResponse(response);
+            validateAiResponse(response, dislikedIngredients);
 
             // Gemini 응답을 JSON으로 변환
             ObjectNode root = objectMapper.valueToTree(response);

--- a/src/main/java/com/cookeep/cookeep/domain/recipe/application/GeminiService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/recipe/application/GeminiService.java
@@ -38,16 +38,18 @@ public class GeminiService {
 
     public GeminiRecipeResponseDto generateRecipe(
             List<IngredientDetailDto> ingredients,
-            Difficulty difficulty) {
-        return generateRecipeByPrompt(buildPrompt(ingredients, difficulty, List.of()));
+            Difficulty difficulty,
+            List<String> dislikedIngredients) {
+        return generateRecipeByPrompt(buildPrompt(ingredients, difficulty, List.of(), dislikedIngredients));
     }
 
     public GeminiRecipeResponseDto generateRecipeWithExclusion(
             List<IngredientDetailDto> ingredients,
             Difficulty difficulty,
-            List<String> excludedTitles
+            List<String> excludedTitles,
+            List<String> dislikedIngredients
     ) {
-        return generateRecipeByPrompt(buildPrompt(ingredients, difficulty, excludedTitles));
+        return generateRecipeByPrompt(buildPrompt(ingredients, difficulty, excludedTitles, dislikedIngredients));
     }
 
     // 레시피 생성
@@ -157,7 +159,8 @@ public class GeminiService {
     private String buildPrompt(
             List<IngredientDetailDto> ingredients,
             Difficulty difficulty,
-            List<String> excludedTitles) {
+            List<String> excludedTitles,
+            List<String> dislikedIngredients) {
 
         // 재료 리스트 (이름 + 단위만)
         String ingredientsJson = ingredients.stream()
@@ -172,10 +175,16 @@ public class GeminiService {
                         excludedTitles.stream().map(t -> "- " + t).collect(Collectors.joining("\n")) +
                         "\n위 요리와 겹치지 않는 새로운 레시피를 추천하세요.\n";
 
+        // 못 먹는 재료 제외
+        String dislikedBlock = (dislikedIngredients == null || dislikedIngredients.isEmpty()) ? "" :
+                "\n[절대 사용 금지 재료]\n" +
+                        dislikedIngredients.stream().map(t -> "- " + t).collect(Collectors.joining("\n")) +
+                        "\n위 재료는 additional_ingredients, optional_ingredients 어디에도 절대 포함하지 마세요.\n";
+
         return "당신은 요리 레시피 전문가입니다.\n\n" +
                 "[난이도] " + difficulty.name() + "\n" +
-                exclusionBlock + "\n" +
-                "[재료 구성 규칙]\n" +
+                exclusionBlock + dislikedBlock +
+                "\n[재료 구성 규칙]\n" +
                 // 규칙 1: user_ingredients — 원본 데이터 그대로 사용
                 "1. user_ingredients의 ingredientId, name, unit은 아래 데이터 값 그대로 사용하세요. quantity는 0보다 큰 양수로 생성하세요.\n" +
                 // 규칙 2: additional_ingredients — 레시피에 필요한 추가 재료 (필수/선택/대체 포함)

--- a/src/main/java/com/cookeep/cookeep/domain/user/entity/User.java
+++ b/src/main/java/com/cookeep/cookeep/domain/user/entity/User.java
@@ -1,6 +1,8 @@
 package com.cookeep.cookeep.domain.user.entity;
 
 import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
 
 import com.cookeep.cookeep.domain.plant.entity.PlantStatus;
 import com.cookeep.cookeep.domain.plant.entity.UserPlant;
@@ -104,6 +106,9 @@ public class User extends BaseEntity {
 	@Column(nullable = false)
 	private boolean isCookeepsOnboarded = false; // 쿠킵스 온보딩 모달 확인 여부
 
+	@Column(name = "disliked_ingredients", columnDefinition = "JSON")
+	private String dislikedIngredientsJson; // 못먹는 재료 목록 (JSON 배열로 저장)
+
 	// 유저가 API를 통해 직접 프로필을 변경할 때 호출
 	public void updateProfilePlant(UserPlant nesUserPlant) {
 		this.profilePlant = nesUserPlant;
@@ -169,5 +174,27 @@ public class User extends BaseEntity {
 
 	public void confirmCookeepsOnboarding() {
 		this.isCookeepsOnboarded = true;
+	}
+
+	public List<String> getDislikedIngredients() {
+		if (dislikedIngredientsJson == null || dislikedIngredientsJson.isBlank()) {
+			return Collections.emptyList();
+		}
+		try {
+			return new com.fasterxml.jackson.databind.ObjectMapper()
+					.readValue(dislikedIngredientsJson, new com.fasterxml.jackson.core.type.TypeReference<List<String>>() {});
+		} catch (Exception e) {
+			return Collections.emptyList();
+		}
+	}
+
+	public void updateDislikedIngredients(List<String> ingredients) {
+		try {
+			this.dislikedIngredientsJson = ingredients == null || ingredients.isEmpty()
+					? null
+					: new com.fasterxml.jackson.databind.ObjectMapper().writeValueAsString(ingredients);
+		} catch (Exception e) {
+			this.dislikedIngredientsJson = null;
+		}
 	}
 }

--- a/src/main/java/com/cookeep/cookeep/domain/user/entity/User.java
+++ b/src/main/java/com/cookeep/cookeep/domain/user/entity/User.java
@@ -176,6 +176,7 @@ public class User extends BaseEntity {
 		this.isCookeepsOnboarded = true;
 	}
 
+	// JSON 문자열 읽기
 	public List<String> getDislikedIngredients() {
 		if (dislikedIngredientsJson == null || dislikedIngredientsJson.isBlank()) {
 			return Collections.emptyList();
@@ -188,6 +189,7 @@ public class User extends BaseEntity {
 		}
 	}
 
+	// 문자열로 변환해서 저장
 	public void updateDislikedIngredients(List<String> ingredients) {
 		try {
 			this.dislikedIngredientsJson = ingredients == null || ingredients.isEmpty()


### PR DESCRIPTION
# Issue
#184 

# Description
- 사용자가 섭취할 수 없는 재료(disliked ingredients)를 기반으로 AI 레시피 생성 시 해당 재료가 포함되지 않도록 제한하는 기능 추가
- 기존: 사용자가 입력한 재료 리스트와 난이도만을 기반으로 레시피 생성
- 변경: 유저 단위로 저장된 기피 재료 정보를 전달하여 AI가 생성하는 additional / optional 재료에 해당 재료들이 포함되지 않도록 개선

# Changes
### 1. User DB 변경
- User 엔티티에 dislikedIngredientsJson 필드 추가
- getter/setter 추가
- DB Users 테이블에 disliked_ingredients JSON NULL 컬럼 추가
- SQL 수정사항
```
--- 컬럼 추가
ALTER TABLE Users ADD COLUMN disliked_ingredients JSON NULL;

-- 임의 값 삽입 (userId = 1인 유저에게)
UPDATE Users SET disliked_ingredients = '["오이", "피클"]' WHERE user_id = 1;

-- 확인
SELECT user_id, nickname, disliked_ingredients FROM Users WHERE user_id = 1;

```
### 2. Gemini 프롬프트 개선
- GeminiService.buildPrompt에 dislikedBlock 추가
- AI 요청 시 기피 재료 리스트를 명시적으로 전달하도록 변경
- 메서드 시그니처 변경 (dislikedIngredients 파라미터 추가)
### 3. AI 레시피 생성 로직 수정
- AiRecipeService에 UserRepository 주입
- 레시피 생성 시 사용자 정보 조회 후 dislikedIngredients 추출
- Gemini 호출 시 해당 데이터를 함께 전달하도록 수정
### 4. ErroCode
- DISLIKED_INGREDIENT_INCLUDED 추가
- additional_ingerdients, optional_ingerdients 에 비선호 재료 존재 여부 확인

# Test Checklist
- [x] 레시피 생성 정상 동작 확인