### PR TITLE
feat: 모든 전체공개 레시피 목록 조회 피드 API 구현

### DIFF
--- a/src/main/java/com/cookeep/cookeep/api/controller/CookeepsController.java
+++ b/src/main/java/com/cookeep/cookeep/api/controller/CookeepsController.java
@@ -3,15 +3,15 @@ package com.cookeep.cookeep.api.controller;
 import com.cookeep.cookeep.api.dto.response.CookeepsOnboardingResponseDto;
 import com.cookeep.cookeep.api.dto.response.CookeepsRecipeDetailResponseDto;
 import com.cookeep.cookeep.api.dto.response.RankingResponseDto;
-import com.cookeep.cookeep.api.dto.response.WeeklyRecipeResponseDto;
+import com.cookeep.cookeep.api.dto.response.CookeepsFeedResponseDto;
 import com.cookeep.cookeep.common.dto.DataResponse;
+import com.cookeep.cookeep.common.dto.SliceResponse;
 import com.cookeep.cookeep.domain.cookeeps.application.CookeepsService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -56,13 +56,13 @@ public class CookeepsController {
 		return ResponseEntity.ok(DataResponse.from(null));
 	}
 
-	@Operation(summary = "이번 주 레시피 전체보기", description = "이번 주차에 올라온 레시피들을 정렬 필터와 함께 조회합니다.")
-	@GetMapping("/recipes/weekly")
-	public ResponseEntity<DataResponse<Page<WeeklyRecipeResponseDto>>> getWeeklyRecipes(
-			@RequestParam(defaultValue = "likes") String filter,
-			@org.springdoc.core.annotations.ParameterObject Pageable pageable // 프론트에서 page, size를 넘기면 자동 매핑
+	@Operation(summary = "쿠킵스 공개 레시피 목록 전체 조회", description = "모든 유저의 공개 레시피를 정렬 필터와 함께 조회합니다. filter: latest(기본, 최신순), likes(좋아요 많은 순), oldest(오래된 순)")
+	@GetMapping("/recipes")
+	public ResponseEntity<DataResponse<SliceResponse<CookeepsFeedResponseDto>>> getAllRecipes(
+			@RequestParam(defaultValue = "latest") String filter,
+			@org.springdoc.core.annotations.ParameterObject Pageable pageable
 	) {
-		return ResponseEntity.ok(DataResponse.from(cookeepsService.getWeeklyRecipes(filter, pageable)));
+		return ResponseEntity.ok(DataResponse.from(SliceResponse.from(cookeepsService.getAllRecipes(filter, pageable))));
 	}
 
 	@Operation(summary = "쿠킵스 레시피 상세 조회", description = "쿠킵스에 공개된 특정 레시피의 상세 내용을 조회합니다.")

--- a/src/main/java/com/cookeep/cookeep/api/dto/response/CookeepsFeedResponseDto.java
+++ b/src/main/java/com/cookeep/cookeep/api/dto/response/CookeepsFeedResponseDto.java
@@ -1,0 +1,16 @@
+package com.cookeep.cookeep.api.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class CookeepsFeedResponseDto {
+    private Long dailyRecipeId;
+    private String title;
+    private Integer likeCount;
+    private String recipeImageUrl;
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/cookeep/cookeep/common/dto/SliceResponse.java
+++ b/src/main/java/com/cookeep/cookeep/common/dto/SliceResponse.java
@@ -1,0 +1,23 @@
+package com.cookeep.cookeep.common.dto;
+
+import org.springframework.data.domain.Slice;
+
+import java.util.List;
+
+public record SliceResponse<T>(
+        List<T> content,
+        boolean last,
+        int number,
+        int size,
+        int numberOfElements
+) {
+    public static <T> SliceResponse<T> from(Slice<T> slice) {
+        return new SliceResponse<>(
+                slice.getContent(),
+                slice.isLast(),
+                slice.getNumber(),
+                slice.getSize(),
+                slice.getNumberOfElements()
+        );
+    }
+}

--- a/src/main/java/com/cookeep/cookeep/domain/cookeeps/application/CookeepsService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/cookeeps/application/CookeepsService.java
@@ -5,10 +5,9 @@ import com.cookeep.cookeep.api.dto.response.CookeepsRecipeDetailResponseDto;
 import com.cookeep.cookeep.api.dto.response.RankingResponseDto;
 import com.cookeep.cookeep.api.dto.response.RankingResponseDto.RecipeRankDto;
 import com.cookeep.cookeep.api.dto.response.RankingResponseDto.WateringRankDto;
-import com.cookeep.cookeep.api.dto.response.WeeklyRecipeResponseDto;
+import com.cookeep.cookeep.api.dto.response.CookeepsFeedResponseDto;
 import com.cookeep.cookeep.common.exception.AppException;
 import com.cookeep.cookeep.common.exception.ErrorCode;
-import com.cookeep.cookeep.common.util.DateTimeUtils;
 import com.cookeep.cookeep.domain.dailyrecipe.dao.DailyRecipeRepository;
 
 import com.cookeep.cookeep.domain.dailyrecipe.entity.DailyRecipe;
@@ -17,8 +16,8 @@ import com.cookeep.cookeep.domain.user.application.UserReader;
 import com.cookeep.cookeep.domain.user.dao.UserRepository;
 import com.cookeep.cookeep.domain.user.entity.User;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
@@ -110,37 +109,28 @@ public class CookeepsService {
 	}
 
 	@Transactional(readOnly = true)
-	public Page<WeeklyRecipeResponseDto> getWeeklyRecipes(String filter, Pageable pageable) {
-		// 1. 유틸리티를 사용해 이번 주 월요일 00:00:00 가져오기
-		LocalDateTime start = DateTimeUtils.getStartOfWeek();
-		LocalDateTime end = start.plusDays(7); // 다음 주 월요일 00:00:00 이전까지
-
-		// 2. 필터에 따른 정렬 기준 동적 설정
+	public Slice<CookeepsFeedResponseDto> getAllRecipes(String filter, Pageable pageable) {
+		//  1단계: 정렬 기준 결정 (switch)
 		Sort sort = switch (filter) {
-			case "latest" -> Sort.by(Sort.Direction.DESC, "createdAt");
-			case "oldest" -> Sort.by(Sort.Direction.ASC, "createdAt");
-			default -> Sort.by(Sort.Direction.DESC, "likeCount")
+			case "likes" -> Sort.by(Sort.Direction.DESC, "likeCount")
 					.and(Sort.by(Sort.Direction.DESC, "createdAt"));
+			case "oldest" -> Sort.by(Sort.Direction.ASC, "createdAt");
+			default -> Sort.by(Sort.Direction.DESC, "createdAt"); // 기본: 최신순
 		};
 
-		// 3. 정렬이 포함된 새로운 Pageable 생성
+		// 2단계: 정렬 포함된 새 Pageable 생성
 		Pageable sortedPageable = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(), sort);
 
-		// 4. 데이터 조회 및 DTO 변환
-		Page<DailyRecipe> recipes = dailyRecipeRepository.findWeeklyPublicRecipes(start, end, sortedPageable);
+		// 3단계: DB 조회 - Slice이므로 COUNT 쿼리 없이 size+1개만 가져옴
+		Slice<DailyRecipe> recipes = dailyRecipeRepository.findAllPublicRecipes(sortedPageable);
 
-		// 5. 순위(rank) 계산을 포함하여 변환
-		int startRank = (int) sortedPageable.getOffset() + 1;
-		return recipes.map(recipe -> {
-			int currentIndex = recipes.getContent().indexOf(recipe);
-			return WeeklyRecipeResponseDto.builder()
-					.rank(startRank + currentIndex)
-					.dailyRecipeId(recipe.getId())
-					.title(recipe.getTitle())
-					.likeCount(recipe.getLikeCount())
-					.recipeImageUrl(recipe.getRecipeImageUrl())
-					.build();
-		});
+		return recipes.map(recipe -> CookeepsFeedResponseDto.builder()
+				.dailyRecipeId(recipe.getId())
+				.title(recipe.getTitle())
+				.likeCount(recipe.getLikeCount())
+				.recipeImageUrl(recipe.getRecipeImageUrl())
+				.createdAt(recipe.getCreatedAt())
+				.build());
 	}
 
 	@Transactional(readOnly = true)

--- a/src/main/java/com/cookeep/cookeep/domain/dailyrecipe/dao/DailyRecipeRepository.java
+++ b/src/main/java/com/cookeep/cookeep/domain/dailyrecipe/dao/DailyRecipeRepository.java
@@ -4,6 +4,7 @@ import com.cookeep.cookeep.domain.dailyrecipe.entity.DailyRecipe;
 import com.cookeep.cookeep.domain.user.entity.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -41,6 +42,10 @@ public interface DailyRecipeRepository extends JpaRepository<DailyRecipe, Long> 
             @Param("start") LocalDateTime start,
             @Param("end") LocalDateTime end,
             Pageable pageable);
+
+    // 전체 공개 레시피 조회 (Slice 기반 - COUNT 쿼리 없음)
+    @Query("SELECT dr FROM DailyRecipe dr WHERE dr.isPublic = true")
+    Slice<DailyRecipe> findAllPublicRecipes(Pageable pageable);
 
     boolean existsByAiRecipe_Session_Id(Long sessionId);
 

--- a/src/main/java/com/cookeep/cookeep/domain/dailyrecipe/dao/DailyRecipeRepository.java
+++ b/src/main/java/com/cookeep/cookeep/domain/dailyrecipe/dao/DailyRecipeRepository.java
@@ -35,14 +35,6 @@ public interface DailyRecipeRepository extends JpaRepository<DailyRecipe, Long> 
             @Param("start") LocalDateTime start,
             @Param("end") LocalDateTime end);
 
-    // 이번 주차(월~일) 중 공개된 레시피만 조회
-    @Query("SELECT dr FROM DailyRecipe dr WHERE dr.isPublic = true " +
-            "AND dr.createdAt >= :start AND dr.createdAt < :end")
-    Page<DailyRecipe> findWeeklyPublicRecipes(
-            @Param("start") LocalDateTime start,
-            @Param("end") LocalDateTime end,
-            Pageable pageable);
-
     // 전체 공개 레시피 조회 (Slice 기반 - COUNT 쿼리 없음)
     @Query("SELECT dr FROM DailyRecipe dr WHERE dr.isPublic = true")
     Slice<DailyRecipe> findAllPublicRecipes(Pageable pageable);

--- a/src/main/java/com/cookeep/cookeep/domain/dailyrecipe/entity/DailyRecipe.java
+++ b/src/main/java/com/cookeep/cookeep/domain/dailyrecipe/entity/DailyRecipe.java
@@ -12,7 +12,10 @@ import lombok.*;
 @AllArgsConstructor
 @Builder
 @Entity
-@Table(name = "daily_recipes")
+@Table(name = "daily_recipes", indexes = {
+        @Index(name = "idx_daily_recipes_public_created", columnList = "is_public, created_at DESC"),
+        @Index(name = "idx_daily_recipes_public_likes", columnList = "is_public, like_count DESC, created_at DESC")
+})
 public class DailyRecipe extends BaseEntity {
 
     @Id

--- a/src/test/java/com/cookeep/cookeep/domain/cookeeps/application/CookeepsServiceTest.java
+++ b/src/test/java/com/cookeep/cookeep/domain/cookeeps/application/CookeepsServiceTest.java
@@ -1,8 +1,10 @@
 package com.cookeep.cookeep.domain.cookeeps.application;
 
+import com.cookeep.cookeep.api.dto.response.CookeepsFeedResponseDto;
 import com.cookeep.cookeep.api.dto.response.CookeepsOnboardingResponseDto;
 import com.cookeep.cookeep.api.dto.response.RankingResponseDto;
 import com.cookeep.cookeep.domain.dailyrecipe.dao.DailyRecipeRepository;
+import com.cookeep.cookeep.domain.dailyrecipe.entity.DailyRecipe;
 import com.cookeep.cookeep.domain.plant.dao.WateringLogRepository;
 import com.cookeep.cookeep.domain.user.application.UserReader;
 import com.cookeep.cookeep.domain.user.dao.UserRepository;
@@ -18,7 +20,12 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.data.domain.Sort;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -231,6 +238,151 @@ class CookeepsServiceTest {
             cookeepsService.confirmOnboarding(USER_ID);
 
             assertThat(user.isCookeepsOnboarded()).isTrue();
+        }
+    }
+
+    @Nested
+    @DisplayName("getAllRecipes - 전체 공개 레시피 피드 조회")
+    class GetAllRecipes {
+
+        private User user;
+
+        @BeforeEach
+        void setUp() {
+            user = User.builder().nickname("테스터").build();
+            given(dailyRecipeRepository.findAllPublicRecipes(any(Pageable.class)))
+                    .willReturn(new SliceImpl<>(List.of()));
+        }
+
+        private DailyRecipe buildRecipe(Long id, String title, int likeCount, String imageUrl, LocalDateTime createdAt) {
+            DailyRecipe recipe = DailyRecipe.builder()
+                    .id(id)
+                    .title(title)
+                    .content("{}")
+                    .isPublic(true)
+                    .likeCount(likeCount)
+                    .recipeImageUrl(imageUrl)
+                    .user(user)
+                    .build();
+            ReflectionTestUtils.setField(recipe, "createdAt", createdAt);
+            return recipe;
+        }
+
+        @Test
+        @DisplayName("filter가 latest이면 createdAt 내림차순 정렬로 조회한다")
+        void filter_latest_createdAt_내림차순_조회() {
+            cookeepsService.getAllRecipes("latest", PageRequest.of(0, 10));
+
+            ArgumentCaptor<Pageable> captor = ArgumentCaptor.forClass(Pageable.class);
+            verify(dailyRecipeRepository).findAllPublicRecipes(captor.capture());
+
+            Sort.Order order = captor.getValue().getSort().getOrderFor("createdAt");
+            assertThat(order).isNotNull();
+            assertThat(order.getDirection()).isEqualTo(Sort.Direction.DESC);
+        }
+
+        @Test
+        @DisplayName("filter가 likes이면 likeCount 내림차순, 동점 시 createdAt 내림차순 정렬로 조회한다")
+        void filter_likes_likeCount_내림차순_createdAt_내림차순_조회() {
+            cookeepsService.getAllRecipes("likes", PageRequest.of(0, 10));
+
+            ArgumentCaptor<Pageable> captor = ArgumentCaptor.forClass(Pageable.class);
+            verify(dailyRecipeRepository).findAllPublicRecipes(captor.capture());
+
+            Sort sort = captor.getValue().getSort();
+            assertThat(sort.getOrderFor("likeCount").getDirection()).isEqualTo(Sort.Direction.DESC);
+            assertThat(sort.getOrderFor("createdAt").getDirection()).isEqualTo(Sort.Direction.DESC);
+        }
+
+        @Test
+        @DisplayName("filter가 oldest이면 createdAt 오름차순 정렬로 조회한다")
+        void filter_oldest_createdAt_오름차순_조회() {
+            cookeepsService.getAllRecipes("oldest", PageRequest.of(0, 10));
+
+            ArgumentCaptor<Pageable> captor = ArgumentCaptor.forClass(Pageable.class);
+            verify(dailyRecipeRepository).findAllPublicRecipes(captor.capture());
+
+            Sort.Order order = captor.getValue().getSort().getOrderFor("createdAt");
+            assertThat(order).isNotNull();
+            assertThat(order.getDirection()).isEqualTo(Sort.Direction.ASC);
+        }
+
+        @Test
+        @DisplayName("알 수 없는 filter 값은 최신순(createdAt 내림차순)으로 처리한다")
+        void 알수없는_filter_최신순_처리() {
+            cookeepsService.getAllRecipes("unknown", PageRequest.of(0, 10));
+
+            ArgumentCaptor<Pageable> captor = ArgumentCaptor.forClass(Pageable.class);
+            verify(dailyRecipeRepository).findAllPublicRecipes(captor.capture());
+
+            Sort.Order order = captor.getValue().getSort().getOrderFor("createdAt");
+            assertThat(order).isNotNull();
+            assertThat(order.getDirection()).isEqualTo(Sort.Direction.DESC);
+        }
+
+        @Test
+        @DisplayName("공개된 레시피가 없으면 빈 content를 반환한다")
+        void 공개_레시피_없으면_빈_content_반환() {
+            given(dailyRecipeRepository.findAllPublicRecipes(any(Pageable.class)))
+                    .willReturn(new SliceImpl<>(List.of()));
+
+            Slice<CookeepsFeedResponseDto> result = cookeepsService.getAllRecipes("latest", PageRequest.of(0, 10));
+
+            assertThat(result.getContent()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("조회된 레시피가 다음 페이지보다 적으면 hasNext가 false이다")
+        void 마지막_페이지면_hasNext_false() {
+            DailyRecipe recipe = buildRecipe(1L, "된장찌개", 5, null, LocalDateTime.now());
+            given(dailyRecipeRepository.findAllPublicRecipes(any(Pageable.class)))
+                    .willReturn(new SliceImpl<>(List.of(recipe), PageRequest.of(0, 10), false));
+
+            Slice<CookeepsFeedResponseDto> result = cookeepsService.getAllRecipes("latest", PageRequest.of(0, 10));
+
+            assertThat(result.hasNext()).isFalse();
+        }
+
+        @Test
+        @DisplayName("다음 페이지가 있으면 hasNext가 true이다")
+        void 다음_페이지_있으면_hasNext_true() {
+            DailyRecipe recipe = buildRecipe(1L, "된장찌개", 5, null, LocalDateTime.now());
+            given(dailyRecipeRepository.findAllPublicRecipes(any(Pageable.class)))
+                    .willReturn(new SliceImpl<>(List.of(recipe), PageRequest.of(0, 10), true));
+
+            Slice<CookeepsFeedResponseDto> result = cookeepsService.getAllRecipes("latest", PageRequest.of(0, 10));
+
+            assertThat(result.hasNext()).isTrue();
+        }
+
+        @Test
+        @DisplayName("조회된 레시피의 필드가 DTO에 올바르게 매핑된다")
+        void 레시피_필드_DTO_올바르게_매핑() {
+            LocalDateTime createdAt = LocalDateTime.of(2026, 3, 28, 14, 0, 0);
+            DailyRecipe recipe = buildRecipe(42L, "된장찌개", 15, "https://example.com/img.jpg", createdAt);
+            given(dailyRecipeRepository.findAllPublicRecipes(any(Pageable.class)))
+                    .willReturn(new SliceImpl<>(List.of(recipe)));
+
+            Slice<CookeepsFeedResponseDto> result = cookeepsService.getAllRecipes("latest", PageRequest.of(0, 10));
+
+            CookeepsFeedResponseDto dto = result.getContent().get(0);
+            assertThat(dto.getDailyRecipeId()).isEqualTo(42L);
+            assertThat(dto.getTitle()).isEqualTo("된장찌개");
+            assertThat(dto.getLikeCount()).isEqualTo(15);
+            assertThat(dto.getRecipeImageUrl()).isEqualTo("https://example.com/img.jpg");
+            assertThat(dto.getCreatedAt()).isEqualTo(createdAt);
+        }
+
+        @Test
+        @DisplayName("recipeImageUrl이 없는 레시피는 null로 매핑된다")
+        void recipeImageUrl_없으면_null_매핑() {
+            DailyRecipe recipe = buildRecipe(1L, "바나나 쉐이크", 0, null, LocalDateTime.now());
+            given(dailyRecipeRepository.findAllPublicRecipes(any(Pageable.class)))
+                    .willReturn(new SliceImpl<>(List.of(recipe)));
+
+            Slice<CookeepsFeedResponseDto> result = cookeepsService.getAllRecipes("latest", PageRequest.of(0, 10));
+
+            assertThat(result.getContent().get(0).getRecipeImageUrl()).isNull();
         }
     }
 }


### PR DESCRIPTION
# Related Issue
CLOSE #188 

# Description
이번 주 레시피만 조회하던 기존 API를 전체 공개 레시피 피드로 전환합니다.
무한 스크롤을 고려해 `Slice<T>` 기반 페이지네이션을 적용하고, 정렬 필터를 지원합니다.

# Changes
- `GET /api/cookeeps/recipes/weekly` → `GET /api/cookeeps/recipes` 엔드포인트 변경
- 이번 주 날짜 제한 제거, 전체 공개 레시피 조회로 전환
- 정렬 필터 추가: `latest`(기본, 최신순), `likes`(좋아요 순), `oldest`(오래된 순)
- `Page<T>` → `Slice<T>` 적용으로 COUNT 쿼리 제거
- `SliceResponse<T>` 커스텀 래퍼 도입으로 응답 필드 정리
- `CookeepsFeedResponseDto` 신규 추가
- `daily_recipes` 조회 성능을 위한 복합 인덱스 2개 추가
- 미사용하게된 `findWeeklyPublicRecipes` 메서드 제거

# Test
- [x] GET /api/cookeeps/recipes?page=0&size=10 → 최신순 응답 확인                                                                                                        
- [x] GET /api/cookeeps/recipes?filter=likes&page=0&size=10 → 좋아요 많은 순 응답 확인                                                                                   
- [x] GET /api/cookeeps/recipes?filter=oldest&page=0&size=10 → 오래된 순 응답 확인                                                                                       
- [x] 알 수 없는 filter 값 입력 시 최신순으로 처리되는지 확인
- [x] 마지막 페이지에서 last: true 확인                                                                                                                                  
- [x] recipeImageUrl 없는 레시피 null 반환 확인                                                                                                                          
- [x] 서버 재시작 후 DB 인덱스 생성 여부 확인 (SHOW INDEX FROM daily_recipes) 