### PR TITLE
feat: 구글 로그인 구현 및 소셜 로그인 범용 구조 리팩토링

### DIFF
--- a/src/main/java/com/cookeep/cookeep/api/controller/AuthController.java
+++ b/src/main/java/com/cookeep/cookeep/api/controller/AuthController.java
@@ -59,6 +59,18 @@ public class AuthController {
 		return ResponseEntity.ok(DataResponse.from(authService.kakaoLogin(code, redirectUri)));
 	}
 
+	@Operation(summary = "구글 로그인 API")
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200", description = "구글 로그인 성공"),
+		@ApiResponse(responseCode = "400", description = "요청 파라미터 오류")
+	})
+	@GetMapping("/login/google")
+	public ResponseEntity<DataResponse<SocialLoginResponseDTO>> googleLogin(
+		@RequestParam String code,
+		@RequestParam(value = "redirect_uri", required = false) String redirectUri) {
+		return ResponseEntity.ok(DataResponse.from(authService.googleLogin(code, redirectUri)));
+	}
+
 	@Operation(summary = "전화번호 회원가입 API")
 	@ApiResponses(value = {
 		@ApiResponse(responseCode = "200", description = "회원가입 성공"),

--- a/src/main/java/com/cookeep/cookeep/api/controller/AuthController.java
+++ b/src/main/java/com/cookeep/cookeep/api/controller/AuthController.java
@@ -21,6 +21,7 @@ import com.cookeep.cookeep.api.dto.response.SignUpResponseDTO;
 import com.cookeep.cookeep.api.dto.response.TokenRefreshResponseDTO;
 import com.cookeep.cookeep.common.dto.DataResponse;
 import com.cookeep.cookeep.domain.user.application.AuthService;
+import com.cookeep.cookeep.domain.user.entity.Provider;
 import com.cookeep.cookeep.security.UserPrincipal;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -56,7 +57,7 @@ public class AuthController {
 	public ResponseEntity<DataResponse<SocialLoginResponseDTO>> kakaoLogin(
 		@RequestParam String code,
 		@RequestParam(value = "redirect_uri", required = false) String redirectUri) {
-		return ResponseEntity.ok(DataResponse.from(authService.kakaoLogin(code, redirectUri)));
+		return ResponseEntity.ok(DataResponse.from(authService.socialLogin(Provider.KAKAO, code, redirectUri)));
 	}
 
 	@Operation(summary = "구글 로그인 API")
@@ -68,7 +69,7 @@ public class AuthController {
 	public ResponseEntity<DataResponse<SocialLoginResponseDTO>> googleLogin(
 		@RequestParam String code,
 		@RequestParam(value = "redirect_uri", required = false) String redirectUri) {
-		return ResponseEntity.ok(DataResponse.from(authService.googleLogin(code, redirectUri)));
+		return ResponseEntity.ok(DataResponse.from(authService.socialLogin(Provider.GOOGLE, code, redirectUri)));
 	}
 
 	@Operation(summary = "전화번호 회원가입 API")

--- a/src/main/java/com/cookeep/cookeep/api/controller/AuthController.java
+++ b/src/main/java/com/cookeep/cookeep/api/controller/AuthController.java
@@ -15,7 +15,7 @@ import com.cookeep.cookeep.api.dto.request.LoginRequestDTO;
 import com.cookeep.cookeep.api.dto.request.ResetPasswordRequestDTO;
 import com.cookeep.cookeep.api.dto.request.SignupRequestDTO;
 import com.cookeep.cookeep.api.dto.request.TokenRefreshRequestDTO;
-import com.cookeep.cookeep.api.dto.response.KakaoLoginResponseDTO;
+import com.cookeep.cookeep.api.dto.response.SocialLoginResponseDTO;
 import com.cookeep.cookeep.api.dto.response.LoginResponseDTO;
 import com.cookeep.cookeep.api.dto.response.SignUpResponseDTO;
 import com.cookeep.cookeep.api.dto.response.TokenRefreshResponseDTO;
@@ -53,9 +53,9 @@ public class AuthController {
 		@ApiResponse(responseCode = "400", description = "요청 파라미터 오류")
 	})
 	@GetMapping("/login/kakao")
-	public ResponseEntity<DataResponse<KakaoLoginResponseDTO>> kakaoLogin(
-			@RequestParam String code,
-			@RequestParam(value = "redirect_uri", required = false) String redirectUri) {
+	public ResponseEntity<DataResponse<SocialLoginResponseDTO>> kakaoLogin(
+		@RequestParam String code,
+		@RequestParam(value = "redirect_uri", required = false) String redirectUri) {
 		return ResponseEntity.ok(DataResponse.from(authService.kakaoLogin(code, redirectUri)));
 	}
 

--- a/src/main/java/com/cookeep/cookeep/api/dto/response/SocialLoginResponseDTO.java
+++ b/src/main/java/com/cookeep/cookeep/api/dto/response/SocialLoginResponseDTO.java
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 
 // nextStep은 null일 경우 JSON 응답에서 제외함
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public record KakaoLoginResponseDTO(
+public record SocialLoginResponseDTO(
 	Long userId, String accessToken,
 	String refreshToken, UserStatus userStatus,
 	NextStep nextStep // nullable

--- a/src/main/java/com/cookeep/cookeep/domain/user/application/AuthService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/user/application/AuthService.java
@@ -25,6 +25,7 @@ import com.cookeep.cookeep.api.dto.response.SocialLoginResponseDTO;
 import com.cookeep.cookeep.api.dto.response.LoginResponseDTO;
 import com.cookeep.cookeep.api.dto.response.SignUpResponseDTO;
 import com.cookeep.cookeep.api.dto.response.TokenRefreshResponseDTO;
+import com.cookeep.cookeep.domain.user.dto.OAuthUserInfoDTO;
 import com.cookeep.cookeep.domain.user.dto.TokenPair;
 import com.cookeep.cookeep.domain.user.entity.Provider;
 import com.cookeep.cookeep.domain.verification.application.SmsVerificationService;
@@ -53,6 +54,7 @@ import lombok.extern.slf4j.Slf4j;
 public class AuthService {
 
 	private final KakaoOAuthProvider kakaoOAuthProvider;
+	private final GoogleOAuthProvider googleOAuthProvider;
 	private final UserRepository userRepository;
 	private final UserAuthRepository userAuthRepository;
 	private final UserSessionRepository userSessionRepository;
@@ -139,15 +141,15 @@ public class AuthService {
 	// 카카오 로그인
 	@Transactional
 	public SocialLoginResponseDTO kakaoLogin(String code, String redirectUri) {
-		String kakaoAccessToken = kakaoOAuthProvider.getKakaoAccessToken(code, redirectUri);
-		KakaoUserInfoResponseDTO userInfo = kakaoOAuthProvider.getKakaoUserInfo(kakaoAccessToken);
+		String kakaoAccessToken = kakaoOAuthProvider.getAccessToken(code, redirectUri);
+		OAuthUserInfoDTO userInfo = kakaoOAuthProvider.getUserInfo(kakaoAccessToken);
 
 		String kakaoId = String.valueOf(userInfo.id());
 
 		// provider = KAKAO, providerUserId인 값을 통해 이미 가입된 회원인지 식별
 		Optional<UserAuth> existingUserAuth = userAuthRepository.findByProviderAndProviderUserId(KAKAO, kakaoId);
 
-		String email = userInfo.kakaoAccount().email();
+		String email = userInfo.email();
 
 		// 신규 유저일 경우 User, UserAuth값을 새롭게 생성함
 		UserAuth userAuth = existingUserAuth
@@ -209,6 +211,80 @@ public class AuthService {
 		}
 
 		log.warn("Failed to generate unique nickname after {} tries (kakao signup).", MAX_TRIES);
+		throw new AppException(ErrorCode.NICKNAME_GENERATION_UNAVAILABLE);
+	}
+
+	public SocialLoginResponseDTO googleLogin(String  code, String redirectUri) {
+		String googleAccessToken = googleOAuthProvider.getAccessToken(code, redirectUri);
+		OAuthUserInfoDTO userInfo = googleOAuthProvider.getUserInfo(googleAccessToken);
+
+		String googleId = String.valueOf(userInfo.id());
+
+		// provider = GOOGLE, providerUserId인 값을 통해 이미 가입된 회원인지 식별
+		Optional<UserAuth> existingUserAuth = userAuthRepository.findByProviderAndProviderUserId(GOOGLE, googleId);
+
+		String email = userInfo.email();
+
+		// 신규 유저일 경우 User, UserAuth값을 새롭게 생성함
+		UserAuth userAuth = existingUserAuth
+			.orElseGet(() -> {
+				User user = createGoogleUser(email);
+
+				return userAuthRepository.save(
+					UserAuth.builder()
+						.user(user)
+						.provider(GOOGLE)
+						.providerUserId(googleId)
+						.build());
+			});
+
+		User user = userAuth.getUser();
+
+		// 액세스 토큰, 리프레쉬 토큰 발급
+		TokenPair tokenPair = issueTokensAndUpsertSession(user);
+
+		UserStatus userStatus = user.getUserStatus();
+		NextStep nextStep = null;
+		Boolean marketingConsent = user.getMarketingConsent();
+
+		// 최초 회원가입한 소셜 로그인 유저일 경우
+		if (user.getUserStatus() == UserStatus.CREATED) {
+			// 최초 회원가입인 경우 TERMS 페이지로 이동,
+			// 회원가입 이후 약관 동의까지 마친 경우 ONBOARDING 페이지로 이동
+			nextStep = (marketingConsent == null)
+				? NextStep.TERMS
+				: NextStep.ONBOARDING;
+		}
+
+		return new SocialLoginResponseDTO(
+			user.getUserId(), tokenPair.accessToken(), tokenPair.refreshToken(),
+			userStatus, nextStep
+		);
+	}
+
+	private User createGoogleUser(String email) {
+
+		for (int i = 0; i < MAX_TRIES; i++) {
+			String nickname = nicknameGenerator.generateRandomNickname();
+
+			try {
+				return userRepository.saveAndFlush(User.builder()
+					.email(email)
+					.nickname(nickname)
+					.build());
+			} catch (DataIntegrityViolationException e) {
+				// 닉네임 관련 제약 위반인 경우에만 재시도
+				if (shouldRetryNickname(e)) {
+					log.debug("Nickname conflict during google signup. try={}/{}", i + 1, MAX_TRIES);
+					continue;
+				}
+				// 그 외 제약 위반은 에러 발생
+				log.error("Signup failed due to integrity violation (non-nickname).", e);
+				throw e;
+			}
+		}
+
+		log.warn("Failed to generate unique nickname after {} tries (google signup).", MAX_TRIES);
 		throw new AppException(ErrorCode.NICKNAME_GENERATION_UNAVAILABLE);
 	}
 

--- a/src/main/java/com/cookeep/cookeep/domain/user/application/AuthService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/user/application/AuthService.java
@@ -166,8 +166,12 @@ public class AuthService {
 		// 신규 유저일 경우 User, UserAuth값을 새롭게 생성함
 		UserAuth userAuth = existingUserAuth
 			.orElseGet(() -> {
-				User user = createSocialUser(email);
+				// 동일한 이메일로 가입된 User가 존재하는지 확인
+				// 존재하지 않을 경우 새로운 유저 생성
+				User user = userRepository.findByEmail(email)
+					.orElseGet(() -> createSocialUser(email));
 
+				// 기존 유저든 신규 유저든 UserAuth가 추가됨
 				return userAuthRepository.save(
 					UserAuth.builder()
 						.user(user)

--- a/src/main/java/com/cookeep/cookeep/domain/user/application/AuthService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/user/application/AuthService.java
@@ -53,8 +53,6 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class AuthService {
 
-	private final KakaoOAuthProvider kakaoOAuthProvider;
-	private final GoogleOAuthProvider googleOAuthProvider;
 	private final UserRepository userRepository;
 	private final UserAuthRepository userAuthRepository;
 	private final UserSessionRepository userSessionRepository;

--- a/src/main/java/com/cookeep/cookeep/domain/user/application/AuthService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/user/application/AuthService.java
@@ -138,29 +138,41 @@ public class AuthService {
 	// 닉네임 제약 위반 시 재시도 횟수를 제한하기 위한 값 (무한 반복 방지)
 	private static final int MAX_TRIES = 30;
 
-	// 카카오 로그인
+	private final List<OAuthProvider> oAuthProviders;
+
+	private OAuthProvider getProvider(Provider provider) {
+		return oAuthProviders.stream()
+			.filter(p -> p.provider() == provider)
+			.findFirst()
+			.orElseThrow(() -> new RuntimeException("지원하지 않는 소셜 로그인입니다."));
+		// ErrorCode가 develop 브랜치에서 대폭 수정된 상태라 추후 AppException으로 수정 예정
+	}
+
+	// 소셜 로그인
 	@Transactional
-	public SocialLoginResponseDTO kakaoLogin(String code, String redirectUri) {
-		String kakaoAccessToken = kakaoOAuthProvider.getAccessToken(code, redirectUri);
-		OAuthUserInfoDTO userInfo = kakaoOAuthProvider.getUserInfo(kakaoAccessToken);
+	public SocialLoginResponseDTO socialLogin(Provider provider, String code, String redirectUri) {
+		// provider 타입에 따라 KakaoOAuthProvider 또는 GoogleOAuthProvider 반환
+		OAuthProvider oAuthProvider = getProvider(provider);
+		String accessToken = oAuthProvider.getAccessToken(code, redirectUri);
+		OAuthUserInfoDTO userInfo = oAuthProvider.getUserInfo(accessToken);
 
-		String kakaoId = String.valueOf(userInfo.id());
+		String socialId = userInfo.id();
 
-		// provider = KAKAO, providerUserId인 값을 통해 이미 가입된 회원인지 식별
-		Optional<UserAuth> existingUserAuth = userAuthRepository.findByProviderAndProviderUserId(KAKAO, kakaoId);
+		// provider, providerUserId인 값을 통해 이미 가입된 회원인지 식별
+		Optional<UserAuth> existingUserAuth = userAuthRepository.findByProviderAndProviderUserId(provider, socialId);
 
 		String email = userInfo.email();
 
 		// 신규 유저일 경우 User, UserAuth값을 새롭게 생성함
 		UserAuth userAuth = existingUserAuth
 			.orElseGet(() -> {
-				User user = createKakaoUser(email);
+				User user = createSocialUser(email);
 
 				return userAuthRepository.save(
 					UserAuth.builder()
 						.user(user)
-						.provider(KAKAO)
-						.providerUserId(kakaoId)
+						.provider(provider)
+						.providerUserId(socialId)
 						.build());
 			});
 
@@ -188,7 +200,7 @@ public class AuthService {
 		);
 	}
 
-	private User createKakaoUser(String email) {
+	private User createSocialUser(String email) {
 
 		for (int i = 0; i < MAX_TRIES; i++) {
 			String nickname = nicknameGenerator.generateRandomNickname();
@@ -201,7 +213,7 @@ public class AuthService {
 			} catch (DataIntegrityViolationException e) {
 				// 닉네임 관련 제약 위반인 경우에만 재시도
 				if (shouldRetryNickname(e)) {
-					log.debug("Nickname conflict during kakao signup. try={}/{}", i + 1, MAX_TRIES);
+					log.debug("Nickname conflict during social signup. try={}/{}", i + 1, MAX_TRIES);
 					continue;
 				}
 				// 그 외 제약 위반은 에러 발생
@@ -210,84 +222,9 @@ public class AuthService {
 			}
 		}
 
-		log.warn("Failed to generate unique nickname after {} tries (kakao signup).", MAX_TRIES);
+		log.warn("Failed to generate unique nickname after {} tries (social signup).", MAX_TRIES);
 		throw new AppException(ErrorCode.NICKNAME_GENERATION_UNAVAILABLE);
 	}
-
-	public SocialLoginResponseDTO googleLogin(String  code, String redirectUri) {
-		String googleAccessToken = googleOAuthProvider.getAccessToken(code, redirectUri);
-		OAuthUserInfoDTO userInfo = googleOAuthProvider.getUserInfo(googleAccessToken);
-
-		String googleId = String.valueOf(userInfo.id());
-
-		// provider = GOOGLE, providerUserId인 값을 통해 이미 가입된 회원인지 식별
-		Optional<UserAuth> existingUserAuth = userAuthRepository.findByProviderAndProviderUserId(GOOGLE, googleId);
-
-		String email = userInfo.email();
-
-		// 신규 유저일 경우 User, UserAuth값을 새롭게 생성함
-		UserAuth userAuth = existingUserAuth
-			.orElseGet(() -> {
-				User user = createGoogleUser(email);
-
-				return userAuthRepository.save(
-					UserAuth.builder()
-						.user(user)
-						.provider(GOOGLE)
-						.providerUserId(googleId)
-						.build());
-			});
-
-		User user = userAuth.getUser();
-
-		// 액세스 토큰, 리프레쉬 토큰 발급
-		TokenPair tokenPair = issueTokensAndUpsertSession(user);
-
-		UserStatus userStatus = user.getUserStatus();
-		NextStep nextStep = null;
-		Boolean marketingConsent = user.getMarketingConsent();
-
-		// 최초 회원가입한 소셜 로그인 유저일 경우
-		if (user.getUserStatus() == UserStatus.CREATED) {
-			// 최초 회원가입인 경우 TERMS 페이지로 이동,
-			// 회원가입 이후 약관 동의까지 마친 경우 ONBOARDING 페이지로 이동
-			nextStep = (marketingConsent == null)
-				? NextStep.TERMS
-				: NextStep.ONBOARDING;
-		}
-
-		return new SocialLoginResponseDTO(
-			user.getUserId(), tokenPair.accessToken(), tokenPair.refreshToken(),
-			userStatus, nextStep
-		);
-	}
-
-	private User createGoogleUser(String email) {
-
-		for (int i = 0; i < MAX_TRIES; i++) {
-			String nickname = nicknameGenerator.generateRandomNickname();
-
-			try {
-				return userRepository.saveAndFlush(User.builder()
-					.email(email)
-					.nickname(nickname)
-					.build());
-			} catch (DataIntegrityViolationException e) {
-				// 닉네임 관련 제약 위반인 경우에만 재시도
-				if (shouldRetryNickname(e)) {
-					log.debug("Nickname conflict during google signup. try={}/{}", i + 1, MAX_TRIES);
-					continue;
-				}
-				// 그 외 제약 위반은 에러 발생
-				log.error("Signup failed due to integrity violation (non-nickname).", e);
-				throw e;
-			}
-		}
-
-		log.warn("Failed to generate unique nickname after {} tries (google signup).", MAX_TRIES);
-		throw new AppException(ErrorCode.NICKNAME_GENERATION_UNAVAILABLE);
-	}
-
 
 	@Transactional
 	public void sendSignupCode(SendCodeRequestDTO sendCodeRequestDTO) {

--- a/src/main/java/com/cookeep/cookeep/domain/user/application/AuthService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/user/application/AuthService.java
@@ -21,7 +21,7 @@ import com.cookeep.cookeep.api.dto.request.SendCodeRequestDTO;
 import com.cookeep.cookeep.api.dto.request.SignupRequestDTO;
 import com.cookeep.cookeep.api.dto.request.TokenRefreshRequestDTO;
 import com.cookeep.cookeep.api.dto.request.VerifyCodeRequestDTO;
-import com.cookeep.cookeep.api.dto.response.KakaoLoginResponseDTO;
+import com.cookeep.cookeep.api.dto.response.SocialLoginResponseDTO;
 import com.cookeep.cookeep.api.dto.response.LoginResponseDTO;
 import com.cookeep.cookeep.api.dto.response.SignUpResponseDTO;
 import com.cookeep.cookeep.api.dto.response.TokenRefreshResponseDTO;
@@ -138,7 +138,7 @@ public class AuthService {
 
 	// 카카오 로그인
 	@Transactional
-	public KakaoLoginResponseDTO kakaoLogin(String code, String redirectUri) {
+	public SocialLoginResponseDTO kakaoLogin(String code, String redirectUri) {
 		String kakaoAccessToken = kakaoOAuthProvider.getKakaoAccessToken(code, redirectUri);
 		KakaoUserInfoResponseDTO userInfo = kakaoOAuthProvider.getKakaoUserInfo(kakaoAccessToken);
 
@@ -180,7 +180,7 @@ public class AuthService {
 				: NextStep.ONBOARDING;
 		}
 
-		return new KakaoLoginResponseDTO(
+		return new SocialLoginResponseDTO(
 			user.getUserId(), tokenPair.accessToken(), tokenPair.refreshToken(),
 			userStatus, nextStep
 		);

--- a/src/main/java/com/cookeep/cookeep/domain/user/application/GoogleOAuthProvider.java
+++ b/src/main/java/com/cookeep/cookeep/domain/user/application/GoogleOAuthProvider.java
@@ -15,7 +15,6 @@ import com.cookeep.cookeep.domain.user.dto.OAuthUserInfoDTO;
 import com.cookeep.cookeep.domain.user.dto.SocialTokenResponseDTO;
 import com.cookeep.cookeep.domain.user.entity.Provider;
 
-import io.netty.handler.codec.http.HttpHeaderValues;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import reactor.core.publisher.Mono;
@@ -41,6 +40,8 @@ public class GoogleOAuthProvider implements OAuthProvider {
 		return Provider.GOOGLE;
 	}
 
+	private WebClient webClient = WebClient.create();
+
 	// 인가코드를 사용해 로그인할 유저의 구글 액세스 토큰값을 받아옴
 	public String getAccessToken(String code, String redirectUri) {
 		String actualRedirectUri = (redirectUri != null) ? redirectUri : defaultRedirectUri;
@@ -52,7 +53,7 @@ public class GoogleOAuthProvider implements OAuthProvider {
 		form.add("redirect_uri", actualRedirectUri);
 		form.add("code", code);
 
-		SocialTokenResponseDTO socialTokenResponseDTO = WebClient.create()
+		SocialTokenResponseDTO socialTokenResponseDTO = webClient
 			.post()
 			.uri(GoogleAccessTokenURL)
 			.contentType(MediaType.APPLICATION_FORM_URLENCODED)
@@ -72,8 +73,9 @@ public class GoogleOAuthProvider implements OAuthProvider {
 
 	// 구글 액세스 토큰을 사용해 유저의 정보값을 받아옴
 	public OAuthUserInfoDTO getUserInfo(String accessToken) {
-		GoogleUserInfoResponseDTO googleUserInfo = WebClient.create(GoogleUserInfoURL)
+		GoogleUserInfoResponseDTO googleUserInfo = webClient
 			.get()
+			.uri(GoogleUserInfoURL)
 			.header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken) // access token 인가
 			.retrieve()
 			.bodyToMono(GoogleUserInfoResponseDTO.class)

--- a/src/main/java/com/cookeep/cookeep/domain/user/application/GoogleOAuthProvider.java
+++ b/src/main/java/com/cookeep/cookeep/domain/user/application/GoogleOAuthProvider.java
@@ -75,7 +75,6 @@ public class GoogleOAuthProvider implements OAuthProvider {
 		GoogleUserInfoResponseDTO googleUserInfo = WebClient.create(GoogleUserInfoURL)
 			.get()
 			.header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken) // access token 인가
-			.header(HttpHeaders.CONTENT_TYPE, HttpHeaderValues.APPLICATION_X_WWW_FORM_URLENCODED.toString())
 			.retrieve()
 			.bodyToMono(GoogleUserInfoResponseDTO.class)
 			.block();

--- a/src/main/java/com/cookeep/cookeep/domain/user/application/GoogleOAuthProvider.java
+++ b/src/main/java/com/cookeep/cookeep/domain/user/application/GoogleOAuthProvider.java
@@ -10,9 +10,9 @@ import org.springframework.util.MultiValueMap;
 import org.springframework.web.reactive.function.BodyInserters;
 import org.springframework.web.reactive.function.client.WebClient;
 
+import com.cookeep.cookeep.domain.user.dto.GoogleUserInfoResponseDTO;
 import com.cookeep.cookeep.domain.user.dto.OAuthUserInfoDTO;
 import com.cookeep.cookeep.domain.user.dto.SocialTokenResponseDTO;
-import com.cookeep.cookeep.domain.user.dto.KakaoUserInfoResponseDTO;
 import com.cookeep.cookeep.domain.user.entity.Provider;
 
 import io.netty.handler.codec.http.HttpHeaderValues;
@@ -23,25 +23,25 @@ import reactor.core.publisher.Mono;
 @Slf4j
 @Service
 @RequiredArgsConstructor
-public class KakaoOAuthProvider implements OAuthProvider {
+public class GoogleOAuthProvider implements OAuthProvider {
 
-	@Value("${kakao.auth.client}")
+	@Value("${google.auth.client}")
 	private String clientId;
-	@Value("${kakao.auth.secret}")
+	@Value("${google.auth.secret}")
 	private String clientSecret;
-	@Value("${kakao.auth.access-token-url}")
-	private String KakaoAccessTokenURL;
-	@Value("${kakao.auth.user-info-url}")
-	private String KakaoUserInfoURL;
-	@Value("${kakao.auth.redirect}")
+	@Value("${google.auth.access-token-url}")
+	private String GoogleAccessTokenURL;
+	@Value("${google.auth.user-info-url}")
+	private String GoogleUserInfoURL;
+	@Value("${google.auth.redirect}")
 	private String defaultRedirectUri;
 
 	@Override
 	public Provider provider() {
-		return Provider.KAKAO;
+		return Provider.GOOGLE;
 	}
 
-	// 인가코드를 사용해 로그인할 유저의 카카오 액세스 토큰값을 받아옴
+	// 인가코드를 사용해 로그인할 유저의 구글 액세스 토큰값을 받아옴
 	public String getAccessToken(String code, String redirectUri) {
 		String actualRedirectUri = (redirectUri != null) ? redirectUri : defaultRedirectUri;
 
@@ -54,15 +54,15 @@ public class KakaoOAuthProvider implements OAuthProvider {
 
 		SocialTokenResponseDTO socialTokenResponseDTO = WebClient.create()
 			.post()
-			.uri(KakaoAccessTokenURL)
+			.uri(GoogleAccessTokenURL)
 			.contentType(MediaType.APPLICATION_FORM_URLENCODED)
 			.body(BodyInserters.fromFormData(form))
 			.retrieve()
 			.onStatus(HttpStatusCode::isError, res ->
 				res.bodyToMono(String.class).defaultIfEmpty("")
 					.doOnNext(
-						body -> log.error("[KAKAO] /oauth/token error status={}, body={}", res.statusCode(), body))
-					.then(Mono.error(new RuntimeException("카카오 로그인 요청에 실패하였습니다.")))
+						body -> log.error("[GOOGLE] /oauth/token error status={}, body={}", res.statusCode(), body))
+					.then(Mono.error(new RuntimeException("구글 로그인 요청에 실패하였습니다.")))
 			)
 			.bodyToMono(SocialTokenResponseDTO.class)
 			.block();
@@ -70,19 +70,18 @@ public class KakaoOAuthProvider implements OAuthProvider {
 		return socialTokenResponseDTO.accessToken();
 	}
 
-	// 카카오 액세스 토큰을 사용해 유저의 정보값을 받아옴
+	// 구글 액세스 토큰을 사용해 유저의 정보값을 받아옴
 	public OAuthUserInfoDTO getUserInfo(String accessToken) {
-		KakaoUserInfoResponseDTO kakaoUserInfo = WebClient.create(KakaoUserInfoURL)
+		GoogleUserInfoResponseDTO googleUserInfo = WebClient.create(GoogleUserInfoURL)
 			.get()
 			.header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken) // access token 인가
 			.header(HttpHeaders.CONTENT_TYPE, HttpHeaderValues.APPLICATION_X_WWW_FORM_URLENCODED.toString())
 			.retrieve()
-			.bodyToMono(KakaoUserInfoResponseDTO.class)
+			.bodyToMono(GoogleUserInfoResponseDTO.class)
 			.block();
 
 		return new OAuthUserInfoDTO(
-			String.valueOf(kakaoUserInfo.id()),
-			kakaoUserInfo.kakaoAccount().email()
+			googleUserInfo.id(), googleUserInfo.email()
 		);
 	}
 }

--- a/src/main/java/com/cookeep/cookeep/domain/user/application/KakaoOAuthProvider.java
+++ b/src/main/java/com/cookeep/cookeep/domain/user/application/KakaoOAuthProvider.java
@@ -15,7 +15,6 @@ import com.cookeep.cookeep.domain.user.dto.SocialTokenResponseDTO;
 import com.cookeep.cookeep.domain.user.dto.KakaoUserInfoResponseDTO;
 import com.cookeep.cookeep.domain.user.entity.Provider;
 
-import io.netty.handler.codec.http.HttpHeaderValues;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import reactor.core.publisher.Mono;
@@ -41,6 +40,8 @@ public class KakaoOAuthProvider implements OAuthProvider {
 		return Provider.KAKAO;
 	}
 
+	private WebClient webClient = WebClient.create();
+
 	// 인가코드를 사용해 로그인할 유저의 카카오 액세스 토큰값을 받아옴
 	public String getAccessToken(String code, String redirectUri) {
 		String actualRedirectUri = (redirectUri != null) ? redirectUri : defaultRedirectUri;
@@ -52,7 +53,7 @@ public class KakaoOAuthProvider implements OAuthProvider {
 		form.add("redirect_uri", actualRedirectUri);
 		form.add("code", code);
 
-		SocialTokenResponseDTO socialTokenResponseDTO = WebClient.create()
+		SocialTokenResponseDTO socialTokenResponseDTO = webClient
 			.post()
 			.uri(KakaoAccessTokenURL)
 			.contentType(MediaType.APPLICATION_FORM_URLENCODED)
@@ -72,8 +73,9 @@ public class KakaoOAuthProvider implements OAuthProvider {
 
 	// 카카오 액세스 토큰을 사용해 유저의 정보값을 받아옴
 	public OAuthUserInfoDTO getUserInfo(String accessToken) {
-		KakaoUserInfoResponseDTO kakaoUserInfo = WebClient.create(KakaoUserInfoURL)
+		KakaoUserInfoResponseDTO kakaoUserInfo = webClient
 			.get()
+			.uri(KakaoUserInfoURL)
 			.header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken) // access token 인가
 			.retrieve()
 			.bodyToMono(KakaoUserInfoResponseDTO.class)

--- a/src/main/java/com/cookeep/cookeep/domain/user/application/KakaoOAuthProvider.java
+++ b/src/main/java/com/cookeep/cookeep/domain/user/application/KakaoOAuthProvider.java
@@ -75,7 +75,6 @@ public class KakaoOAuthProvider implements OAuthProvider {
 		KakaoUserInfoResponseDTO kakaoUserInfo = WebClient.create(KakaoUserInfoURL)
 			.get()
 			.header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken) // access token 인가
-			.header(HttpHeaders.CONTENT_TYPE, HttpHeaderValues.APPLICATION_X_WWW_FORM_URLENCODED.toString())
 			.retrieve()
 			.bodyToMono(KakaoUserInfoResponseDTO.class)
 			.block();

--- a/src/main/java/com/cookeep/cookeep/domain/user/application/KakaoOAuthProvider.java
+++ b/src/main/java/com/cookeep/cookeep/domain/user/application/KakaoOAuthProvider.java
@@ -11,7 +11,7 @@ import org.springframework.web.reactive.function.BodyInserters;
 import org.springframework.web.reactive.function.client.WebClient;
 
 import com.cookeep.cookeep.domain.user.dao.UserRepository;
-import com.cookeep.cookeep.domain.user.dto.KakaoTokenResponseDTO;
+import com.cookeep.cookeep.domain.user.dto.SocialTokenResponseDTO;
 import com.cookeep.cookeep.domain.user.dto.KakaoUserInfoResponseDTO;
 import com.cookeep.cookeep.domain.user.entity.Provider;
 
@@ -29,9 +29,9 @@ public class KakaoOAuthProvider implements OAuthProvider {
 	private String clientId;
 	@Value("${kakao.auth.secret}")
 	private String clientSecret;
-	@Value("${kakao.auth.accessTokenURL}")
+	@Value("${kakao.auth.access-token-url}")
 	private String KakaoAccessTokenURL;
-	@Value("${kakao.auth.userInfoURL}")
+	@Value("${kakao.auth.user-info-url}")
 	private String KakaoUserInfoURL;
 	@Value("${kakao.auth.redirect}")
 	private String defaultRedirectUri;
@@ -54,7 +54,7 @@ public class KakaoOAuthProvider implements OAuthProvider {
 		form.add("redirect_uri", actualRedirectUri);
 		form.add("code", code);
 
-		KakaoTokenResponseDTO kakaoTokenResponseDTO = WebClient.create()
+		SocialTokenResponseDTO socialTokenResponseDTO = WebClient.create()
 			.post()
 			.uri(KakaoAccessTokenURL)
 			.contentType(MediaType.APPLICATION_FORM_URLENCODED)
@@ -62,13 +62,14 @@ public class KakaoOAuthProvider implements OAuthProvider {
 			.retrieve()
 			.onStatus(HttpStatusCode::isError, res ->
 				res.bodyToMono(String.class).defaultIfEmpty("")
-					.doOnNext(body -> log.error("[KAKAO] /oauth/token error status={}, body={}", res.statusCode(), body))
+					.doOnNext(
+						body -> log.error("[KAKAO] /oauth/token error status={}, body={}", res.statusCode(), body))
 					.then(Mono.error(new RuntimeException("카카오 로그인 요청에 실패하였습니다.")))
 			)
-			.bodyToMono(KakaoTokenResponseDTO.class)
+			.bodyToMono(SocialTokenResponseDTO.class)
 			.block();
 
-		return kakaoTokenResponseDTO.accessToken();
+		return socialTokenResponseDTO.accessToken();
 	}
 
 	// 카카오 액세스 토큰을 사용해 유저의 정보값을 받아옴

--- a/src/main/java/com/cookeep/cookeep/domain/user/application/OAuthProvider.java
+++ b/src/main/java/com/cookeep/cookeep/domain/user/application/OAuthProvider.java
@@ -1,10 +1,11 @@
 package com.cookeep.cookeep.domain.user.application;
 
 import com.cookeep.cookeep.domain.user.dto.KakaoUserInfoResponseDTO;
+import com.cookeep.cookeep.domain.user.dto.OAuthUserInfoDTO;
 import com.cookeep.cookeep.domain.user.entity.Provider;
 
 public interface OAuthProvider {
 	Provider provider();
-	String getKakaoAccessToken(String code, String redirectUri);
-	KakaoUserInfoResponseDTO getKakaoUserInfo(String accessToken);
+	String getAccessToken(String code, String redirectUri);
+	OAuthUserInfoDTO getUserInfo(String accessToken);
 }

--- a/src/main/java/com/cookeep/cookeep/domain/user/dto/GoogleUserInfoResponseDTO.java
+++ b/src/main/java/com/cookeep/cookeep/domain/user/dto/GoogleUserInfoResponseDTO.java
@@ -1,0 +1,11 @@
+package com.cookeep.cookeep.domain.user.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record GoogleUserInfoResponseDTO(
+	@JsonProperty("id") String id,
+	@JsonProperty("email") String email
+) {
+}

--- a/src/main/java/com/cookeep/cookeep/domain/user/dto/OAuthUserInfoDTO.java
+++ b/src/main/java/com/cookeep/cookeep/domain/user/dto/OAuthUserInfoDTO.java
@@ -1,0 +1,8 @@
+package com.cookeep.cookeep.domain.user.dto;
+
+// 카카오, 구글 모두 공통적으로 소셜ID, 이메일 정보 필요
+public record OAuthUserInfoDTO(
+	String id,
+	String email
+) {
+}

--- a/src/main/java/com/cookeep/cookeep/domain/user/dto/SocialTokenResponseDTO.java
+++ b/src/main/java/com/cookeep/cookeep/domain/user/dto/SocialTokenResponseDTO.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-public record KakaoTokenResponseDTO(
+public record SocialTokenResponseDTO(
 	@JsonProperty("access_token") String accessToken
 ) {
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -31,11 +31,11 @@ spring:
 
 kakao:
   auth:
-    client: ${CLIENT_ID}
-    secret: ${CLIENT_SECRET}
-    redirect: ${REDIRECT_URI}
-    accessTokenURL: https://kauth.kakao.com/oauth/token
-    userInfoURL: https://kapi.kakao.com/v2/user/me
+    client: ${KAKAO_CLIENT_ID}
+    secret: ${KAKAO_CLIENT_SECRET}
+    redirect: ${KAKAO_REDIRECT_URI}
+    access-token-url: https://kauth.kakao.com/oauth/token
+    user-info-url: https://kapi.kakao.com/v2/user/me
 jwt:
   access-secret: ${JWT_ACCESS_SECRET_KEY}
   refresh-secret: ${JWT_REFRESH_SECRET_KEY}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -46,6 +46,12 @@ google:
     model: gemini-2.5-flash
   youtube:
     api-key: ${YOUTUBE_API_KEY}
+  auth:
+    client: ${GOOGLE_CLIENT_ID}
+    secret: ${GOOGLE_CLIENT_SECRET}
+    redirect: ${GOOGLE_REDIRECT_URI}
+    access-token-url: https://oauth2.googleapis.com/token
+    user-info-url: https://www.googleapis.com/oauth2/v2/userinfo
 
 ai:
   recipe:


### PR DESCRIPTION
# Related Issue  
#159
</br></br>

# Description  

관련 정리 글 - https://velog.io/@0-x-14/Spring-Boot-소셜-로그인-구조를-범용으로-리팩토링하기
</br></br>
### 구글 로그인 구현
- `GET /api/auth/login/google`
- 기존 카카오 로그인과 동일한 인가코드 방식으로 구현
- `GoogleOAuthProvider`를 추가하여 구글 OAuth 인증 처리
</br>

### OAuthProvider 범용 구조 리팩토링
- 기존 카카오 전용이었던 `OAuthProvider` 인터페이스를 범용으로 변경
  - `getKakaoAccessToken()` → `getAccessToken()`
  - `getKakaoUserInfo()` → `getUserInfo()` (반환타입 `OAuthUserInfoDTO`로 변경)
- 카카오·구글의 API 응답 구조가 달라 공통 DTO `OAuthUserInfoDTO` 추가
  - 각 Provider에서 자체 응답을 파싱 후 `OAuthUserInfoDTO`로 변환하여 반환
  - `AuthService`는 소셜 로그인 종류와 무관하게 공통 DTO만 처리하도록 설계
</br>

### AuthService 소셜 로그인 로직 통합
- `kakaoLogin()`, `googleLogin()`을 `socialLogin()`으로 통합
- `List<OAuthProvider>` 주입을 통해 Provider 타입에 맞는 구현체를 동적으로 선택
- 동일 이메일, 다른 Provider로 가입 시도 시 기존 계정에 UserAuth를 추가하여 계정 통합 처리
</br></br>

# Changes
- `GoogleOAuthProvider` 추가
- `GoogleUserInfoResponseDTO`, `OAuthUserInfoDTO` 추가
- `SocialTokenResponseDTO`로 통합 (`KakaoTokenResponseDTO` 대체)
- `KakaoLoginResponseDTO` → `SocialLoginResponseDTO` 변경
- `OAuthProvider` 인터페이스 범용화
- `KakaoOAuthProvider` 수정 (메서드명, 반환타입 변경)
- `AuthService` 소셜 로그인 메서드 통합 (`socialLogin()`)
- `application.yml` 카카오 환경변수명 분리 및 구글 OAuth 설정 추가