### PR TITLE
feat: 식재료이름 조회 (비선호 식재료 등록용)

### DIFF
--- a/src/main/java/com/cookeep/cookeep/api/controller/OnboardingController.java
+++ b/src/main/java/com/cookeep/cookeep/api/controller/OnboardingController.java
@@ -1,12 +1,9 @@
 package com.cookeep.cookeep.api.controller;
 
+import com.cookeep.cookeep.api.dto.response.IngredientNameResponseDto;
+import com.cookeep.cookeep.domain.ingredient.defaultingredient.application.IngredientNameService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
 
 import com.cookeep.cookeep.api.dto.request.AgreementRequestDTO;
 import com.cookeep.cookeep.api.dto.request.OnboardingRequestDTO;
@@ -19,6 +16,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -26,6 +24,7 @@ import lombok.RequiredArgsConstructor;
 public class OnboardingController {
 
 	private final OnboardingService onboardingService;
+	private final IngredientNameService ingredientNameService;
 
 	@Operation(summary = "약관 동의 여부 저장", description = "소셜로그인 회원을 대상으로 약관 동의 여부를 저장합니다.")
 	@ApiResponses(value = {
@@ -73,5 +72,15 @@ public class OnboardingController {
 		Long userId = principal.userId();
 		onboardingService.saveOnboarding(userId, onboardingRequestDTO);
 		return ResponseEntity.ok(DataResponse.ok());
+	}
+
+	@Operation(summary = "식재료 이름 조회 (비선호식재료 입력 시 재료명 조회용)")
+	@ApiResponses(value = {
+			@ApiResponse(responseCode = "200", description = "조회 성공"),
+			@ApiResponse(responseCode = "500", description = "서버 내부 오류")
+	})
+	@GetMapping("/onboarding/ingredients")
+	public ResponseEntity<DataResponse<IngredientNameResponseDto>> getIngredientNames() {
+		return ResponseEntity.ok(DataResponse.from(ingredientNameService.getIngredientNames()));
 	}
 }

--- a/src/main/java/com/cookeep/cookeep/api/dto/response/IngredientNameResponseDto.java
+++ b/src/main/java/com/cookeep/cookeep/api/dto/response/IngredientNameResponseDto.java
@@ -1,0 +1,28 @@
+package com.cookeep.cookeep.api.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Schema(
+        name = "IngredientNameResponse",
+        description = "디폴트 식재료 아이디+이름 응답 DTO"
+)
+@Getter
+@Builder
+@AllArgsConstructor
+public class IngredientNameResponseDto {
+
+    private List<IngredientItem> ingredients;
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    public static class IngredientItem {
+        private Long defaultIngredientId;
+        private String ingredient;
+    }
+}

--- a/src/main/java/com/cookeep/cookeep/domain/ingredient/defaultingredient/application/IngredientNameService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/ingredient/defaultingredient/application/IngredientNameService.java
@@ -1,0 +1,26 @@
+package com.cookeep.cookeep.domain.ingredient.defaultingredient.application;
+
+import com.cookeep.cookeep.api.dto.response.IngredientNameResponseDto;
+import com.cookeep.cookeep.domain.ingredient.defaultingredient.dao.DefaultIngredientRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class IngredientNameService {
+
+    private final DefaultIngredientRepository defaultIngredientRepository;
+
+    @Transactional(readOnly = true)
+   public IngredientNameResponseDto getIngredientNames() {
+        List<IngredientNameResponseDto.IngredientItem> items = defaultIngredientRepository
+                .findAllByOrderByIdAsc()
+                .stream()
+                .map(i -> new IngredientNameResponseDto.IngredientItem(i.getId(), i.getIngredient()))
+                .toList();
+        return new IngredientNameResponseDto(items);
+    }
+}


### PR DESCRIPTION
# Issue
#197 

# Description
비선호 식재료 등록 시 사용할 수 있도록 디폴트 식재료 전체 재료명을 응답합니다. 응답 시 식재료 아이디를 함께 반환합니다.
GET /api/users/me/onboarding/ingredients 경로로 되어있으나, 추후 이름만 조회하는 API가 또 필요하게되면 별도 controller로 분리하는 것도 고려중입니다. (현재는 온보딩 비선호식재료 등록에서만 사용되어서 온보딩으로 경로 설정해두었습니다)

# Changes
- IngredientNameResponseDto: 식재료 이름 응답 dto
- IngredientNameService: 식재료 아이디 + 이름 조회 service
- OnboardingController: GET /api/users/me/onboarding/ingredients 경로로 식재료명 조회 API 추가

# Test Checklist
- [x] 식재료 아이디 + 재료명 정상 조회 확인