### PR TITLE
Feat: web push 전송 로직 구현

### DIFF
--- a/src/main/java/com/cookeep/cookeep/api/controller/WebPushSubscriptionController.java
+++ b/src/main/java/com/cookeep/cookeep/api/controller/WebPushSubscriptionController.java
@@ -1,6 +1,7 @@
 package com.cookeep.cookeep.api.controller;
 
 import com.cookeep.cookeep.api.dto.request.WebPushSubscriptionRequestDto;
+import com.cookeep.cookeep.api.dto.response.WebPushEligibilityResponseDto;
 import com.cookeep.cookeep.api.dto.response.WebPushSubscriptionResponseDto;
 import com.cookeep.cookeep.common.dto.DataResponse;
 import com.cookeep.cookeep.common.exception.ErrorCode;
@@ -15,10 +16,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "웹 푸시 알림 구독", description = "Web Push 구독 등록 / 삭제 / 수신 가능 여부 API")
 @RestController
@@ -57,4 +55,60 @@ public class WebPushSubscriptionController {
         WebPushSubscriptionResponseDto response = webPushSubscriptionService.subscribe(userId, request);
         return ResponseEntity.ok(DataResponse.from(response));
     }
+
+    @Operation(
+            summary = "웹 푸시 구독 삭제",
+            description = "서버에 저장된 Push Subscription을 endpoint 기준으로 삭제합니다."
+    )
+    @ApiErrorCodeExamples({
+            ErrorCode.UNAUTHORIZED,
+            ErrorCode.FORBIDDEN,
+            ErrorCode.USER_NOT_FOUND,
+            ErrorCode.SUBSCRIPTION_NOT_FOUND,
+            ErrorCode.INTERNAL_SERVER_ERROR
+    })
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "구독 삭제 성공"),
+            @ApiResponse(responseCode = "400", description = "요청 값이 올바르지 않음", content = @Content),
+            @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content),
+            @ApiResponse(responseCode = "403", description = "본인 소유 구독이 아님", content = @Content),
+            @ApiResponse(responseCode = "404", description = """
+                    리소스를 찾을 수 없습니다.
+                    - USER_NOT_FOUND: 사용자 없음
+                    - SUBSCRIPTION_NOT_FOUND: 해당 subscription 없음
+                    """, content = @Content),
+            @ApiResponse(responseCode = "500", description = "서버 오류", content = @Content)
+    })
+    @DeleteMapping("/subscription")
+    public ResponseEntity<DataResponse<WebPushSubscriptionResponseDto>> unsubscribe(
+            @AuthenticationPrincipal(expression = "userId") Long userId,
+            @Valid @RequestBody WebPushSubscriptionRequestDto request
+    ) {
+        WebPushSubscriptionResponseDto response = webPushSubscriptionService.unsubscribe(userId, request);
+        return ResponseEntity.ok(DataResponse.from(response));
+    }
+
+    @Operation(
+            summary = "웹 푸시 알림 수신 가능 여부 확인",
+            description = "현재 유저가 웹 푸시 알림을 받을 수 있는 상태인지 확인"
+    )
+    @ApiErrorCodeExamples({
+            ErrorCode.UNAUTHORIZED,
+            ErrorCode.USER_NOT_FOUND,
+            ErrorCode.INTERNAL_SERVER_ERROR
+    })
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content),
+            @ApiResponse(responseCode = "404", description = "사용자 없음", content = @Content),
+            @ApiResponse(responseCode = "500", description = "서버 오류", content = @Content)
+    })
+    @GetMapping("/eligibility")
+    public ResponseEntity<DataResponse<WebPushEligibilityResponseDto>> checkEligibility(
+            @AuthenticationPrincipal(expression = "userId") Long userId
+    ) {
+        WebPushEligibilityResponseDto response = webPushSubscriptionService.checkEligibility(userId);
+        return ResponseEntity.ok(DataResponse.from(response));
+    }
+
 }

--- a/src/main/java/com/cookeep/cookeep/api/controller/WebPushSubscriptionController.java
+++ b/src/main/java/com/cookeep/cookeep/api/controller/WebPushSubscriptionController.java
@@ -1,0 +1,4 @@
+package com.cookeep.cookeep.api.controller;
+
+public class WebPushSubscriptionController {
+}

--- a/src/main/java/com/cookeep/cookeep/api/controller/WebPushSubscriptionController.java
+++ b/src/main/java/com/cookeep/cookeep/api/controller/WebPushSubscriptionController.java
@@ -1,4 +1,60 @@
 package com.cookeep.cookeep.api.controller;
 
+import com.cookeep.cookeep.api.dto.request.WebPushSubscriptionRequestDto;
+import com.cookeep.cookeep.api.dto.response.WebPushSubscriptionResponseDto;
+import com.cookeep.cookeep.common.dto.DataResponse;
+import com.cookeep.cookeep.common.exception.ErrorCode;
+import com.cookeep.cookeep.config.ApiErrorCodeExamples;
+import com.cookeep.cookeep.domain.notification.application.WebPushSubscriptionService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "웹 푸시 알림 구독", description = "Web Push 구독 등록 / 삭제 / 수신 가능 여부 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/users/me/web/push")
 public class WebPushSubscriptionController {
+
+    private final WebPushSubscriptionService webPushSubscriptionService;
+
+    @Operation(
+            summary = "웹 푸시 구독 등록",
+            description = "브라우저가 생성한 푸시 알림 구독 정보를 서버에 저장. 동일 endpoint 있으면 유지 & 성공 응답"
+    )
+    @ApiErrorCodeExamples({
+            ErrorCode.UNAUTHORIZED,
+            ErrorCode.USER_NOT_FOUND,
+            ErrorCode.INVALID_ENDPOINT,
+            ErrorCode.INTERNAL_SERVER_ERROR
+    })
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "구독 등록 성공"),
+            @ApiResponse(responseCode = "400", description = """
+                    잘못된 요청입니다.
+                    - INVALID_REQUEST: 요청 값이 올바르지 않음
+                    - INVALID_ENDPOINT: subscription endpoint 정보 누락
+                    """, content = @Content),
+            @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content),
+            @ApiResponse(responseCode = "404", description = "사용자 없음", content = @Content),
+            @ApiResponse(responseCode = "500", description = "서버 오류", content = @Content)
+    })
+    @PostMapping("/subscription")
+    public ResponseEntity<DataResponse<WebPushSubscriptionResponseDto>> subscribe(
+            @AuthenticationPrincipal(expression = "userId") Long userId,
+            @Valid @RequestBody WebPushSubscriptionRequestDto request
+    ) {
+        WebPushSubscriptionResponseDto response = webPushSubscriptionService.subscribe(userId, request);
+        return ResponseEntity.ok(DataResponse.from(response));
+    }
 }

--- a/src/main/java/com/cookeep/cookeep/api/dto/request/WebPushSubscriptionRequestDto.java
+++ b/src/main/java/com/cookeep/cookeep/api/dto/request/WebPushSubscriptionRequestDto.java
@@ -1,7 +1,9 @@
 package com.cookeep.cookeep.api.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -22,18 +24,32 @@ public class WebPushSubscriptionRequestDto {
     private String endpoint;
 
     @Schema(
-            description = "VAPID 공개 키 (Base64url)",
-            example = "BNcRdreALRFXTkOOUHK1EtK2wtaz5Ry4YfYCA_0QTpQtUbVlO...",
+            description = "암호화 키 정보",
             requiredMode = Schema.RequiredMode.REQUIRED
     )
-    @NotBlank(message = "p256dh는 필수입니다.")
-    private String p256dh;
+    @NotNull(message = "keys는 필수입니다.")
+    @Valid
+    private Keys keys;
 
-    @Schema(
-            description = "VAPID 인증 시크릿 (Base64url)",
-            example = "tBHItJI5svbpez7KI4CCXg==",
-            requiredMode = Schema.RequiredMode.REQUIRED
-    )
-    @NotBlank(message = "auth는 필수입니다.")
-    private String auth;
+    @Schema(name = "WebPushKeys", description = "Web Push 암호화 키")
+    @Getter
+    @NoArgsConstructor
+    public static class Keys {
+
+        @Schema(
+                description = "공개키 (암호화용, Base64url)",
+                example = "BNcRdreALRFXTkOOUHK1EtK2wtaz5Ry4YfYCA_0QTpQt...",
+                requiredMode = Schema.RequiredMode.REQUIRED
+        )
+        @NotBlank(message = "p256dh는 필수입니다.")
+        private String p256dh;
+
+        @Schema(
+                description = "인증키 (Base64url)",
+                example = "tBHItJI5svbpez7KI4CCXg==",
+                requiredMode = Schema.RequiredMode.REQUIRED
+        )
+        @NotBlank(message = "auth는 필수입니다.")
+        private String auth;
+    }
 }

--- a/src/main/java/com/cookeep/cookeep/api/dto/request/WebPushSubscriptionRequestDto.java
+++ b/src/main/java/com/cookeep/cookeep/api/dto/request/WebPushSubscriptionRequestDto.java
@@ -1,0 +1,39 @@
+package com.cookeep.cookeep.api.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Schema(
+        name = "WebPushSubscriptionRequest",
+        description = "웹 푸시 구독 등록 요청 DTO"
+)
+@Getter
+@NoArgsConstructor
+public class WebPushSubscriptionRequestDto {
+
+    @Schema(
+            description = "브라우저가 발급한 Push 엔드포인트 URL",
+            example = "https://fcm.googleapis.com/fcm/send/...",
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
+    @NotBlank(message = "endpoint는 필수입니다.")
+    private String endpoint;
+
+    @Schema(
+            description = "VAPID 공개 키 (Base64url)",
+            example = "BNcRdreALRFXTkOOUHK1EtK2wtaz5Ry4YfYCA_0QTpQtUbVlO...",
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
+    @NotBlank(message = "p256dh는 필수입니다.")
+    private String p256dh;
+
+    @Schema(
+            description = "VAPID 인증 시크릿 (Base64url)",
+            example = "tBHItJI5svbpez7KI4CCXg==",
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
+    @NotBlank(message = "auth는 필수입니다.")
+    private String auth;
+}

--- a/src/main/java/com/cookeep/cookeep/api/dto/response/WebPushEligibilityResponseDto.java
+++ b/src/main/java/com/cookeep/cookeep/api/dto/response/WebPushEligibilityResponseDto.java
@@ -1,0 +1,4 @@
+package com.cookeep.cookeep.api.dto.response;
+
+public class WebPushEligibilityResponseDto {
+}

--- a/src/main/java/com/cookeep/cookeep/api/dto/response/WebPushEligibilityResponseDto.java
+++ b/src/main/java/com/cookeep/cookeep/api/dto/response/WebPushEligibilityResponseDto.java
@@ -1,4 +1,25 @@
 package com.cookeep.cookeep.api.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Schema(
+        name = "WebPushEligibilityResponse",
+        description = "웹 푸시 알림 수신 가능 여부 응답 DTO"
+)
+@Getter
+@AllArgsConstructor
 public class WebPushEligibilityResponseDto {
+
+    @Schema(
+            description = "웹 푸시 수신 가능 여부 (subscription 존재 여부 기준)",
+            example = "true"
+    )
+    private Boolean eligible;
+
+    public static WebPushEligibilityResponseDto of(boolean eligible) {
+        return new WebPushEligibilityResponseDto(eligible);
+    }
+
 }

--- a/src/main/java/com/cookeep/cookeep/api/dto/response/WebPushSubscriptionResponseDto.java
+++ b/src/main/java/com/cookeep/cookeep/api/dto/response/WebPushSubscriptionResponseDto.java
@@ -1,0 +1,34 @@
+package com.cookeep.cookeep.api.dto.response;
+
+import com.cookeep.cookeep.domain.notification.entity.WebPushSubscription;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Schema(
+        name = "WebPushSubscriptionResponse",
+        description = "웹 푸시 구독 등록 응답 DTO"
+)
+@Getter
+@Builder
+public class WebPushSubscriptionResponseDto {
+
+    @Schema(description = "생성된 구독 ID", example = "1")
+    private Long subscriptionId;
+
+    @Schema(description = "등록된 엔드포인트", example = "https://fcm.googleapis.com/fcm/send/...")
+    private String endpoint;
+
+    @Schema(description = "구독 등록 시각", example = "2026-04-04T12:00:00")
+    private LocalDateTime createdAt;
+
+    public static WebPushSubscriptionResponseDto from(WebPushSubscription subscription) {
+        return WebPushSubscriptionResponseDto.builder()
+                .subscriptionId(subscription.getId())
+                .endpoint(subscription.getEndpoint())
+                .createdAt(subscription.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/cookeep/cookeep/api/dto/response/WebPushSubscriptionResponseDto.java
+++ b/src/main/java/com/cookeep/cookeep/api/dto/response/WebPushSubscriptionResponseDto.java
@@ -2,6 +2,7 @@ package com.cookeep.cookeep.api.dto.response;
 
 import com.cookeep.cookeep.domain.notification.entity.WebPushSubscription;
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -9,26 +10,21 @@ import java.time.LocalDateTime;
 
 @Schema(
         name = "WebPushSubscriptionResponse",
-        description = "웹 푸시 구독 등록 응답 DTO"
+        description = "웹 푸시 구독 등록 / 삭제 응답 DTO"
 )
 @Getter
 @Builder
+@AllArgsConstructor
 public class WebPushSubscriptionResponseDto {
 
-    @Schema(description = "생성된 구독 ID", example = "1")
-    private Long subscriptionId;
+    @Schema(description = "처리 결과 메시지", example = "웹 푸시 구독이 등록되었습니다.")
+    private String message;
 
-    @Schema(description = "등록된 엔드포인트", example = "https://fcm.googleapis.com/fcm/send/...")
-    private String endpoint;
+    public static WebPushSubscriptionResponseDto subscribed() {
+        return new WebPushSubscriptionResponseDto("웹 푸시 구독이 등록되었습니다.");
+    }
 
-    @Schema(description = "구독 등록 시각", example = "2026-04-04T12:00:00")
-    private LocalDateTime createdAt;
-
-    public static WebPushSubscriptionResponseDto from(WebPushSubscription subscription) {
-        return WebPushSubscriptionResponseDto.builder()
-                .subscriptionId(subscription.getId())
-                .endpoint(subscription.getEndpoint())
-                .createdAt(subscription.getCreatedAt())
-                .build();
+    public static WebPushSubscriptionResponseDto unsubscribed() {
+        return new WebPushSubscriptionResponseDto("웹 푸시 구독이 해제되었습니다.");
     }
 }

--- a/src/main/java/com/cookeep/cookeep/common/exception/ErrorCode.java
+++ b/src/main/java/com/cookeep/cookeep/common/exception/ErrorCode.java
@@ -149,7 +149,7 @@ public enum ErrorCode {
 	VERIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "인증 요청 내역이 없습니다.", "SMS-004"),
 
 	// NOTIFICATION
-	SUBSCRIPTION_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 subscription을 찾을 수 없습니다.", "NOTIFICATION-002"),
+	SUBSCRIPTION_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 subscription을 찾을 수 없습니다.", "NOTIFICATION-003"),
 
 	// ==============================
 	// 409 CONFLICT

--- a/src/main/java/com/cookeep/cookeep/common/exception/ErrorCode.java
+++ b/src/main/java/com/cookeep/cookeep/common/exception/ErrorCode.java
@@ -89,6 +89,7 @@ public enum ErrorCode {
 
 	// NOTIFICATION
 	INVALID_ENDPOINT(HttpStatus.BAD_REQUEST, "subscription endpoint 정보가 누락되었습니다.", "NOTIFICATION-001"),
+	INVALID_REQUEST(HttpStatus.BAD_REQUEST, "요청 정보는 필수입니다.", "NOTIFICATION-002"),
 
 	// ==============================
 	// 401 UNAUTHORIZED

--- a/src/main/java/com/cookeep/cookeep/common/exception/ErrorCode.java
+++ b/src/main/java/com/cookeep/cookeep/common/exception/ErrorCode.java
@@ -87,6 +87,9 @@ public enum ErrorCode {
 	SAME_AS_CURRENT_PHONE_NUMBER(HttpStatus.BAD_REQUEST, "기존 등록된 전화번호와 동일한 전화번호입니다.", "USER-007"),
 	SAME_AS_CURRENT_EMAIL(HttpStatus.BAD_REQUEST, "기존 등록된 이메일과 동일한 이메일입니다.", "USER-008"),
 
+	// NOTIFICATION
+	INVALID_ENDPOINT(HttpStatus.BAD_REQUEST, "subscription endpoint 정보가 누락되었습니다.", "NOTIFICATION-001"),
+
 	// ==============================
 	// 401 UNAUTHORIZED
 	// ==============================
@@ -143,6 +146,9 @@ public enum ErrorCode {
 
 	// SMS
 	VERIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "인증 요청 내역이 없습니다.", "SMS-004"),
+
+	// NOTIFICATION
+	SUBSCRIPTION_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 subscription을 찾을 수 없습니다.", "NOTIFICATION-002"),
 
 	// ==============================
 	// 409 CONFLICT

--- a/src/main/java/com/cookeep/cookeep/domain/notice/entity/WebPushSubscription.java
+++ b/src/main/java/com/cookeep/cookeep/domain/notice/entity/WebPushSubscription.java
@@ -1,0 +1,39 @@
+package com.cookeep.cookeep.domain.notice.entity;
+
+import com.cookeep.cookeep.common.entity.BaseEntity;
+import com.cookeep.cookeep.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@EntityListeners(AuditingEntityListener.class)
+@Table(
+        name = "web_push_subscriptions",
+        uniqueConstraints = {
+                @UniqueConstraint(columnNames = "endpoint")
+        }
+)
+public class WebPushSubscription extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(nullable = false, unique = true, length = 512)
+    private String endpoint; // Push 전송 주소 (기기/브라우저 마다 다름)
+
+    @Column(nullable = false, length = 256)
+    private String p256dh; // VAPID 공개키
+
+    @Column(nullable = false, length = 64)
+    private String auth; // VAPID 인증키
+}

--- a/src/main/java/com/cookeep/cookeep/domain/notification/application/WebPushSubscriptionService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/notification/application/WebPushSubscriptionService.java
@@ -25,7 +25,6 @@ public class WebPushSubscriptionService {
     // 1. 구독등록: 브라우저가 생성한 Push Subscription 저장 or 이미 존재하면 기존 정보 반환
     @Transactional
     public WebPushSubscriptionResponseDto subscribe(Long userId, WebPushSubscriptionRequestDto request) {
-        User user = userReader.readById(userId);
 
         // request 자체 null
         if (request == null) {
@@ -41,6 +40,8 @@ public class WebPushSubscriptionService {
         if (request.getKeys() == null) {
             throw new AppException(ErrorCode.INVALID_REQUEST);
         }
+
+        User user = userReader.readById(userId);
 
         // 동일 endpoint가 이미 존재하면 해당 정보 응답
         if (webPushSubscriptionRepository.findByEndpoint(request.getEndpoint()).isPresent()) {

--- a/src/main/java/com/cookeep/cookeep/domain/notification/application/WebPushSubscriptionService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/notification/application/WebPushSubscriptionService.java
@@ -26,9 +26,19 @@ public class WebPushSubscriptionService {
     public WebPushSubscriptionResponseDto subscribe(Long userId, WebPushSubscriptionRequestDto request) {
         User user = userReader.readById(userId);
 
-        // endpoint 누락 체크 (에러 방지)
+        // request 자체 null
+        if (request == null) {
+            throw new AppException(ErrorCode.INVALID_REQUEST);
+        }
+
+        // endpoint 검증
         if (request.getEndpoint() == null || request.getEndpoint().isBlank()) {
             throw new AppException(ErrorCode.INVALID_ENDPOINT);
+        }
+
+        // keys 검증
+        if (request.getKeys() == null) {
+            throw new AppException(ErrorCode.INVALID_REQUEST);
         }
 
         // 동일 endpoint가 이미 존재하면 해당 정보 응답

--- a/src/main/java/com/cookeep/cookeep/domain/notification/application/WebPushSubscriptionService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/notification/application/WebPushSubscriptionService.java
@@ -1,6 +1,7 @@
 package com.cookeep.cookeep.domain.notification.application;
 
 import com.cookeep.cookeep.api.dto.request.WebPushSubscriptionRequestDto;
+import com.cookeep.cookeep.api.dto.response.WebPushEligibilityResponseDto;
 import com.cookeep.cookeep.api.dto.response.WebPushSubscriptionResponseDto;
 import com.cookeep.cookeep.common.exception.AppException;
 import com.cookeep.cookeep.common.exception.ErrorCode;
@@ -61,6 +62,37 @@ public class WebPushSubscriptionService {
                 userId, subscription.getId());
 
         return WebPushSubscriptionResponseDto.subscribed();
+    }
+
+    // 2. 구독 삭제: endpoint 구독 정보 삭제
+    @Transactional
+    public WebPushSubscriptionResponseDto unsubscribe(Long userId, WebPushSubscriptionRequestDto request) {
+        WebPushSubscription subscription = webPushSubscriptionRepository
+                .findByEndpoint(request.getEndpoint())
+                .orElseThrow(() -> new AppException(ErrorCode.SUBSCRIPTION_NOT_FOUND));
+
+        // 본인 소유 여부 검증
+        if (!subscription.getUser().getUserId().equals(userId)) {
+            throw new AppException(ErrorCode.FORBIDDEN);
+        }
+
+        webPushSubscriptionRepository.delete(subscription);
+
+        log.info("WebPush 구독 정보 삭제. userId={}, subscriptionId={}",
+                userId, subscription.getId());
+
+        return WebPushSubscriptionResponseDto.unsubscribed();
+    }
+
+    // 3. 수신 가능 여부 확인
+    @Transactional(readOnly = true)
+    public WebPushEligibilityResponseDto checkEligibility(Long userId) {
+
+        userReader.readById(userId);
+
+        boolean subscribed = webPushSubscriptionRepository.existsByUser_UserId(userId);
+
+        return WebPushEligibilityResponseDto.of(subscribed);
     }
 
     private String maskEndpoint(String endpoint) {

--- a/src/main/java/com/cookeep/cookeep/domain/notification/application/WebPushSubscriptionService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/notification/application/WebPushSubscriptionService.java
@@ -1,0 +1,49 @@
+package com.cookeep.cookeep.domain.notification.application;
+
+import com.cookeep.cookeep.api.dto.request.WebPushSubscriptionRequestDto;
+import com.cookeep.cookeep.api.dto.response.WebPushSubscriptionResponseDto;
+import com.cookeep.cookeep.domain.notification.dao.WebPushSubscriptionRepository;
+import com.cookeep.cookeep.domain.notification.entity.WebPushSubscription;
+import com.cookeep.cookeep.domain.user.application.UserReader;
+import com.cookeep.cookeep.domain.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class WebPushSubscriptionService {
+
+    private final WebPushSubscriptionRepository webPushSubscriptionRepository;
+    private final UserReader userReader;
+
+    // 1. 구독등록: 브라우저가 생성한 Push Subscription 저장 or 이미 존재하면 기존 정보 반환
+    @Transactional
+    public WebPushSubscriptionResponseDto subscribe(Long userId, WebPushSubscriptionRequestDto request) {
+        User user = userReader.readById(userId);
+
+        // 동일 endpoint가 이미 존재하면 기존 것 반환 (멱등)
+        return webPushSubscriptionRepository.findByEndpoint(request.getEndpoint())
+                .map(existing -> {
+                    log.debug("WebPush subscription already exists. userId={}, endpoint={}",
+                            userId, maskEndpoint(request.getEndpoint()));
+                    return WebPushSubscriptionResponseDto.from(existing);
+                })
+                .orElseGet(() -> {
+                    WebPushSubscription subscription = WebPushSubscription.builder()
+                            .user(user)
+                            .endpoint(request.getEndpoint())
+                            .p256dh(request.getP256dh())
+                            .auth(request.getAuth())
+                            .build();
+
+                    WebPushSubscription saved = webPushSubscriptionRepository.save(subscription);
+                    log.info("WebPush subscription registered. userId={}, subscriptionId={}",
+                            userId, saved.getId());
+                    return WebPushSubscriptionResponseDto.from(saved);
+                });
+    }
+
+}

--- a/src/main/java/com/cookeep/cookeep/domain/notification/application/WebPushSubscriptionService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/notification/application/WebPushSubscriptionService.java
@@ -2,6 +2,8 @@ package com.cookeep.cookeep.domain.notification.application;
 
 import com.cookeep.cookeep.api.dto.request.WebPushSubscriptionRequestDto;
 import com.cookeep.cookeep.api.dto.response.WebPushSubscriptionResponseDto;
+import com.cookeep.cookeep.common.exception.AppException;
+import com.cookeep.cookeep.common.exception.ErrorCode;
 import com.cookeep.cookeep.domain.notification.dao.WebPushSubscriptionRepository;
 import com.cookeep.cookeep.domain.notification.entity.WebPushSubscription;
 import com.cookeep.cookeep.domain.user.application.UserReader;
@@ -24,26 +26,36 @@ public class WebPushSubscriptionService {
     public WebPushSubscriptionResponseDto subscribe(Long userId, WebPushSubscriptionRequestDto request) {
         User user = userReader.readById(userId);
 
-        // 동일 endpoint가 이미 존재하면 기존 것 반환 (멱등)
-        return webPushSubscriptionRepository.findByEndpoint(request.getEndpoint())
-                .map(existing -> {
-                    log.debug("WebPush subscription already exists. userId={}, endpoint={}",
-                            userId, maskEndpoint(request.getEndpoint()));
-                    return WebPushSubscriptionResponseDto.from(existing);
-                })
-                .orElseGet(() -> {
-                    WebPushSubscription subscription = WebPushSubscription.builder()
-                            .user(user)
-                            .endpoint(request.getEndpoint())
-                            .p256dh(request.getP256dh())
-                            .auth(request.getAuth())
-                            .build();
+        // endpoint 누락 체크 (에러 방지)
+        if (request.getEndpoint() == null || request.getEndpoint().isBlank()) {
+            throw new AppException(ErrorCode.INVALID_ENDPOINT);
+        }
 
-                    WebPushSubscription saved = webPushSubscriptionRepository.save(subscription);
-                    log.info("WebPush subscription registered. userId={}, subscriptionId={}",
-                            userId, saved.getId());
-                    return WebPushSubscriptionResponseDto.from(saved);
-                });
+        // 동일 endpoint가 이미 존재하면 해당 정보 응답
+        if (webPushSubscriptionRepository.findByEndpoint(request.getEndpoint()).isPresent()) {
+            log.debug("WebPush 구독 정보 이미 존재함. userId={}, endpoint={}",
+                    userId, maskEndpoint(request.getEndpoint()));
+            return WebPushSubscriptionResponseDto.subscribed();
+        }
+
+        WebPushSubscription subscription = WebPushSubscription.builder()
+                .user(user)
+                .endpoint(request.getEndpoint())
+                .p256dh(request.getKeys().getP256dh())
+                .auth(request.getKeys().getAuth())
+                .build();
+
+        webPushSubscriptionRepository.save(subscription);
+
+        log.info("WebPush subscription registered. userId={}, subscriptionId={}",
+                userId, subscription.getId());
+
+        return WebPushSubscriptionResponseDto.subscribed();
+    }
+
+    private String maskEndpoint(String endpoint) {
+        if (endpoint == null || endpoint.length() < 20) return "****";
+        return endpoint.substring(0, 20) + "****";
     }
 
 }

--- a/src/main/java/com/cookeep/cookeep/domain/notification/dao/WebPushSubscriptionRepository.java
+++ b/src/main/java/com/cookeep/cookeep/domain/notification/dao/WebPushSubscriptionRepository.java
@@ -1,0 +1,31 @@
+package com.cookeep.cookeep.domain.notification.dao;
+
+import com.cookeep.cookeep.domain.notification.entity.WebPushSubscription;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface WebPushSubscriptionRepository extends JpaRepository<WebPushSubscription, Long> {
+
+    // 유저별 모든 구독 정보 조히
+    List<WebPushSubscription> findAllByUser_UserId(Long userId);
+
+    // 엔드포인트 기준 조회
+    Optional<WebPushSubscription> findByEndpoint(String endpoint);
+
+    // 유저 + 엔드포인트 별 조회
+    Optional<WebPushSubscription> findByUser_UserIdAndEndpoint(Long userId, String endpoint);
+
+    // 엔드포인트 별 존재 여부 확인
+    boolean existsByEndpoint(String endpoint);
+
+    // 유저 별 구독 존재 여부 확인
+    boolean existsByUser_UserId(Long userId);
+
+    // 엔드포인트 삭제
+    void deleteByEndpoint(String endpoint);
+
+    // 특정 유저의 모든 구독 정보 삭제
+    void deleteAllByUser_UserId(Long userId);
+}

--- a/src/main/java/com/cookeep/cookeep/domain/notification/entity/NotificationType.java
+++ b/src/main/java/com/cookeep/cookeep/domain/notification/entity/NotificationType.java
@@ -9,8 +9,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum NotificationType {
     EXPIRATION("유통기한임박"),
-    PLANT_WILTING("시듦"),
-    PLANT_GROWTH_STOP("성장정지");
+    PLANT_WILTING("시듦"), //필요시수정(to.현정)
+    PLANT_GROWTH_STOP("성장정지"); //필요시수정(to.현정)
 
     private final String displayName;
 

--- a/src/main/java/com/cookeep/cookeep/domain/notification/entity/NotificationType.java
+++ b/src/main/java/com/cookeep/cookeep/domain/notification/entity/NotificationType.java
@@ -1,0 +1,38 @@
+package com.cookeep.cookeep.domain.notification.entity;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum NotificationType {
+    EXPIRATION("유통기한임박"),
+    PLANT_WILTING("시듦"),
+    PLANT_GROWTH_STOP("성장정지");
+
+    private final String displayName;
+
+    @JsonCreator
+    public static NotificationType from(String value) {
+        for (NotificationType type : NotificationType.values()) {
+
+            // enum 이름으로 매핑 (EXPIRATION 등)
+            if (type.name().equalsIgnoreCase(value)) {
+                return type;
+            }
+
+            // displayName으로 매핑 (유통기한임박 등)
+            if (type.displayName.equals(value)) {
+                return type;
+            }
+        }
+        throw new IllegalArgumentException("Invalid notification type: " + value);
+    }
+
+    @JsonValue
+    public String toJson() {
+        return this.displayName;
+    }
+}

--- a/src/main/java/com/cookeep/cookeep/domain/notification/entity/WebPushSubscription.java
+++ b/src/main/java/com/cookeep/cookeep/domain/notification/entity/WebPushSubscription.java
@@ -28,12 +28,15 @@ public class WebPushSubscription extends BaseEntity {
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
+    // Push 전송 주소 (기기/브라우저 마다 다름)
     @Column(nullable = false, unique = true, length = 512)
-    private String endpoint; // Push 전송 주소 (기기/브라우저 마다 다름)
+    private String endpoint;
 
+    // VAPID 공개키
     @Column(nullable = false, length = 256)
-    private String p256dh; // VAPID 공개키
+    private String p256dh;
 
+    // VAPID 인증키
     @Column(nullable = false, length = 64)
-    private String auth; // VAPID 인증키
+    private String auth;
 }

--- a/src/main/java/com/cookeep/cookeep/domain/notification/entity/WebPushSubscription.java
+++ b/src/main/java/com/cookeep/cookeep/domain/notification/entity/WebPushSubscription.java
@@ -1,4 +1,4 @@
-package com.cookeep.cookeep.domain.notice.entity;
+package com.cookeep.cookeep.domain.notification.entity;
 
 import com.cookeep.cookeep.common.entity.BaseEntity;
 import com.cookeep.cookeep.domain.user.entity.User;

--- a/src/test/java/com/cookeep/cookeep/domain/notification/application/WebPushSubscriptionServiceTest.java
+++ b/src/test/java/com/cookeep/cookeep/domain/notification/application/WebPushSubscriptionServiceTest.java
@@ -1,6 +1,7 @@
 package com.cookeep.cookeep.domain.notification.application;
 
 import com.cookeep.cookeep.api.dto.request.WebPushSubscriptionRequestDto;
+import com.cookeep.cookeep.api.dto.response.WebPushEligibilityResponseDto;
 import com.cookeep.cookeep.api.dto.response.WebPushSubscriptionResponseDto;
 import com.cookeep.cookeep.common.exception.AppException;
 import com.cookeep.cookeep.common.exception.ErrorCode;
@@ -43,140 +44,215 @@ public class WebPushSubscriptionServiceTest {
     private static final String P256DH   = "BNcRdreALRFXTkOOUHK1EtK2wtaz5Ry4YfYCA_0QTpQt";
     private static final String AUTH     = "tBHItJI5svbpez7KI4CCXg==";
 
-    private User mockUser;
-    private WebPushSubscriptionRequestDto validRequest;
+    private User user;
 
     @BeforeEach
     void setUp() {
-        mockUser = mock(User.class);
-        given(mockUser.getUserId()).willReturn(USER_ID);
-
-        validRequest = makeRequest(ENDPOINT, P256DH, AUTH);
+        user = mock(User.class);
+        lenient().when(user.getUserId()).thenReturn(USER_ID);
+        lenient().when(userReader.readById(USER_ID)).thenReturn(user);
     }
 
     // 1. 구독 등록
     @Nested
-    @DisplayName("1. subscribe (구독 등록)")
+    @DisplayName("1. subscribe - 구독 등록")
     class Subscribe {
 
         @Test
-        @DisplayName("성공 - 신규 endpoint면 저장 후 성공 메시지 반환")
-        void subscribe_success_newEndpoint() {
-            // given
-            given(userReader.readById(USER_ID)).willReturn(mockUser);
+        @DisplayName("신규 endpoint이면 저장 후 성공 메시지를 반환한다")
+        void 신규_endpoint_저장_성공메시지_반환() {
             given(webPushSubscriptionRepository.findByEndpoint(ENDPOINT)).willReturn(Optional.empty());
 
-            // WebPushSubscription 저장 시 id 세팅 모킹
-            doAnswer(invocation -> {
-                WebPushSubscription sub = invocation.getArgument(0);
-                ReflectionTestUtils.setField(sub, "id", 10L);
-                return sub;
-            }).when(webPushSubscriptionRepository).save(any(WebPushSubscription.class));
+            WebPushSubscriptionResponseDto result =
+                    webPushSubscriptionService.subscribe(USER_ID, buildRequest(ENDPOINT, P256DH, AUTH));
 
-            // when
-            WebPushSubscriptionResponseDto response = webPushSubscriptionService.subscribe(USER_ID, validRequest);
-
-            // then
-            assertThat(response.getMessage()).isEqualTo("웹 푸시 구독이 등록되었습니다.");
-            then(webPushSubscriptionRepository).should(times(1)).save(any(WebPushSubscription.class));
+            assertThat(result.getMessage()).isEqualTo("웹 푸시 구독이 등록되었습니다.");
+            verify(webPushSubscriptionRepository, times(1)).save(any(WebPushSubscription.class));
         }
 
         @Test
-        @DisplayName("성공 (멱등) - 이미 동일한 endpoint가 존재하면 저장하지 않고 성공 메시지 반환")
-        void subscribe_success_duplicateEndpoint_idempotent() {
-            // given
-            WebPushSubscription existingSubscription = buildSubscription(10L, mockUser, ENDPOINT);
-            given(userReader.readById(USER_ID)).willReturn(mockUser);
+        @DisplayName("이미 동일한 endpoint가 존재하면 저장하지 않고 성공 메시지를 반환한다")
+        void 중복_endpoint_저장_생략_성공메시지_반환() {
+            WebPushSubscription existing = buildSubscription(10L, user, ENDPOINT);
             given(webPushSubscriptionRepository.findByEndpoint(ENDPOINT))
-                    .willReturn(Optional.of(existingSubscription));
+                    .willReturn(Optional.of(existing));
 
-            // when
-            WebPushSubscriptionResponseDto response = webPushSubscriptionService.subscribe(USER_ID, validRequest);
+            WebPushSubscriptionResponseDto result =
+                    webPushSubscriptionService.subscribe(USER_ID, buildRequest(ENDPOINT, P256DH, AUTH));
 
-            // then
-            assertThat(response.getMessage()).isEqualTo("웹 푸시 구독이 등록되었습니다.");
-            then(webPushSubscriptionRepository).should(never()).save(any());
+            assertThat(result.getMessage()).isEqualTo("웹 푸시 구독이 등록되었습니다.");
+            verify(webPushSubscriptionRepository, never()).save(any());
         }
 
         @Test
-        @DisplayName("실패 - 존재하지 않는 유저")
-        void subscribe_fail_userNotFound() {
-            // given
+        @DisplayName("존재하지 않는 유저이면 USER_NOT_FOUND 예외가 발생한다")
+        void 존재하지않는_유저_예외발생() {
             given(userReader.readById(USER_ID))
                     .willThrow(new AppException(ErrorCode.USER_NOT_FOUND));
 
-            // when & then
-            assertThatThrownBy(() -> webPushSubscriptionService.subscribe(USER_ID, validRequest))
+            assertThatThrownBy(() ->
+                    webPushSubscriptionService.subscribe(USER_ID, buildRequest(ENDPOINT, P256DH, AUTH))
+            )
                     .isInstanceOf(AppException.class)
-                    .extracting(e -> ((AppException) e).getErrorCode())
-                    .isEqualTo(ErrorCode.USER_NOT_FOUND);
+                    .hasMessageContaining(ErrorCode.USER_NOT_FOUND.getMessage());
 
-            then(webPushSubscriptionRepository).should(never()).save(any());
+            verify(webPushSubscriptionRepository, never()).save(any());
         }
 
         @Test
-        @DisplayName("실패 - request 자체가 null")
-        void subscribe_fail_requestNull() {
-            // given
-            given(userReader.readById(USER_ID)).willReturn(mockUser);
-
-            // when & then
-            assertThatThrownBy(() -> webPushSubscriptionService.subscribe(USER_ID, null))
+        @DisplayName("request가 null이면 INVALID_REQUEST 예외가 발생한다")
+        void request_null_INVALID_REQUEST_예외발생() {
+            assertThatThrownBy(() ->
+                    webPushSubscriptionService.subscribe(USER_ID, null)
+            )
                     .isInstanceOf(AppException.class)
-                    .extracting(e -> ((AppException) e).getErrorCode())
-                    .isEqualTo(ErrorCode.INVALID_REQUEST);
+                    .hasMessageContaining(ErrorCode.INVALID_REQUEST.getMessage());
+
+            verify(webPushSubscriptionRepository, never()).save(any());
         }
 
         @Test
-        @DisplayName("실패 - endpoint가 null")
-        void subscribe_fail_endpointNull() {
-            // given
-            given(userReader.readById(USER_ID)).willReturn(mockUser);
-            WebPushSubscriptionRequestDto requestWithNullEndpoint = makeRequest(null, P256DH, AUTH);
-
-            // when & then
-            assertThatThrownBy(() -> webPushSubscriptionService.subscribe(USER_ID, requestWithNullEndpoint))
+        @DisplayName("endpoint가 null이면 INVALID_ENDPOINT 예외가 발생한다")
+        void endpoint_null_INVALID_ENDPOINT_예외발생() {
+            assertThatThrownBy(() ->
+                    webPushSubscriptionService.subscribe(USER_ID, buildRequest(null, P256DH, AUTH))
+            )
                     .isInstanceOf(AppException.class)
-                    .extracting(e -> ((AppException) e).getErrorCode())
-                    .isEqualTo(ErrorCode.INVALID_ENDPOINT);
+                    .hasMessageContaining(ErrorCode.INVALID_ENDPOINT.getMessage());
+
+            verify(webPushSubscriptionRepository, never()).save(any());
         }
 
         @Test
-        @DisplayName("실패 - endpoint가 빈 문자열")
-        void subscribe_fail_endpointBlank() {
-            // given
-            given(userReader.readById(USER_ID)).willReturn(mockUser);
-            WebPushSubscriptionRequestDto requestWithBlankEndpoint = makeRequest("  ", P256DH, AUTH);
-
-            // when & then
-            assertThatThrownBy(() -> webPushSubscriptionService.subscribe(USER_ID, requestWithBlankEndpoint))
+        @DisplayName("endpoint가 빈 문자열이면 INVALID_ENDPOINT 예외가 발생한다")
+        void endpoint_공백_INVALID_ENDPOINT_예외발생() {
+            assertThatThrownBy(() ->
+                    webPushSubscriptionService.subscribe(USER_ID, buildRequest("  ", P256DH, AUTH))
+            )
                     .isInstanceOf(AppException.class)
-                    .extracting(e -> ((AppException) e).getErrorCode())
-                    .isEqualTo(ErrorCode.INVALID_ENDPOINT);
+                    .hasMessageContaining(ErrorCode.INVALID_ENDPOINT.getMessage());
+
+            verify(webPushSubscriptionRepository, never()).save(any());
         }
 
         @Test
-        @DisplayName("실패 - keys가 null")
-        void subscribe_fail_keysNull() {
-            // given
-            given(userReader.readById(USER_ID)).willReturn(mockUser);
-            WebPushSubscriptionRequestDto requestWithNullKeys = makeRequest(ENDPOINT, null, null);
+        @DisplayName("keys가 null이면 INVALID_REQUEST 예외가 발생한다")
+        void keys_null_INVALID_REQUEST_예외발생() {
+            WebPushSubscriptionRequestDto request = new WebPushSubscriptionRequestDto();
+            ReflectionTestUtils.setField(request, "endpoint", ENDPOINT);
+            // keys 필드를 명시적으로 null로 유지
 
-            // when & then
-            assertThatThrownBy(() -> webPushSubscriptionService.subscribe(USER_ID, requestWithNullKeys))
+            assertThatThrownBy(() ->
+                    webPushSubscriptionService.subscribe(USER_ID, request)
+            )
                     .isInstanceOf(AppException.class)
-                    .extracting(e -> ((AppException) e).getErrorCode())
-                    .isEqualTo(ErrorCode.INVALID_REQUEST);
+                    .hasMessageContaining(ErrorCode.INVALID_REQUEST.getMessage());
+
+            verify(webPushSubscriptionRepository, never()).save(any());
         }
     }
 
     // 2. 구독 삭제
+    @Nested
+    @DisplayName("2. unsubscribe - 구독 삭제")
+    class Unsubscribe {
 
+        @Test
+        @DisplayName("본인 소유 endpoint이면 삭제 후 성공 메시지를 반환한다")
+        void 본인_소유_endpoint_삭제_성공메시지_반환() {
+            WebPushSubscription subscription = buildSubscription(10L, user, ENDPOINT);
+            given(webPushSubscriptionRepository.findByEndpoint(ENDPOINT))
+                    .willReturn(Optional.of(subscription));
+
+            WebPushSubscriptionResponseDto result =
+                    webPushSubscriptionService.unsubscribe(USER_ID, buildRequest(ENDPOINT, P256DH, AUTH));
+
+            assertThat(result.getMessage()).isEqualTo("웹 푸시 구독이 해제되었습니다.");
+            verify(webPushSubscriptionRepository, times(1)).delete(subscription);
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 endpoint이면 SUBSCRIPTION_NOT_FOUND 예외가 발생한다")
+        void 존재하지않는_endpoint_SUBSCRIPTION_NOT_FOUND_예외발생() {
+            given(webPushSubscriptionRepository.findByEndpoint(ENDPOINT))
+                    .willReturn(Optional.empty());
+
+            assertThatThrownBy(() ->
+                    webPushSubscriptionService.unsubscribe(USER_ID, buildRequest(ENDPOINT, P256DH, AUTH))
+            )
+                    .isInstanceOf(AppException.class)
+                    .hasMessageContaining(ErrorCode.SUBSCRIPTION_NOT_FOUND.getMessage());
+
+            verify(webPushSubscriptionRepository, never()).delete(any());
+        }
+
+        @Test
+        @DisplayName("다른 유저 소유의 endpoint를 삭제하려 하면 FORBIDDEN 예외가 발생한다")
+        void 타인_소유_endpoint_FORBIDDEN_예외발생() {
+            User anotherUser = mock(User.class);
+            given(anotherUser.getUserId()).willReturn(999L);
+
+            WebPushSubscription subscription = buildSubscription(10L, anotherUser, ENDPOINT);
+            given(webPushSubscriptionRepository.findByEndpoint(ENDPOINT))
+                    .willReturn(Optional.of(subscription));
+
+            assertThatThrownBy(() ->
+                    webPushSubscriptionService.unsubscribe(USER_ID, buildRequest(ENDPOINT, P256DH, AUTH))
+            )
+                    .isInstanceOf(AppException.class)
+                    .hasMessageContaining(ErrorCode.FORBIDDEN.getMessage());
+
+            verify(webPushSubscriptionRepository, never()).delete(any());
+        }
+    }
+
+    // 3. 구독 가능 여부 확인
+    @Nested
+    @DisplayName("3. checkEligibility - 수신 가능 여부 확인")
+    class CheckEligibility {
+
+        @Test
+        @DisplayName("구독 정보가 존재하면 eligible=true를 반환한다")
+        void 구독_존재_eligible_true_반환() {
+            given(webPushSubscriptionRepository.existsByUser_UserId(USER_ID)).willReturn(true);
+
+            WebPushEligibilityResponseDto result =
+                    webPushSubscriptionService.checkEligibility(USER_ID);
+
+            assertThat(result.getEligible()).isTrue();
+        }
+
+        @Test
+        @DisplayName("구독 정보가 없으면 eligible=false를 반환한다")
+        void 구독_없음_eligible_false_반환() {
+            given(webPushSubscriptionRepository.existsByUser_UserId(USER_ID)).willReturn(false);
+
+            WebPushEligibilityResponseDto result =
+                    webPushSubscriptionService.checkEligibility(USER_ID);
+
+            assertThat(result.getEligible()).isFalse();
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 유저이면 USER_NOT_FOUND 예외가 발생한다")
+        void 존재하지않는_유저_USER_NOT_FOUND_예외발생() {
+            given(userReader.readById(USER_ID))
+                    .willThrow(new AppException(ErrorCode.USER_NOT_FOUND));
+
+            assertThatThrownBy(() ->
+                    webPushSubscriptionService.checkEligibility(USER_ID)
+            )
+                    .isInstanceOf(AppException.class)
+                    .hasMessageContaining(ErrorCode.USER_NOT_FOUND.getMessage());
+
+            verify(webPushSubscriptionRepository, never()).existsByUser_UserId(any());
+        }
+    }
 
     // --- 내부 메서드 ---
 
     // Keys 객체 생성
-    private WebPushSubscriptionRequestDto makeRequest(String endpoint, String p256dh, String auth) {
+    private WebPushSubscriptionRequestDto buildRequest(String endpoint, String p256dh, String auth) {
         WebPushSubscriptionRequestDto dto = new WebPushSubscriptionRequestDto();
         ReflectionTestUtils.setField(dto, "endpoint", endpoint);
 
@@ -186,14 +262,13 @@ public class WebPushSubscriptionServiceTest {
             ReflectionTestUtils.setField(keys, "auth", auth);
             ReflectionTestUtils.setField(dto, "keys", keys);
         }
-
         return dto;
     }
 
     // 테스트용 WebPushSubscription 생성
-    private WebPushSubscription buildSubscription(Long id, User user, String endpoint) {
+    private WebPushSubscription buildSubscription(Long id, User owner, String endpoint) {
         WebPushSubscription sub = WebPushSubscription.builder()
-                .user(user)
+                .user(owner)
                 .endpoint(endpoint)
                 .p256dh(P256DH)
                 .auth(AUTH)

--- a/src/test/java/com/cookeep/cookeep/domain/notification/application/WebPushSubscriptionServiceTest.java
+++ b/src/test/java/com/cookeep/cookeep/domain/notification/application/WebPushSubscriptionServiceTest.java
@@ -1,0 +1,205 @@
+package com.cookeep.cookeep.domain.notification.application;
+
+import com.cookeep.cookeep.api.dto.request.WebPushSubscriptionRequestDto;
+import com.cookeep.cookeep.api.dto.response.WebPushSubscriptionResponseDto;
+import com.cookeep.cookeep.common.exception.AppException;
+import com.cookeep.cookeep.common.exception.ErrorCode;
+import com.cookeep.cookeep.domain.notification.dao.WebPushSubscriptionRepository;
+import com.cookeep.cookeep.domain.notification.entity.WebPushSubscription;
+import com.cookeep.cookeep.domain.user.application.UserReader;
+import com.cookeep.cookeep.domain.user.entity.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class WebPushSubscriptionServiceTest {
+
+    @InjectMocks
+    private WebPushSubscriptionService webPushSubscriptionService;
+
+    @Mock
+    private WebPushSubscriptionRepository webPushSubscriptionRepository;
+
+    @Mock
+    private UserReader userReader;
+
+    private static final Long USER_ID = 1L;
+    private static final String ENDPOINT = "https://fcm.googleapis.com/fcm/send/test-endpoint-12345";
+    private static final String P256DH   = "BNcRdreALRFXTkOOUHK1EtK2wtaz5Ry4YfYCA_0QTpQt";
+    private static final String AUTH     = "tBHItJI5svbpez7KI4CCXg==";
+
+    private User mockUser;
+    private WebPushSubscriptionRequestDto validRequest;
+
+    @BeforeEach
+    void setUp() {
+        mockUser = mock(User.class);
+        given(mockUser.getUserId()).willReturn(USER_ID);
+
+        validRequest = makeRequest(ENDPOINT, P256DH, AUTH);
+    }
+
+    // 1. 구독 등록
+    @Nested
+    @DisplayName("1. subscribe (구독 등록)")
+    class Subscribe {
+
+        @Test
+        @DisplayName("성공 - 신규 endpoint면 저장 후 성공 메시지 반환")
+        void subscribe_success_newEndpoint() {
+            // given
+            given(userReader.readById(USER_ID)).willReturn(mockUser);
+            given(webPushSubscriptionRepository.findByEndpoint(ENDPOINT)).willReturn(Optional.empty());
+
+            // WebPushSubscription 저장 시 id 세팅 모킹
+            doAnswer(invocation -> {
+                WebPushSubscription sub = invocation.getArgument(0);
+                ReflectionTestUtils.setField(sub, "id", 10L);
+                return sub;
+            }).when(webPushSubscriptionRepository).save(any(WebPushSubscription.class));
+
+            // when
+            WebPushSubscriptionResponseDto response = webPushSubscriptionService.subscribe(USER_ID, validRequest);
+
+            // then
+            assertThat(response.getMessage()).isEqualTo("웹 푸시 구독이 등록되었습니다.");
+            then(webPushSubscriptionRepository).should(times(1)).save(any(WebPushSubscription.class));
+        }
+
+        @Test
+        @DisplayName("성공 (멱등) - 이미 동일한 endpoint가 존재하면 저장하지 않고 성공 메시지 반환")
+        void subscribe_success_duplicateEndpoint_idempotent() {
+            // given
+            WebPushSubscription existingSubscription = buildSubscription(10L, mockUser, ENDPOINT);
+            given(userReader.readById(USER_ID)).willReturn(mockUser);
+            given(webPushSubscriptionRepository.findByEndpoint(ENDPOINT))
+                    .willReturn(Optional.of(existingSubscription));
+
+            // when
+            WebPushSubscriptionResponseDto response = webPushSubscriptionService.subscribe(USER_ID, validRequest);
+
+            // then
+            assertThat(response.getMessage()).isEqualTo("웹 푸시 구독이 등록되었습니다.");
+            then(webPushSubscriptionRepository).should(never()).save(any());
+        }
+
+        @Test
+        @DisplayName("실패 - 존재하지 않는 유저")
+        void subscribe_fail_userNotFound() {
+            // given
+            given(userReader.readById(USER_ID))
+                    .willThrow(new AppException(ErrorCode.USER_NOT_FOUND));
+
+            // when & then
+            assertThatThrownBy(() -> webPushSubscriptionService.subscribe(USER_ID, validRequest))
+                    .isInstanceOf(AppException.class)
+                    .extracting(e -> ((AppException) e).getErrorCode())
+                    .isEqualTo(ErrorCode.USER_NOT_FOUND);
+
+            then(webPushSubscriptionRepository).should(never()).save(any());
+        }
+
+        @Test
+        @DisplayName("실패 - request 자체가 null")
+        void subscribe_fail_requestNull() {
+            // given
+            given(userReader.readById(USER_ID)).willReturn(mockUser);
+
+            // when & then
+            assertThatThrownBy(() -> webPushSubscriptionService.subscribe(USER_ID, null))
+                    .isInstanceOf(AppException.class)
+                    .extracting(e -> ((AppException) e).getErrorCode())
+                    .isEqualTo(ErrorCode.INVALID_REQUEST);
+        }
+
+        @Test
+        @DisplayName("실패 - endpoint가 null")
+        void subscribe_fail_endpointNull() {
+            // given
+            given(userReader.readById(USER_ID)).willReturn(mockUser);
+            WebPushSubscriptionRequestDto requestWithNullEndpoint = makeRequest(null, P256DH, AUTH);
+
+            // when & then
+            assertThatThrownBy(() -> webPushSubscriptionService.subscribe(USER_ID, requestWithNullEndpoint))
+                    .isInstanceOf(AppException.class)
+                    .extracting(e -> ((AppException) e).getErrorCode())
+                    .isEqualTo(ErrorCode.INVALID_ENDPOINT);
+        }
+
+        @Test
+        @DisplayName("실패 - endpoint가 빈 문자열")
+        void subscribe_fail_endpointBlank() {
+            // given
+            given(userReader.readById(USER_ID)).willReturn(mockUser);
+            WebPushSubscriptionRequestDto requestWithBlankEndpoint = makeRequest("  ", P256DH, AUTH);
+
+            // when & then
+            assertThatThrownBy(() -> webPushSubscriptionService.subscribe(USER_ID, requestWithBlankEndpoint))
+                    .isInstanceOf(AppException.class)
+                    .extracting(e -> ((AppException) e).getErrorCode())
+                    .isEqualTo(ErrorCode.INVALID_ENDPOINT);
+        }
+
+        @Test
+        @DisplayName("실패 - keys가 null")
+        void subscribe_fail_keysNull() {
+            // given
+            given(userReader.readById(USER_ID)).willReturn(mockUser);
+            WebPushSubscriptionRequestDto requestWithNullKeys = makeRequest(ENDPOINT, null, null);
+
+            // when & then
+            assertThatThrownBy(() -> webPushSubscriptionService.subscribe(USER_ID, requestWithNullKeys))
+                    .isInstanceOf(AppException.class)
+                    .extracting(e -> ((AppException) e).getErrorCode())
+                    .isEqualTo(ErrorCode.INVALID_REQUEST);
+        }
+    }
+
+    // 2. 구독 삭제
+
+
+    // --- 내부 메서드 ---
+
+    // Keys 객체 생성
+    private WebPushSubscriptionRequestDto makeRequest(String endpoint, String p256dh, String auth) {
+        WebPushSubscriptionRequestDto dto = new WebPushSubscriptionRequestDto();
+        ReflectionTestUtils.setField(dto, "endpoint", endpoint);
+
+        if (p256dh != null || auth != null) {
+            WebPushSubscriptionRequestDto.Keys keys = new WebPushSubscriptionRequestDto.Keys();
+            ReflectionTestUtils.setField(keys, "p256dh", p256dh);
+            ReflectionTestUtils.setField(keys, "auth", auth);
+            ReflectionTestUtils.setField(dto, "keys", keys);
+        }
+
+        return dto;
+    }
+
+    // 테스트용 WebPushSubscription 생성
+    private WebPushSubscription buildSubscription(Long id, User user, String endpoint) {
+        WebPushSubscription sub = WebPushSubscription.builder()
+                .user(user)
+                .endpoint(endpoint)
+                .p256dh(P256DH)
+                .auth(AUTH)
+                .build();
+        ReflectionTestUtils.setField(sub, "id", id);
+        return sub;
+    }
+
+}

--- a/src/test/java/com/cookeep/cookeep/domain/recipe/application/AiRecipeServiceTest.java
+++ b/src/test/java/com/cookeep/cookeep/domain/recipe/application/AiRecipeServiceTest.java
@@ -19,6 +19,7 @@ import com.cookeep.cookeep.domain.recipe.dao.AiMessageRepository;
 import com.cookeep.cookeep.domain.recipe.dao.AiRecipeRepository;
 import com.cookeep.cookeep.domain.recipe.dao.AiSessionRepository;
 import com.cookeep.cookeep.domain.recipe.entity.*;
+import com.cookeep.cookeep.domain.user.dao.UserRepository;
 import com.cookeep.cookeep.domain.user.entity.User;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
@@ -61,6 +62,7 @@ public class AiRecipeServiceTest {
     @Mock private DailyRecipeRepository dailyRecipeRepository;
     @Mock private WeeklyGoalService weeklyGoalService;
     @Mock private AiRateLimitService rateLimitService;
+    @Mock private UserRepository userRepository;
 
     @Spy
     private ObjectMapper objectMapper = new ObjectMapper();
@@ -90,6 +92,9 @@ public class AiRecipeServiceTest {
     @BeforeEach
     void setUp() throws Exception {
         user = User.builder().nickname("테스터").build();
+
+        given(userRepository.findById(anyLong()))
+                .willReturn(Optional.of(user));
 
         session = AiSession.builder()
                 .userId(1L)
@@ -352,8 +357,12 @@ public class AiRecipeServiceTest {
             com.cookeep.cookeep.domain.recipe.dto.GeminiRecipeResponseDto response =
                     buildValidGeminiResponse();
 
-            given(geminiService.generateRecipeWithExclusion(anyList(), any(), anyList()))
-                    .willReturn(response);
+            given(geminiService.generateRecipeWithExclusion(
+                    anyList(),
+                    any(Difficulty.class),
+                    anyList(),
+                    anyList()
+            )).willReturn(response);
             given(youtubeSearchService.searchVideos(anyList())).willReturn(List.of());
             given(aiMessageRepository.save(any())).willAnswer(inv -> inv.getArgument(0));
             given(aiSessionRepository.save(any())).willAnswer(inv -> inv.getArgument(0));
@@ -403,7 +412,12 @@ public class AiRecipeServiceTest {
                     .hasFieldOrPropertyWithValue("errorCode", ErrorCode.USER_RATE_LIMIT_EXCEEDED);
 
             // Rate Limit에 걸렸으므로 Gemini는 절대 호출되면 안 됨
-            verify(geminiService, never()).generateRecipeWithExclusion(anyList(), any(), anyList());
+            verify(geminiService, never()).generateRecipeWithExclusion(
+                    anyList(),
+                    any(Difficulty.class),
+                    anyList(),
+                    anyList()
+            );
         }
 
         @Test


### PR DESCRIPTION
# Issue
#200

# Description
유통기한 임박 알림 등 서버에서 발생하는 이벤트를 브라우저 푸시 알림으로 전달하기 위한 Web Push 구독 관리 기능을 구현
프론트엔드에서 Service Worker를 통해 생성한 Push Subscription 정보(endpoint, p256dh, auth)를 서버에 저장하고, 이를 기반으로 추후 서버 → 브라우저 방향의 알림 전송이 가능한 구조를 갖춥니다.
알림 전송 조건 판단 로직 및 실제 Web Push 발송 처리는 추후 구현 예정입니다.

# Changes
### Entity
- WebPushSubscription 엔티티 추가
- user, endpoint(UNIQUE), p256dh, auth 필드 구성
- endpoint unique 제약으로 중복 구독 방지
### Dto
- WebPushSubscriptionRequestDto 추가
   - 요청 바디 구조: { endpoint, keys: { p256dh, auth } } — 브라우저 Web Push API 스펙과 동일
- WebPushSubscriptionResponseDto 추가
   - 구독 등록/해제 결과 메시지 반환
- WebPushEligibilityResponseDto 추가
   - eligible 필드 단일 반환
### Service
- WebPushSubscriptionService 추가
- subscribe: 신규 구독 저장, 동일 endpoint 존재 시 멱등 처리
- unsubscribe: 본인 소유 검증 후 구독 삭제, 미존재 endpoint는 SUBSCRIPTION_NOT_FOUND 예외
- checkEligibility: 서버에 구독 정보 존재 여부 기준으로 eligible 반환
### Controller
- WebPushSubscriptionController 추가 (/api/users/me/web/push)
- POST /subscription — 구독 등록
- DELETE /subscription — 구독 삭제
- GET /eligibility — 수신 가능 여부 확인

# Test Checklist
WebPushSubscriptionServiceTest
- [x] subscribe: 신규 저장 성공 / 중복 멱등 / 유저 없음 / request null / endpoint null·공백 / keys null
- [x] unsubscribe: 정상 삭제 / endpoint 없음 / 타인 소유 403
- [x] checkEligibility: eligible true / eligible false / 유저 없음