### PR TITLE
refactor: 모달 알림 엔드포인트 수정

### DIFF
--- a/src/main/java/com/cookeep/cookeep/api/controller/PushNotificationController.java
+++ b/src/main/java/com/cookeep/cookeep/api/controller/PushNotificationController.java
@@ -22,7 +22,7 @@ import java.util.Map;
 @Slf4j
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/users/me/push")
+@RequestMapping("/api/users/me")
 public class PushNotificationController {
 
     private final PushNotificationEligibilityService pushNotificationEligibilityService;
@@ -53,7 +53,7 @@ public class PushNotificationController {
                     - INTERNAL_SERVER_ERROR: 서버 내부 오류가 발생했습니다.
                     """, content = @Content)
     })
-    @GetMapping("/eligibility")
+    @GetMapping("/alerts")
     public ResponseEntity<DataResponse<PushNotificationEligibilityResponseDto>> checkPushNotificationEligibility(
             @AuthenticationPrincipal(expression = "userId") Long userId
     ) {


### PR DESCRIPTION
# Issue
#193 

# Description
-웹/앱 푸시 알림과의 구분을 위해 모달 알림(앱 내 팝업 알림) 엔드포인트 수정

# Changes
- 기존 /api/users/me/push/eligibility 경로를 /api/users/me/alerts 로 수정