### PR TITLE
infra: 도메인 cookeep.kr 전환에 따른 CORS 허용 출처 업데이트

### DIFF
--- a/src/main/java/com/cookeep/cookeep/config/SecurityConfig.java
+++ b/src/main/java/com/cookeep/cookeep/config/SecurityConfig.java
@@ -34,8 +34,8 @@ public class SecurityConfig {
 		config.setAllowedOrigins(List.of(
 			"http://localhost:5173",
 			"https://12th-coo-keep-fe.vercel.app",
-			"https://cookeep.store",
-			"https://api.cookeep.store"
+			"https://cookeep.kr",
+			"https://api.cookeep.kr"
 		));
 		config.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
 		config.setAllowedHeaders(List.of("*"));


### PR DESCRIPTION
# Description

도메인을 `cookeep.store`에서 `cookeep.kr`로 전환함에 따라 CORS 허용 출처를 업데이트합니다.

# Changes

`SecurityConfig`: CORS allowedOrigins에서 `cookeep.store`, `api.cookeep.store` 제거 후 `cookeep.kr`, `api.cookeep.kr` 추가