### PR TITLE
Feat: 유통기한 임박 웹 푸시 알림 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,11 @@ dependencies {
 	// AWS S3
 	implementation 'software.amazon.awssdk:s3:2.25.27'
 
+	// Web Push
+	implementation 'nl.martijndwars:web-push:5.1.1'
+	implementation 'org.bouncycastle:bcprov-jdk15on:1.70'
+	implementation 'org.json:json:20231013'
+
 //	// Twilio
 //	implementation "com.twilio.sdk:twilio:10.+"
 

--- a/src/main/java/com/cookeep/cookeep/api/controller/PushNotificationController.java
+++ b/src/main/java/com/cookeep/cookeep/api/controller/PushNotificationController.java
@@ -23,7 +23,7 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/api/users/me")
 public class PushNotificationController {
 
-    private final PopupNotificationEligibilityService pushNotificationEligibilityService;
+    private final PopupNotificationEligibilityService popupNotificationEligibilityService;
 
     @Operation(
             summary = "유통기한 임박 팝업 자격 확인",
@@ -56,7 +56,7 @@ public class PushNotificationController {
             @AuthenticationPrincipal(expression = "userId") Long userId
     ) {
         PushNotificationEligibilityResponseDto response =
-                pushNotificationEligibilityService.checkEligibility(userId);
+                popupNotificationEligibilityService.checkEligibility(userId);
 
         return ResponseEntity.ok(DataResponse.from(response));
     }

--- a/src/main/java/com/cookeep/cookeep/api/controller/PushNotificationController.java
+++ b/src/main/java/com/cookeep/cookeep/api/controller/PushNotificationController.java
@@ -1,9 +1,11 @@
 package com.cookeep.cookeep.api.controller;
 
+import com.cookeep.cookeep.api.dto.response.WebPushSendResponseDto;
 import com.cookeep.cookeep.common.dto.DataResponse;
 import com.cookeep.cookeep.common.exception.ErrorCode;
 import com.cookeep.cookeep.config.ApiErrorCodeExamples;
 import com.cookeep.cookeep.domain.notification.application.PopupNotificationEligibilityService;
+import com.cookeep.cookeep.domain.notification.application.WebPushNotificationService;
 import com.cookeep.cookeep.domain.notification.dto.PushNotificationEligibilityResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -24,9 +26,10 @@ import org.springframework.web.bind.annotation.*;
 public class PushNotificationController {
 
     private final PopupNotificationEligibilityService popupNotificationEligibilityService;
+    private final WebPushNotificationService webPushNotificationService;
 
     @Operation(
-            summary = "유통기한 임박 팝업 자격 확인",
+            summary = "1. 유통기한 임박 팝업 자격 확인 (모달 팝업 알림)",
             description = """
                     유통기한이 당일(D-0)인 식재료가 존재하는지 확인하여 팝업을 띄울지 결정합니다.
                     
@@ -61,4 +64,42 @@ public class PushNotificationController {
         return ResponseEntity.ok(DataResponse.from(response));
     }
 
+    @Operation(
+            summary = "2. 유통기한 임박 웹 팝업 알림 전송",
+            description = """
+                    유통기한이 당일(D-0)인 식재료가 있는 경우 웹 푸시 알림을 전송합니다.
+                    
+                    **전송 조건 (모두 충족 시 전송)**
+                    1. 마케팅 수신 동의(marketingConsent) = true
+                    2. 냉장고 속 leftDays = 0 인 식재료 존재
+                    3. 서버에 구독 정보(WebPushSubscription) 존재
+                    
+                    - 조건 미충족 시 sent = false 반환 (에러 아님)
+                    - 만료된 구독(410/404 응답)은 자동 삭제
+                    - 알림 타입: EXPIRATION (유통기한 임박)
+                    """
+    )
+    @ApiErrorCodeExamples({
+            ErrorCode.UNAUTHORIZED,
+            ErrorCode.USER_NOT_FOUND,
+            ErrorCode.SUBSCRIPTION_NOT_FOUND,
+            ErrorCode.INTERNAL_SERVER_ERROR
+    })
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "알림 전송 성공 또는 전송 조건 미충족 (sent 필드로 구분)"),
+            @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content),
+            @ApiResponse(responseCode = "404", description = """
+                    리소스를 찾을 수 없습니다.
+                    - USER_NOT_FOUND: 사용자 없음
+                    - SUBSCRIPTION_NOT_FOUND: 구독 없음
+                    """, content = @Content),
+            @ApiResponse(responseCode = "500", description = "서버 오류", content = @Content)
+    })
+    @PostMapping("/web/push/notifications")
+    public ResponseEntity<DataResponse<WebPushSendResponseDto>> sendAlert(
+            @AuthenticationPrincipal(expression = "userId") Long userId
+    ) {
+        WebPushSendResponseDto response = webPushNotificationService.sendExpirationAlert(userId);
+        return ResponseEntity.ok(DataResponse.from(response));
+    }
 }

--- a/src/main/java/com/cookeep/cookeep/api/controller/PushNotificationController.java
+++ b/src/main/java/com/cookeep/cookeep/api/controller/PushNotificationController.java
@@ -3,7 +3,7 @@ package com.cookeep.cookeep.api.controller;
 import com.cookeep.cookeep.common.dto.DataResponse;
 import com.cookeep.cookeep.common.exception.ErrorCode;
 import com.cookeep.cookeep.config.ApiErrorCodeExamples;
-import com.cookeep.cookeep.domain.notification.application.PushNotificationEligibilityService;
+import com.cookeep.cookeep.domain.notification.application.PopupNotificationEligibilityService;
 import com.cookeep.cookeep.domain.notification.dto.PushNotificationEligibilityResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -16,8 +16,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.Map;
-
 @Tag(name = "(MAIN04) 푸시 알림", description = "유통기한 임박 식재료 팝업 알림 API")
 @Slf4j
 @RestController
@@ -25,7 +23,7 @@ import java.util.Map;
 @RequestMapping("/api/users/me")
 public class PushNotificationController {
 
-    private final PushNotificationEligibilityService pushNotificationEligibilityService;
+    private final PopupNotificationEligibilityService pushNotificationEligibilityService;
 
     @Operation(
             summary = "유통기한 임박 팝업 자격 확인",

--- a/src/main/java/com/cookeep/cookeep/api/controller/WebPushSubscriptionController.java
+++ b/src/main/java/com/cookeep/cookeep/api/controller/WebPushSubscriptionController.java
@@ -2,12 +2,10 @@ package com.cookeep.cookeep.api.controller;
 
 import com.cookeep.cookeep.api.dto.request.WebPushSubscriptionRequestDto;
 import com.cookeep.cookeep.api.dto.response.WebPushEligibilityResponseDto;
-import com.cookeep.cookeep.api.dto.response.WebPushSendResponseDto;
 import com.cookeep.cookeep.api.dto.response.WebPushSubscriptionResponseDto;
 import com.cookeep.cookeep.common.dto.DataResponse;
 import com.cookeep.cookeep.common.exception.ErrorCode;
 import com.cookeep.cookeep.config.ApiErrorCodeExamples;
-import com.cookeep.cookeep.domain.notification.application.WebPushNotificationService;
 import com.cookeep.cookeep.domain.notification.application.WebPushSubscriptionService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -16,6 +14,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -27,6 +26,9 @@ import org.springframework.web.bind.annotation.*;
 public class WebPushSubscriptionController {
 
     private final WebPushSubscriptionService webPushSubscriptionService;
+
+    @Value("${vapid.public-key}")
+    private String vapidPublicKey;
 
     @Operation(
             summary = "웹 푸시 구독 등록",
@@ -111,6 +113,15 @@ public class WebPushSubscriptionController {
     ) {
         WebPushEligibilityResponseDto response = webPushSubscriptionService.checkEligibility(userId);
         return ResponseEntity.ok(DataResponse.from(response));
+    }
+
+    @Operation(
+            summary = "퍼블릭 키 전달",
+            description = "프론트에서 구독 등록에 이용한 퍼블릭 키 전달"
+    )
+    @GetMapping("/public-key")
+    public ResponseEntity<DataResponse<String>> getPublicKey() {
+        return ResponseEntity.ok(DataResponse.from(vapidPublicKey));
     }
 
 }

--- a/src/main/java/com/cookeep/cookeep/api/controller/WebPushSubscriptionController.java
+++ b/src/main/java/com/cookeep/cookeep/api/controller/WebPushSubscriptionController.java
@@ -2,10 +2,12 @@ package com.cookeep.cookeep.api.controller;
 
 import com.cookeep.cookeep.api.dto.request.WebPushSubscriptionRequestDto;
 import com.cookeep.cookeep.api.dto.response.WebPushEligibilityResponseDto;
+import com.cookeep.cookeep.api.dto.response.WebPushSendResponseDto;
 import com.cookeep.cookeep.api.dto.response.WebPushSubscriptionResponseDto;
 import com.cookeep.cookeep.common.dto.DataResponse;
 import com.cookeep.cookeep.common.exception.ErrorCode;
 import com.cookeep.cookeep.config.ApiErrorCodeExamples;
+import com.cookeep.cookeep.domain.notification.application.WebPushNotificationService;
 import com.cookeep.cookeep.domain.notification.application.WebPushSubscriptionService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -25,6 +27,7 @@ import org.springframework.web.bind.annotation.*;
 public class WebPushSubscriptionController {
 
     private final WebPushSubscriptionService webPushSubscriptionService;
+    private final WebPushNotificationService webPushNotificationService;
 
     @Operation(
             summary = "웹 푸시 구독 등록",
@@ -108,6 +111,45 @@ public class WebPushSubscriptionController {
             @AuthenticationPrincipal(expression = "userId") Long userId
     ) {
         WebPushEligibilityResponseDto response = webPushSubscriptionService.checkEligibility(userId);
+        return ResponseEntity.ok(DataResponse.from(response));
+    }
+
+    @Operation(
+            summary = "웹 푸시 알림 전송",
+            description = """
+                    유통기한이 당일(D-0)인 식재료가 있는 경우 웹 푸시 알림을 전송합니다.
+                    
+                    **전송 조건 (모두 충족 시 전송)**
+                    1. 마케팅 수신 동의(marketingConsent) = true
+                    2. 냉장고 속 leftDays = 0 인 식재료 존재
+                    3. 서버에 구독 정보(WebPushSubscription) 존재
+                    
+                    - 조건 미충족 시 sent = false 반환 (에러 아님)
+                    - 만료된 구독(410/404 응답)은 자동 삭제
+                    - 알림 타입: EXPIRATION (유통기한 임박)
+                    """
+    )
+    @ApiErrorCodeExamples({
+            ErrorCode.UNAUTHORIZED,
+            ErrorCode.USER_NOT_FOUND,
+            ErrorCode.SUBSCRIPTION_NOT_FOUND,
+            ErrorCode.INTERNAL_SERVER_ERROR
+    })
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "알림 전송 성공 또는 전송 조건 미충족 (sent 필드로 구분)"),
+            @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content),
+            @ApiResponse(responseCode = "404", description = """
+                    리소스를 찾을 수 없습니다.
+                    - USER_NOT_FOUND: 사용자 없음
+                    - SUBSCRIPTION_NOT_FOUND: 구독 없음
+                    """, content = @Content),
+            @ApiResponse(responseCode = "500", description = "서버 오류", content = @Content)
+    })
+    @PostMapping("/alerts")
+    public ResponseEntity<DataResponse<WebPushSendResponseDto>> sendAlert(
+            @AuthenticationPrincipal(expression = "userId") Long userId
+    ) {
+        WebPushSendResponseDto response = webPushNotificationService.sendExpirationAlert(userId);
         return ResponseEntity.ok(DataResponse.from(response));
     }
 

--- a/src/main/java/com/cookeep/cookeep/api/controller/WebPushSubscriptionController.java
+++ b/src/main/java/com/cookeep/cookeep/api/controller/WebPushSubscriptionController.java
@@ -27,7 +27,6 @@ import org.springframework.web.bind.annotation.*;
 public class WebPushSubscriptionController {
 
     private final WebPushSubscriptionService webPushSubscriptionService;
-    private final WebPushNotificationService webPushNotificationService;
 
     @Operation(
             summary = "웹 푸시 구독 등록",
@@ -111,45 +110,6 @@ public class WebPushSubscriptionController {
             @AuthenticationPrincipal(expression = "userId") Long userId
     ) {
         WebPushEligibilityResponseDto response = webPushSubscriptionService.checkEligibility(userId);
-        return ResponseEntity.ok(DataResponse.from(response));
-    }
-
-    @Operation(
-            summary = "웹 푸시 알림 전송",
-            description = """
-                    유통기한이 당일(D-0)인 식재료가 있는 경우 웹 푸시 알림을 전송합니다.
-                    
-                    **전송 조건 (모두 충족 시 전송)**
-                    1. 마케팅 수신 동의(marketingConsent) = true
-                    2. 냉장고 속 leftDays = 0 인 식재료 존재
-                    3. 서버에 구독 정보(WebPushSubscription) 존재
-                    
-                    - 조건 미충족 시 sent = false 반환 (에러 아님)
-                    - 만료된 구독(410/404 응답)은 자동 삭제
-                    - 알림 타입: EXPIRATION (유통기한 임박)
-                    """
-    )
-    @ApiErrorCodeExamples({
-            ErrorCode.UNAUTHORIZED,
-            ErrorCode.USER_NOT_FOUND,
-            ErrorCode.SUBSCRIPTION_NOT_FOUND,
-            ErrorCode.INTERNAL_SERVER_ERROR
-    })
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "알림 전송 성공 또는 전송 조건 미충족 (sent 필드로 구분)"),
-            @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content),
-            @ApiResponse(responseCode = "404", description = """
-                    리소스를 찾을 수 없습니다.
-                    - USER_NOT_FOUND: 사용자 없음
-                    - SUBSCRIPTION_NOT_FOUND: 구독 없음
-                    """, content = @Content),
-            @ApiResponse(responseCode = "500", description = "서버 오류", content = @Content)
-    })
-    @PostMapping("/alerts")
-    public ResponseEntity<DataResponse<WebPushSendResponseDto>> sendAlert(
-            @AuthenticationPrincipal(expression = "userId") Long userId
-    ) {
-        WebPushSendResponseDto response = webPushNotificationService.sendExpirationAlert(userId);
         return ResponseEntity.ok(DataResponse.from(response));
     }
 

--- a/src/main/java/com/cookeep/cookeep/api/dto/response/WebPushSendResponseDto.java
+++ b/src/main/java/com/cookeep/cookeep/api/dto/response/WebPushSendResponseDto.java
@@ -1,0 +1,33 @@
+package com.cookeep.cookeep.api.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Schema(
+        name = "WebPushSendResponse",
+        description = "웹 푸시 알림 전송 결과 응답 DTO"
+)
+@Getter
+@AllArgsConstructor
+public class WebPushSendResponseDto {
+
+    @Schema(description = "알림 전송 여부", example = "true")
+    private Boolean sent;
+
+    @Schema(description = "결과 메시지", example = "유통기한 만료 재료 알림이 전송되었습니다.")
+    private String message;
+
+    public static WebPushSendResponseDto sent() {
+        return new WebPushSendResponseDto(true, "유통기한 만료 재료 알림(EXPIRATION)이 전송되었습니다.");
+    }
+
+    public static WebPushSendResponseDto notConsented() {
+        return new WebPushSendResponseDto(false, "알림 수신 동의가 되어있지 않습니다.");
+    }
+
+    public static WebPushSendResponseDto noExpiringIngredients() {
+        return new WebPushSendResponseDto(false, "유통기한이 만료된 재료가 없습니다.");
+    }
+
+}

--- a/src/main/java/com/cookeep/cookeep/api/dto/response/WebPushSendResponseDto.java
+++ b/src/main/java/com/cookeep/cookeep/api/dto/response/WebPushSendResponseDto.java
@@ -30,4 +30,9 @@ public class WebPushSendResponseDto {
         return new WebPushSendResponseDto(false, "유통기한이 만료된 재료가 없습니다.");
     }
 
+    // 구독은 존재. 전부 만료(410/404) or 전송 실패
+    public static WebPushSendResponseDto allSubscriptionsExpired() {
+        return new WebPushSendResponseDto(false, "유효한 구독이 없어 알림을 전송하지 못했습니다.");
+    }
+
 }

--- a/src/main/java/com/cookeep/cookeep/api/dto/response/WebPushSendResponseDto.java
+++ b/src/main/java/com/cookeep/cookeep/api/dto/response/WebPushSendResponseDto.java
@@ -1,5 +1,6 @@
 package com.cookeep.cookeep.api.dto.response;
 
+import com.cookeep.cookeep.domain.notification.entity.NotificationType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -18,9 +19,11 @@ public class WebPushSendResponseDto {
     @Schema(description = "결과 메시지", example = "유통기한 만료 재료 알림이 전송되었습니다.")
     private String message;
 
-    public static WebPushSendResponseDto sent() {
-        return new WebPushSendResponseDto(true, "유통기한 만료 재료 알림(EXPIRATION)이 전송되었습니다.");
+    public static WebPushSendResponseDto sent(NotificationType type) {
+        return new WebPushSendResponseDto(true,
+                type.getDisplayName() + " 알림이 전송되었습니다.");
     }
+
 
     public static WebPushSendResponseDto notConsented() {
         return new WebPushSendResponseDto(false, "알림 수신 동의가 되어있지 않습니다.");

--- a/src/main/java/com/cookeep/cookeep/config/WebPushConfig.java
+++ b/src/main/java/com/cookeep/cookeep/config/WebPushConfig.java
@@ -1,0 +1,29 @@
+package com.cookeep.cookeep.config;
+
+import nl.martijndwars.webpush.PushService;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.security.Security;
+
+@Configuration
+public class WebPushConfig {
+
+    @Value("${vapid.public-key}")
+    private String vapidPublicKey;
+
+    @Value("${vapid.private-key}")
+    private String vapidPrivateKey;
+
+    @Bean
+    public PushService pushService() throws Exception {
+        // BouncyCastle Provider 등록 (EC 키 처리에 필요)
+        if (Security.getProvider(BouncyCastleProvider.PROVIDER_NAME) == null) {
+            Security.addProvider(new BouncyCastleProvider());
+        }
+
+        return new PushService(vapidPublicKey, vapidPrivateKey);
+    }
+}

--- a/src/main/java/com/cookeep/cookeep/domain/notification/application/PopupNotificationEligibilityService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/notification/application/PopupNotificationEligibilityService.java
@@ -1,7 +1,5 @@
 package com.cookeep.cookeep.domain.notification.application;
 
-import com.cookeep.cookeep.common.exception.AppException;
-import com.cookeep.cookeep.common.exception.ErrorCode;
 import com.cookeep.cookeep.domain.ingredient.useringredient.dao.UserIngredientRepository;
 import com.cookeep.cookeep.domain.notification.dto.PushNotificationEligibilityResponseDto;
 import com.cookeep.cookeep.domain.user.application.UserReader;
@@ -13,15 +11,13 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
-import java.util.List;
-import java.util.stream.Collectors;
 
-// 푸시 알림 실제 전송
+// 팝업(모달) 알림 실제 전송
 @Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
-public class PushNotificationEligibilityService {
+public class PopupNotificationEligibilityService {
 
     private final UserIngredientRepository userIngredientRepository;
     private final UserRepository userRepository;

--- a/src/main/java/com/cookeep/cookeep/domain/notification/application/WebPushNotificationService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/notification/application/WebPushNotificationService.java
@@ -1,0 +1,110 @@
+package com.cookeep.cookeep.domain.notification.application;
+
+import com.cookeep.cookeep.api.dto.response.WebPushSendResponseDto;
+import com.cookeep.cookeep.common.exception.AppException;
+import com.cookeep.cookeep.common.exception.ErrorCode;
+import com.cookeep.cookeep.domain.ingredient.useringredient.dao.UserIngredientRepository;
+import com.cookeep.cookeep.domain.notification.dao.WebPushSubscriptionRepository;
+import com.cookeep.cookeep.domain.notification.entity.NotificationType;
+import com.cookeep.cookeep.domain.notification.entity.WebPushSubscription;
+import com.cookeep.cookeep.domain.user.application.UserReader;
+import com.cookeep.cookeep.domain.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import nl.martijndwars.webpush.Notification;
+import nl.martijndwars.webpush.PushService;
+import org.jose4j.json.internal.json_simple.JSONObject;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.util.List;
+
+// 웹 푸시 알림 전송
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class WebPushNotificationService {
+
+    private final UserReader userReader;
+    private final UserIngredientRepository userIngredientRepository;
+    private final WebPushSubscriptionRepository webPushSubscriptionRepository;
+    private final PushService pushService;
+
+    public WebPushSendResponseDto sendExpirationAlert(Long userId) {
+
+        User user = userReader.readById(userId);
+
+        // 1. 마케팅 수신 동의 확인
+        if (!Boolean.TRUE.equals(user.getMarketingConsent())) {
+            log.debug("웹 푸시 알림 미전송 - 수신 미동의. userId={}", userId);
+            return WebPushSendResponseDto.notConsented();
+        }
+
+        // 2. leftDays = 0 인 식재료 존재 여부 확인
+        LocalDate today = LocalDate.now();
+        boolean hasExpiringToday =
+                userIngredientRepository.existsByUserIdAndExpirationDate(userId, today);
+
+        if (!hasExpiringToday) {
+            log.debug("웹 푸시 알림 미전송 - 만료 임박 재료 없음. userId={}", userId);
+            return WebPushSendResponseDto.noExpiringIngredients();
+        }
+
+        // 3. 구독 정보 조회
+        List<WebPushSubscription> subscriptions =
+                webPushSubscriptionRepository.findAllByUser_UserId(userId);
+
+        if (subscriptions.isEmpty()) {
+            throw new AppException(ErrorCode.SUBSCRIPTION_NOT_FOUND);
+        }
+
+        // 4. 알림 페이로드 생성
+        String payload = buildPayload(NotificationType.EXPIRATION);
+
+        // 5. 구독별 전송 (실패 구독은 제거)
+        sendToSubscriptions(subscriptions, payload);
+
+        log.info("웹 푸시 알림 전송 완료. userId={}, subscriptionCount={}", userId, subscriptions.size());
+
+        return WebPushSendResponseDto.sent();
+
+    }
+
+    private String buildPayload(NotificationType type) {
+        JSONObject payload = new JSONObject();
+        payload.put("title", "재료 만료 임박");
+        payload.put("body", "오늘 유통기한이 만료되는 재료가 있어요!");
+        payload.put("url", "/refrigerator");
+        payload.put("type", type.name());
+        return payload.toString();
+    }
+
+    // 각 구독에 푸시 알림을 전송
+    // 전송 실패 시 410 Gone / 404 Not Found 응답이면 만료 구독으로 판단하고 DB에서 삭제
+    private void sendToSubscriptions(List<WebPushSubscription> subscriptions, String payload) {
+        for (WebPushSubscription subscription : subscriptions) {
+            try {
+                Notification notification = new Notification(
+                        subscription.getEndpoint(),
+                        subscription.getP256dh(),
+                        subscription.getAuth(),
+                        payload.getBytes()
+                );
+
+                int statusCode = pushService.send(notification).getStatusLine().getStatusCode();
+
+                // 410 Gone 또는 404 Not Found : 만료된 구독 → 삭제
+                if (statusCode == 410 || statusCode == 404) {
+                    log.warn("만료된 구독 삭제. subscriptionId={}, statusCode={}",
+                            subscription.getId(), statusCode);
+                    webPushSubscriptionRepository.delete(subscription);
+                }
+
+            } catch (Exception e) {
+                log.error("웹 푸시 전송 실패. subscriptionId={}, error={}",
+                        subscription.getId(), e.getMessage());
+                // 개별 구독 실패는 전체 흐름을 중단하지 않음
+            }
+        }
+    }
+}

--- a/src/main/java/com/cookeep/cookeep/domain/notification/application/WebPushNotificationService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/notification/application/WebPushNotificationService.java
@@ -61,12 +61,16 @@ public class WebPushNotificationService {
         // 4. 알림 페이로드 생성
         String payload = buildPayload(NotificationType.EXPIRATION);
 
-        // 5. 구독별 전송 (실패 구독은 제거)
-        sendToSubscriptions(subscriptions, payload);
+        // 5. 구독별 전송 — 실제로 브라우저에 전달된 횟수를 반환
+        int successCount = sendToSubscriptions(subscriptions, payload);
 
-        log.info("웹 푸시 알림 전송 완료. userId={}, subscriptionCount={}", userId, subscriptions.size());
+        log.info("웹 푸시 알림 전송 완료. userId={}, total={}, success={}",
+                userId, subscriptions.size(), successCount);
 
-        return WebPushSendResponseDto.sent();
+        // 6. 성공 횟수가 0이면 모든 구독이 만료됐거나 전송에 실패한 것
+        return successCount > 0
+                ? WebPushSendResponseDto.sent()
+                : WebPushSendResponseDto.allSubscriptionsExpired();
 
     }
 
@@ -85,7 +89,10 @@ public class WebPushNotificationService {
 
     // 각 구독에 푸시 알림을 전송
     // 전송 실패 시 410 Gone / 404 Not Found 응답이면 만료 구독으로 판단하고 DB에서 삭제
-    private void sendToSubscriptions(List<WebPushSubscription> subscriptions, String payload) {
+    private int sendToSubscriptions(List<WebPushSubscription> subscriptions, String payload) {
+
+        int successCount = 0;
+
         for (WebPushSubscription subscription : subscriptions) {
             try {
                 Notification notification = new Notification(
@@ -99,9 +106,18 @@ public class WebPushNotificationService {
 
                 // 410 Gone 또는 404 Not Found : 만료된 구독 → 삭제
                 if (statusCode == 410 || statusCode == 404) {
+                    // 만료된 구독 → 삭제, 성공 카운트에 포함하지 않음
                     log.warn("만료된 구독 삭제. subscriptionId={}, statusCode={}",
                             subscription.getId(), statusCode);
                     webPushSubscriptionRepository.delete(subscription);
+
+                } else if (statusCode >= 200 && statusCode < 300) {
+                    // 2xx → 브라우저에 실제로 전달됨
+                    successCount++;
+
+                } else {
+                    log.warn("웹 푸시 비정상 응답. subscriptionId={}, statusCode={}",
+                            subscription.getId(), statusCode);
                 }
 
             } catch (Exception e) {
@@ -110,5 +126,7 @@ public class WebPushNotificationService {
                 // 개별 구독 실패는 전체 흐름을 중단하지 않음
             }
         }
+        return successCount;
+
     }
 }

--- a/src/main/java/com/cookeep/cookeep/domain/notification/application/WebPushNotificationService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/notification/application/WebPushNotificationService.java
@@ -40,7 +40,7 @@ public class WebPushNotificationService {
             return WebPushSendResponseDto.notConsented();
         }
 
-        // 2. leftDays = 0 인 식재료 존재 여부 확인
+        // 2. D-0 재료 존재 여부 확인
         LocalDate today = LocalDate.now();
         boolean hasExpiringToday =
                 userIngredientRepository.existsByUserIdAndExpirationDate(userId, today);

--- a/src/main/java/com/cookeep/cookeep/domain/notification/application/WebPushNotificationService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/notification/application/WebPushNotificationService.java
@@ -69,7 +69,7 @@ public class WebPushNotificationService {
 
         // 6. 성공 횟수가 0이면 모든 구독이 만료됐거나 전송에 실패한 것
         return successCount > 0
-                ? WebPushSendResponseDto.sent()
+                ? WebPushSendResponseDto.sent(NotificationType.EXPIRATION)
                 : WebPushSendResponseDto.allSubscriptionsExpired();
 
     }

--- a/src/main/java/com/cookeep/cookeep/domain/notification/application/WebPushNotificationService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/notification/application/WebPushNotificationService.java
@@ -72,7 +72,8 @@ public class WebPushNotificationService {
 
     private String buildPayload(NotificationType type) {
         JSONObject payload = new JSONObject();
-        payload.put("title", "재료 만료 임박");
+
+        payload.put("title", tyoe.getTitle());
         payload.put("body", "오늘 유통기한이 만료되는 재료가 있어요!");
         payload.put("url", "/refrigerator");
         payload.put("type", type.name());

--- a/src/main/java/com/cookeep/cookeep/domain/notification/application/WebPushNotificationService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/notification/application/WebPushNotificationService.java
@@ -70,12 +70,15 @@ public class WebPushNotificationService {
 
     }
 
+    // --- 내부 메서드 ---
+
+    // 알림 내용 생성
     private String buildPayload(NotificationType type) {
         JSONObject payload = new JSONObject();
 
-        payload.put("title", tyoe.getTitle());
-        payload.put("body", "오늘 유통기한이 만료되는 재료가 있어요!");
-        payload.put("url", "/refrigerator");
+        payload.put("title", type.getTitle());
+        payload.put("body", type.getBody());
+        payload.put("url", type.getUrl());
         payload.put("type", type.name());
         return payload.toString();
     }

--- a/src/main/java/com/cookeep/cookeep/domain/notification/application/WebPushSubscriptionService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/notification/application/WebPushSubscriptionService.java
@@ -14,6 +14,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+// 알림 구독 등록
 @Slf4j
 @RequiredArgsConstructor
 @Service

--- a/src/main/java/com/cookeep/cookeep/domain/notification/entity/NotificationType.java
+++ b/src/main/java/com/cookeep/cookeep/domain/notification/entity/NotificationType.java
@@ -12,7 +12,7 @@ public enum NotificationType {
             "유통기한임박",
             "유통기한임박",
             "오늘 유통기한이 만료되는 재료가 있어요! \n 지금 확인하고 요리해볼까요?",
-            "/api/users/me/web/push/notifications"),
+            "/api/users/me/refrigerator/home"),
 
     //필요시수정(to.현정)
     PLANT_WILTING(

--- a/src/main/java/com/cookeep/cookeep/domain/notification/entity/NotificationType.java
+++ b/src/main/java/com/cookeep/cookeep/domain/notification/entity/NotificationType.java
@@ -8,11 +8,28 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum NotificationType {
-    EXPIRATION("유통기한임박"),
-    PLANT_WILTING("시듦"), //필요시수정(to.현정)
-    PLANT_GROWTH_STOP("성장정지"); //필요시수정(to.현정)
+    EXPIRATION(
+            "유통기한임박",
+            "유통기한임박",
+            "오늘 유통기한이 만료되는 재료가 있어요! \n 지금 확인하고 요리해볼까요?",
+            "/api/users/me/web/push/notifications"),
 
+    //필요시수정(to.현정)
+    PLANT_WILTING(
+            "시듦",
+            "시듦",
+            "식물이 시들었어요!",
+            "/api/users/me"),
+    PLANT_GROWTH_STOP(
+            "성장정지",
+            "성장정지",
+            "성장정지되었어요",
+            "/api/users/me"
+            );
     private final String displayName;
+    private final String title;
+    private final String body;
+    private final String url;
 
     @JsonCreator
     public static NotificationType from(String value) {

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -76,3 +76,7 @@ otp:
   ttl-seconds: 300 # OTP 유효 시간 5분
   send-cooldown-seconds: 60 # 재전송 제한 시간 1분
   max-verify-failures: 5 # 인증 실패 허용 횟수, 초과시 잠금
+
+vapid:
+  public-key: ${VAPID_PUBLIC_KEY}
+  private-key: ${VAPID_PRIVATE_KEY}

--- a/src/test/java/com/cookeep/cookeep/domain/notification/application/WebPushSubscriptionServiceTest.java
+++ b/src/test/java/com/cookeep/cookeep/domain/notification/application/WebPushSubscriptionServiceTest.java
@@ -21,6 +21,8 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.nio.charset.StandardCharsets;
@@ -38,6 +40,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 public class WebPushSubscriptionServiceTest {
 
     private String validP256dh;
@@ -281,55 +284,38 @@ public class WebPushSubscriptionServiceTest {
     }
 
     @Nested
-    @DisplayName("4. sendExpirationAlert - 웹 푸시 전송")
+    @DisplayName("4. sendExpirationAlert - 전송 조건 검증")
     class SendExpirationAlert {
 
         @Test
-        @DisplayName("정상 조건이면 pushService.send()를 호출하고 sent=true를 반환한다")
-        void 정상조건_전송성공() throws Exception {
-            // given
-            given(user.getMarketingConsent()).willReturn(true);
-            given(userIngredientRepository.existsByUserIdAndExpirationDate(eq(USER_ID), any()))
-                    .willReturn(true);
-
-            WebPushSubscription subscription = buildSubscription(10L, ENDPOINT, validP256dh, validAuth);
-            given(webPushSubscriptionRepository.findAllByUser_UserId(USER_ID))
-                    .willReturn(List.of(subscription));
-
-            CloseableHttpResponse response = mock(CloseableHttpResponse.class);
-            StatusLine statusLine = mock(StatusLine.class);
-            given(response.getStatusLine()).willReturn(statusLine);
-            given(statusLine.getStatusCode()).willReturn(201);
-            given(pushService.send(any())).willReturn(response);
-
-            // when
-            WebPushSendResponseDto result = webPushNotificationService.sendExpirationAlert(USER_ID);
-
-            // then
-            assertThat(result).isNotNull();
-            verify(pushService, times(1)).send(any());
-            verify(webPushSubscriptionRepository, never()).delete(any());
-        }
-
-        @Test
-        @DisplayName("마케팅 수신 미동의면 전송하지 않고 pushService.send()도 호출하지 않는다")
-        void 수신미동의_전송안함() throws Exception {
-            // given
+        @DisplayName("마케팅 수신 미동의면 전송하지 않고 sent=false와 수신 미동의 메시지를 반환한다")
+        void 수신미동의_전송안함_sent_false() throws Exception {
             given(user.getMarketingConsent()).willReturn(false);
 
-            // when
             WebPushSendResponseDto result = webPushNotificationService.sendExpirationAlert(USER_ID);
 
-            // then
-            assertThat(result).isNotNull();
+            assertThat(result.getSent()).isFalse();
+            assertThat(result.getMessage()).isEqualTo("알림 수신 동의가 되어있지 않습니다.");
             verify(userIngredientRepository, never()).existsByUserIdAndExpirationDate(anyLong(), any());
             verify(webPushSubscriptionRepository, never()).findAllByUser_UserId(anyLong());
             verify(pushService, never()).send(any());
         }
 
         @Test
-        @DisplayName("당일 만료 재료가 없으면 전송하지 않고 pushService.send()도 호출하지 않는다")
-        void 만료재료없음_전송안함() throws Exception {
+        @DisplayName("marketingConsent가 null이면 미동의로 처리해 sent=false를 반환한다")
+        void marketingConsent_null_sent_false() throws Exception {
+            given(user.getMarketingConsent()).willReturn(null);
+
+            WebPushSendResponseDto result = webPushNotificationService.sendExpirationAlert(USER_ID);
+
+            assertThat(result.getSent()).isFalse();
+            assertThat(result.getMessage()).isEqualTo("알림 수신 동의가 되어있지 않습니다.");
+            verify(pushService, never()).send(any());
+        }
+
+        @Test
+        @DisplayName("당일 만료 재료가 없으면 전송하지 않고 sent=false와 재료 없음 메시지를 반환한다")
+        void 만료재료없음_전송안함_sent_false() throws Exception {
             // given
             given(user.getMarketingConsent()).willReturn(true);
             given(userIngredientRepository.existsByUserIdAndExpirationDate(eq(USER_ID), any()))
@@ -339,13 +325,14 @@ public class WebPushSubscriptionServiceTest {
             WebPushSendResponseDto result = webPushNotificationService.sendExpirationAlert(USER_ID);
 
             // then
-            assertThat(result).isNotNull();
+            assertThat(result.getSent()).isFalse();
+            assertThat(result.getMessage()).isEqualTo("유통기한이 만료된 재료가 없습니다.");
             verify(webPushSubscriptionRepository, never()).findAllByUser_UserId(anyLong());
             verify(pushService, never()).send(any());
         }
 
         @Test
-        @DisplayName("구독 정보가 없으면 SUBSCRIPTION_NOT_FOUND 예외가 발생한다")
+        @DisplayName("구독 정보가 없으면 SUBSCRIPTION_NOT_FOUND 예외가 발생하고 pushService는 호출되지 않는다")
         void 구독정보없음_예외발생() throws Exception {
             // given
             given(user.getMarketingConsent()).willReturn(true);
@@ -363,84 +350,190 @@ public class WebPushSubscriptionServiceTest {
         }
 
         @Test
-        @DisplayName("응답이 410이면 만료된 구독으로 판단하고 삭제한다")
-        void 응답410_구독삭제() throws Exception {
-            // given
-            given(user.getMarketingConsent()).willReturn(true);
-            given(userIngredientRepository.existsByUserIdAndExpirationDate(eq(USER_ID), any()))
-                    .willReturn(true);
+        @DisplayName("존재하지 않는 유저이면 USER_NOT_FOUND 예외가 발생한다")
+        void 존재하지않는_유저_예외발생() {
+            given(userReader.readById(USER_ID))
+                    .willThrow(new AppException(ErrorCode.USER_NOT_FOUND));
 
-            WebPushSubscription subscription = buildSubscription(10L, ENDPOINT, validP256dh, validAuth);
-            given(webPushSubscriptionRepository.findAllByUser_UserId(USER_ID))
-                    .willReturn(List.of(subscription));
+            assertThatThrownBy(() -> webPushNotificationService.sendExpirationAlert(USER_ID))
+                    .isInstanceOf(AppException.class)
+                    .hasMessageContaining(ErrorCode.USER_NOT_FOUND.getMessage());
 
-            CloseableHttpResponse response = mock(CloseableHttpResponse.class);
-            StatusLine statusLine = mock(StatusLine.class);
-            given(response.getStatusLine()).willReturn(statusLine);
-            given(statusLine.getStatusCode()).willReturn(410);
-            given(pushService.send(any())).willReturn(response);
-
-            // when
-            webPushNotificationService.sendExpirationAlert(USER_ID);
-
-            // then
-            verify(pushService, times(1)).send(any());
-            verify(webPushSubscriptionRepository, times(1)).delete(subscription);
+            verifyNoInteractions(userIngredientRepository, webPushSubscriptionRepository, pushService);
         }
 
+    }
+
+    @Nested
+    @DisplayName("4. sendExpirationAlert - 전송 성공/실패 결과")
+    class SendResult {
+
         @Test
-        @DisplayName("응답이 404이면 만료된 구독으로 판단하고 삭제한다")
-        void 응답404_구독삭제() throws Exception {
-            // given
+        @DisplayName("201 응답이면 sent=true와 성공 메시지를 반환한다")
+        void 응답201_sent_true() throws Exception {
             given(user.getMarketingConsent()).willReturn(true);
             given(userIngredientRepository.existsByUserIdAndExpirationDate(eq(USER_ID), any()))
                     .willReturn(true);
-
-            WebPushSubscription subscription = buildSubscription(10L, ENDPOINT, validP256dh, validAuth);
             given(webPushSubscriptionRepository.findAllByUser_UserId(USER_ID))
-                    .willReturn(List.of(subscription));
-
-            CloseableHttpResponse response = mock(CloseableHttpResponse.class);
-            StatusLine statusLine = mock(StatusLine.class);
-            given(response.getStatusLine()).willReturn(statusLine);
-            given(statusLine.getStatusCode()).willReturn(404);
+                    .willReturn(List.of(buildSubscription(10L, ENDPOINT, validP256dh, validAuth)));
+            CloseableHttpResponse response = mockResponse(201);
             given(pushService.send(any())).willReturn(response);
 
-            // when
-            webPushNotificationService.sendExpirationAlert(USER_ID);
-
-            // then
-            verify(pushService, times(1)).send(any());
-            verify(webPushSubscriptionRepository, times(1)).delete(subscription);
-        }
-
-        @Test
-        @DisplayName("push 전송 중 예외가 발생해도 전체 흐름은 중단되지 않고 sent를 반환한다")
-        void 전송중예외발생_전체흐름유지() throws Exception {
-            // given
-            given(user.getMarketingConsent()).willReturn(true);
-            given(userIngredientRepository.existsByUserIdAndExpirationDate(eq(USER_ID), any()))
-                    .willReturn(true);
-
-            WebPushSubscription subscription = buildSubscription(10L, ENDPOINT, validP256dh, validAuth);
-            given(webPushSubscriptionRepository.findAllByUser_UserId(USER_ID))
-                    .willReturn(List.of(subscription));
-
-            given(pushService.send(any())).willThrow(new RuntimeException("push send failed"));
-
-            // when
             WebPushSendResponseDto result = webPushNotificationService.sendExpirationAlert(USER_ID);
 
-            // then
-            assertThat(result).isNotNull();
-            verify(pushService, times(1)).send(any());
-            verify(webPushSubscriptionRepository, never()).delete(any());
+            assertThat(result.getSent()).isTrue();
+            assertThat(result.getMessage()).contains("전송되었습니다");
         }
+
+        @Test
+        @DisplayName("모든 구독이 410 응답이면 구독 삭제 후 sent=false와 만료 메시지를 반환한다")
+        void 모든구독_410응답_sent_false_만료메시지() throws Exception {
+
+            // 410 → 구독 삭제 → successCount=0 → sent=false 반환
+            given(user.getMarketingConsent()).willReturn(true);
+            given(userIngredientRepository.existsByUserIdAndExpirationDate(eq(USER_ID), any()))
+                    .willReturn(true);
+
+            WebPushSubscription subscription = buildSubscription(10L, ENDPOINT, validP256dh, validAuth);
+            given(webPushSubscriptionRepository.findAllByUser_UserId(USER_ID))
+                    .willReturn(List.of(subscription));
+            CloseableHttpResponse response = mockResponse(410);
+            given(pushService.send(any())).willReturn(response);
+
+            WebPushSendResponseDto result = webPushNotificationService.sendExpirationAlert(USER_ID);
+
+            // 만료 구독 삭제
+            verify(webPushSubscriptionRepository, times(1)).delete(subscription);
+            // 실제 전달 없음 → sent=false
+            assertThat(result.getSent()).isFalse();
+            assertThat(result.getMessage()).isEqualTo("유효한 구독이 없어 알림을 전송하지 못했습니다.");
+        }
+
+        @Test
+        @DisplayName("모든 구독이 404 응답이면 구독 삭제 후 sent=false와 만료 메시지를 반환한다")
+        void 모든구독_404응답_sent_false_만료메시지() throws Exception {
+            given(user.getMarketingConsent()).willReturn(true);
+            given(userIngredientRepository.existsByUserIdAndExpirationDate(eq(USER_ID), any()))
+                    .willReturn(true);
+
+            WebPushSubscription subscription = buildSubscription(10L, ENDPOINT, validP256dh, validAuth);
+            given(webPushSubscriptionRepository.findAllByUser_UserId(USER_ID))
+                    .willReturn(List.of(subscription));
+            CloseableHttpResponse response = mockResponse(404);
+            given(pushService.send(any())).willReturn(response);
+
+            WebPushSendResponseDto result = webPushNotificationService.sendExpirationAlert(USER_ID);
+
+            verify(webPushSubscriptionRepository, times(1)).delete(subscription);
+            assertThat(result.getSent()).isFalse();
+            assertThat(result.getMessage()).isEqualTo("유효한 구독이 없어 알림을 전송하지 못했습니다.");
+        }
+
+        @Test
+        @DisplayName("구독 2개 중 1개가 410이면 해당 구독만 삭제하고 나머지 성공 → sent=true를 반환한다")
+        void 구독2개_1개410_1개201_sent_true() throws Exception {
+            given(user.getMarketingConsent()).willReturn(true);
+            given(userIngredientRepository.existsByUserIdAndExpirationDate(eq(USER_ID), any()))
+                    .willReturn(true);
+
+            WebPushSubscription sub1 = buildSubscription(10L, ENDPOINT, validP256dh, validAuth);
+            WebPushSubscription sub2 = buildSubscription(11L, ENDPOINT + "-2", validP256dh, validAuth);
+            given(webPushSubscriptionRepository.findAllByUser_UserId(USER_ID))
+                    .willReturn(List.of(sub1, sub2));
+
+            // sub1 → 410(만료), sub2 → 201(성공)
+            CloseableHttpResponse response410 = mockResponse(410);
+            CloseableHttpResponse response201 = mockResponse(201);
+
+            given(pushService.send(any()))
+                    .willReturn(response410)
+                    .willReturn(response201);
+
+            WebPushSendResponseDto result = webPushNotificationService.sendExpirationAlert(USER_ID);
+
+            verify(webPushSubscriptionRepository, times(1)).delete(sub1);
+            verify(webPushSubscriptionRepository, never()).delete(sub2);
+            assertThat(result.getSent()).isTrue();
+        }
+
+        @Test
+        @DisplayName("구독 2개가 모두 410이면 모두 삭제하고 sent=false를 반환한다")
+        void 구독2개_모두410_sent_false() throws Exception {
+            given(user.getMarketingConsent()).willReturn(true);
+            given(userIngredientRepository.existsByUserIdAndExpirationDate(eq(USER_ID), any()))
+                    .willReturn(true);
+
+            WebPushSubscription sub1 = buildSubscription(10L, ENDPOINT, validP256dh, validAuth);
+            WebPushSubscription sub2 = buildSubscription(11L, ENDPOINT + "-2", validP256dh, validAuth);
+            given(webPushSubscriptionRepository.findAllByUser_UserId(USER_ID))
+                    .willReturn(List.of(sub1, sub2));
+            CloseableHttpResponse response410 = mockResponse(410);
+
+            given(pushService.send(any()))
+                    .willReturn(response410)
+                    .willReturn(response410);
+
+            WebPushSendResponseDto result = webPushNotificationService.sendExpirationAlert(USER_ID);
+
+            verify(webPushSubscriptionRepository, times(1)).delete(sub1);
+            verify(webPushSubscriptionRepository, times(1)).delete(sub2);
+            assertThat(result.getSent()).isFalse();
+        }
+
+        @Test
+        @DisplayName("모든 구독에서 예외가 발생하면 sent=false와 만료 메시지를 반환한다")
+        void 모든구독_예외발생_sent_false() throws Exception {
+            given(user.getMarketingConsent()).willReturn(true);
+            given(userIngredientRepository.existsByUserIdAndExpirationDate(eq(USER_ID), any()))
+                    .willReturn(true);
+
+            WebPushSubscription subscription = buildSubscription(10L, ENDPOINT, validP256dh, validAuth);
+            given(webPushSubscriptionRepository.findAllByUser_UserId(USER_ID))
+                    .willReturn(List.of(subscription));
+            given(pushService.send(any())).willThrow(new RuntimeException("네트워크 오류"));
+
+            WebPushSendResponseDto result = webPushNotificationService.sendExpirationAlert(USER_ID);
+
+            // 예외가 발생한 구독은 삭제하지 않음
+            verify(webPushSubscriptionRepository, never()).delete(any());
+            // 성공 없음 → sent=false
+            assertThat(result.getSent()).isFalse();
+            assertThat(result.getMessage()).isEqualTo("유효한 구독이 없어 알림을 전송하지 못했습니다.");
+        }
+
+        @Test
+        @DisplayName("구독 2개 중 1개 예외, 1개 성공이면 예외 구독은 삭제하지 않고 sent=true를 반환한다")
+        void 구독2개_1개예외_1개성공_sent_true() throws Exception {
+            given(user.getMarketingConsent()).willReturn(true);
+            given(userIngredientRepository.existsByUserIdAndExpirationDate(eq(USER_ID), any()))
+                    .willReturn(true);
+
+            WebPushSubscription sub1 = buildSubscription(10L, ENDPOINT, validP256dh, validAuth);
+            WebPushSubscription sub2 = buildSubscription(11L, ENDPOINT + "-2", validP256dh, validAuth);
+            given(webPushSubscriptionRepository.findAllByUser_UserId(USER_ID))
+                    .willReturn(List.of(sub1, sub2));
+
+            // sub1 → 예외, sub2 → 201
+            given(pushService.send(any()))
+                    .willThrow(new RuntimeException("push send failed"))
+                    .willReturn(mockResponse(201));
+
+            WebPushSendResponseDto result = webPushNotificationService.sendExpirationAlert(USER_ID);
+
+            verify(webPushSubscriptionRepository, never()).delete(any());
+            assertThat(result.getSent()).isTrue();
+            // 전송 자체는 2회 시도
+            verify(pushService, times(2)).send(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("4. sendExpirationAlert - 페이로드 내용 검증")
+    class PayloadVerification {
 
         @Test
         @DisplayName("전송 payload에는 title, body, url, type 정보가 포함된다")
         void payload_내용검증() throws Exception {
-            // given
             given(user.getMarketingConsent()).willReturn(true);
             given(userIngredientRepository.existsByUserIdAndExpirationDate(eq(USER_ID), any()))
                     .willReturn(true);
@@ -448,29 +541,45 @@ public class WebPushSubscriptionServiceTest {
             WebPushSubscription subscription = buildSubscription(10L, ENDPOINT, validP256dh, validAuth);
             given(webPushSubscriptionRepository.findAllByUser_UserId(USER_ID))
                     .willReturn(List.of(subscription));
-
-            CloseableHttpResponse response = mock(CloseableHttpResponse.class);
-            StatusLine statusLine = mock(StatusLine.class);
-            given(response.getStatusLine()).willReturn(statusLine);
-            given(statusLine.getStatusCode()).willReturn(201);
+            CloseableHttpResponse response = mockResponse(201);
             given(pushService.send(any())).willReturn(response);
 
             ArgumentCaptor<nl.martijndwars.webpush.Notification> captor =
                     ArgumentCaptor.forClass(nl.martijndwars.webpush.Notification.class);
 
-            // when
             webPushNotificationService.sendExpirationAlert(USER_ID);
 
-            // then
             verify(pushService).send(captor.capture());
-
-            nl.martijndwars.webpush.Notification sentNotification = captor.getValue();
-            String payload = new String(sentNotification.getPayload(), StandardCharsets.UTF_8);
+            String payload = new String(captor.getValue().getPayload(), StandardCharsets.UTF_8);
 
             assertThat(payload).contains("title");
             assertThat(payload).contains("body");
             assertThat(payload).contains("url");
             assertThat(payload).contains("EXPIRATION");
+        }
+
+        @Test
+        @DisplayName("EXPIRATION 타입의 title은 '유통기한임박'이다")
+        void EXPIRATION_title_검증() throws Exception {
+            given(user.getMarketingConsent()).willReturn(true);
+            given(userIngredientRepository.existsByUserIdAndExpirationDate(eq(USER_ID), any()))
+                    .willReturn(true);
+
+            WebPushSubscription subscription = buildSubscription(10L, ENDPOINT, validP256dh, validAuth);
+            given(webPushSubscriptionRepository.findAllByUser_UserId(USER_ID))
+                    .willReturn(List.of(subscription));
+            CloseableHttpResponse response = mockResponse(201);
+            given(pushService.send(any())).willReturn(response);
+
+            ArgumentCaptor<nl.martijndwars.webpush.Notification> captor =
+                    ArgumentCaptor.forClass(nl.martijndwars.webpush.Notification.class);
+
+            webPushNotificationService.sendExpirationAlert(USER_ID);
+
+            verify(pushService).send(captor.capture());
+            String payload = new String(captor.getValue().getPayload(), StandardCharsets.UTF_8);
+
+            assertThat(payload).contains("유통기한임박");
         }
     }
 
@@ -511,6 +620,14 @@ public class WebPushSubscriptionServiceTest {
 
         ReflectionTestUtils.setField(subscription, "id", id);
         return subscription;
+    }
+
+    private CloseableHttpResponse mockResponse(int statusCode) {
+        CloseableHttpResponse response = mock(CloseableHttpResponse.class);
+        StatusLine statusLine = mock(StatusLine.class);
+        given(response.getStatusLine()).willReturn(statusLine);
+        given(statusLine.getStatusCode()).willReturn(statusCode);
+        return response;
     }
 
     private String generateValidP256dh() throws Exception {

--- a/src/test/java/com/cookeep/cookeep/domain/notification/application/WebPushSubscriptionServiceTest.java
+++ b/src/test/java/com/cookeep/cookeep/domain/notification/application/WebPushSubscriptionServiceTest.java
@@ -2,36 +2,59 @@ package com.cookeep.cookeep.domain.notification.application;
 
 import com.cookeep.cookeep.api.dto.request.WebPushSubscriptionRequestDto;
 import com.cookeep.cookeep.api.dto.response.WebPushEligibilityResponseDto;
+import com.cookeep.cookeep.api.dto.response.WebPushSendResponseDto;
 import com.cookeep.cookeep.api.dto.response.WebPushSubscriptionResponseDto;
 import com.cookeep.cookeep.common.exception.AppException;
 import com.cookeep.cookeep.common.exception.ErrorCode;
+import com.cookeep.cookeep.domain.ingredient.useringredient.dao.UserIngredientRepository;
 import com.cookeep.cookeep.domain.notification.dao.WebPushSubscriptionRepository;
 import com.cookeep.cookeep.domain.notification.entity.WebPushSubscription;
 import com.cookeep.cookeep.domain.user.application.UserReader;
 import com.cookeep.cookeep.domain.user.entity.User;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
+import nl.martijndwars.webpush.PushService;
+import org.apache.http.StatusLine;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import java.nio.charset.StandardCharsets;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.Security;
+import java.security.interfaces.ECPublicKey;
+import java.util.Base64;
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 public class WebPushSubscriptionServiceTest {
 
+    private String validP256dh;
+    private String validAuth;
+
+    @BeforeAll
+    static void registerBouncyCastleProvider() {
+        if (Security.getProvider(BouncyCastleProvider.PROVIDER_NAME) == null) {
+            Security.addProvider(new BouncyCastleProvider());
+        }
+    }
+
     @InjectMocks
     private WebPushSubscriptionService webPushSubscriptionService;
+
+    @InjectMocks
+    private WebPushNotificationService webPushNotificationService;
 
     @Mock
     private WebPushSubscriptionRepository webPushSubscriptionRepository;
@@ -39,16 +62,24 @@ public class WebPushSubscriptionServiceTest {
     @Mock
     private UserReader userReader;
 
+    @Mock
+    private UserIngredientRepository userIngredientRepository;
+
+    @Mock
+    private PushService pushService;
+
     private static final Long USER_ID = 1L;
     private static final String ENDPOINT = "https://fcm.googleapis.com/fcm/send/test-endpoint-12345";
-    private static final String P256DH   = "BNcRdreALRFXTkOOUHK1EtK2wtaz5Ry4YfYCA_0QTpQt";
-    private static final String AUTH     = "tBHItJI5svbpez7KI4CCXg==";
 
     private User user;
 
     @BeforeEach
-    void setUp() {
+    void setUp() throws Exception {
         user = mock(User.class);
+
+        validP256dh = generateValidP256dh();
+        validAuth = generateValidAuth();
+
         lenient().when(user.getUserId()).thenReturn(USER_ID);
         lenient().when(userReader.readById(USER_ID)).thenReturn(user);
     }
@@ -64,7 +95,7 @@ public class WebPushSubscriptionServiceTest {
             given(webPushSubscriptionRepository.findByEndpoint(ENDPOINT)).willReturn(Optional.empty());
 
             WebPushSubscriptionResponseDto result =
-                    webPushSubscriptionService.subscribe(USER_ID, buildRequest(ENDPOINT, P256DH, AUTH));
+                    webPushSubscriptionService.subscribe(USER_ID, buildRequest(ENDPOINT, validP256dh, validAuth));
 
             assertThat(result.getMessage()).isEqualTo("웹 푸시 구독이 등록되었습니다.");
             verify(webPushSubscriptionRepository, times(1)).save(any(WebPushSubscription.class));
@@ -78,7 +109,7 @@ public class WebPushSubscriptionServiceTest {
                     .willReturn(Optional.of(existing));
 
             WebPushSubscriptionResponseDto result =
-                    webPushSubscriptionService.subscribe(USER_ID, buildRequest(ENDPOINT, P256DH, AUTH));
+                    webPushSubscriptionService.subscribe(USER_ID, buildRequest(ENDPOINT, validP256dh, validAuth));
 
             assertThat(result.getMessage()).isEqualTo("웹 푸시 구독이 등록되었습니다.");
             verify(webPushSubscriptionRepository, never()).save(any());
@@ -91,7 +122,7 @@ public class WebPushSubscriptionServiceTest {
                     .willThrow(new AppException(ErrorCode.USER_NOT_FOUND));
 
             assertThatThrownBy(() ->
-                    webPushSubscriptionService.subscribe(USER_ID, buildRequest(ENDPOINT, P256DH, AUTH))
+                    webPushSubscriptionService.subscribe(USER_ID, buildRequest(ENDPOINT, validP256dh, validAuth))
             )
                     .isInstanceOf(AppException.class)
                     .hasMessageContaining(ErrorCode.USER_NOT_FOUND.getMessage());
@@ -115,7 +146,7 @@ public class WebPushSubscriptionServiceTest {
         @DisplayName("endpoint가 null이면 INVALID_ENDPOINT 예외가 발생한다")
         void endpoint_null_INVALID_ENDPOINT_예외발생() {
             assertThatThrownBy(() ->
-                    webPushSubscriptionService.subscribe(USER_ID, buildRequest(null, P256DH, AUTH))
+                    webPushSubscriptionService.subscribe(USER_ID, buildRequest(null, validP256dh, validAuth))
             )
                     .isInstanceOf(AppException.class)
                     .hasMessageContaining(ErrorCode.INVALID_ENDPOINT.getMessage());
@@ -127,7 +158,7 @@ public class WebPushSubscriptionServiceTest {
         @DisplayName("endpoint가 빈 문자열이면 INVALID_ENDPOINT 예외가 발생한다")
         void endpoint_공백_INVALID_ENDPOINT_예외발생() {
             assertThatThrownBy(() ->
-                    webPushSubscriptionService.subscribe(USER_ID, buildRequest("  ", P256DH, AUTH))
+                    webPushSubscriptionService.subscribe(USER_ID, buildRequest("  ", validP256dh, validAuth))
             )
                     .isInstanceOf(AppException.class)
                     .hasMessageContaining(ErrorCode.INVALID_ENDPOINT.getMessage());
@@ -165,7 +196,7 @@ public class WebPushSubscriptionServiceTest {
                     .willReturn(Optional.of(subscription));
 
             WebPushSubscriptionResponseDto result =
-                    webPushSubscriptionService.unsubscribe(USER_ID, buildRequest(ENDPOINT, P256DH, AUTH));
+                    webPushSubscriptionService.unsubscribe(USER_ID, buildRequest(ENDPOINT, validP256dh, validAuth));
 
             assertThat(result.getMessage()).isEqualTo("웹 푸시 구독이 해제되었습니다.");
             verify(webPushSubscriptionRepository, times(1)).delete(subscription);
@@ -178,7 +209,7 @@ public class WebPushSubscriptionServiceTest {
                     .willReturn(Optional.empty());
 
             assertThatThrownBy(() ->
-                    webPushSubscriptionService.unsubscribe(USER_ID, buildRequest(ENDPOINT, P256DH, AUTH))
+                    webPushSubscriptionService.unsubscribe(USER_ID, buildRequest(ENDPOINT, validP256dh, validAuth))
             )
                     .isInstanceOf(AppException.class)
                     .hasMessageContaining(ErrorCode.SUBSCRIPTION_NOT_FOUND.getMessage());
@@ -197,7 +228,7 @@ public class WebPushSubscriptionServiceTest {
                     .willReturn(Optional.of(subscription));
 
             assertThatThrownBy(() ->
-                    webPushSubscriptionService.unsubscribe(USER_ID, buildRequest(ENDPOINT, P256DH, AUTH))
+                    webPushSubscriptionService.unsubscribe(USER_ID, buildRequest(ENDPOINT, validP256dh, validAuth))
             )
                     .isInstanceOf(AppException.class)
                     .hasMessageContaining(ErrorCode.FORBIDDEN.getMessage());
@@ -249,6 +280,200 @@ public class WebPushSubscriptionServiceTest {
         }
     }
 
+    @Nested
+    @DisplayName("4. sendExpirationAlert - 웹 푸시 전송")
+    class SendExpirationAlert {
+
+        @Test
+        @DisplayName("정상 조건이면 pushService.send()를 호출하고 sent=true를 반환한다")
+        void 정상조건_전송성공() throws Exception {
+            // given
+            given(user.getMarketingConsent()).willReturn(true);
+            given(userIngredientRepository.existsByUserIdAndExpirationDate(eq(USER_ID), any()))
+                    .willReturn(true);
+
+            WebPushSubscription subscription = buildSubscription(10L, ENDPOINT, validP256dh, validAuth);
+            given(webPushSubscriptionRepository.findAllByUser_UserId(USER_ID))
+                    .willReturn(List.of(subscription));
+
+            CloseableHttpResponse response = mock(CloseableHttpResponse.class);
+            StatusLine statusLine = mock(StatusLine.class);
+            given(response.getStatusLine()).willReturn(statusLine);
+            given(statusLine.getStatusCode()).willReturn(201);
+            given(pushService.send(any())).willReturn(response);
+
+            // when
+            WebPushSendResponseDto result = webPushNotificationService.sendExpirationAlert(USER_ID);
+
+            // then
+            assertThat(result).isNotNull();
+            verify(pushService, times(1)).send(any());
+            verify(webPushSubscriptionRepository, never()).delete(any());
+        }
+
+        @Test
+        @DisplayName("마케팅 수신 미동의면 전송하지 않고 pushService.send()도 호출하지 않는다")
+        void 수신미동의_전송안함() throws Exception {
+            // given
+            given(user.getMarketingConsent()).willReturn(false);
+
+            // when
+            WebPushSendResponseDto result = webPushNotificationService.sendExpirationAlert(USER_ID);
+
+            // then
+            assertThat(result).isNotNull();
+            verify(userIngredientRepository, never()).existsByUserIdAndExpirationDate(anyLong(), any());
+            verify(webPushSubscriptionRepository, never()).findAllByUser_UserId(anyLong());
+            verify(pushService, never()).send(any());
+        }
+
+        @Test
+        @DisplayName("당일 만료 재료가 없으면 전송하지 않고 pushService.send()도 호출하지 않는다")
+        void 만료재료없음_전송안함() throws Exception {
+            // given
+            given(user.getMarketingConsent()).willReturn(true);
+            given(userIngredientRepository.existsByUserIdAndExpirationDate(eq(USER_ID), any()))
+                    .willReturn(false);
+
+            // when
+            WebPushSendResponseDto result = webPushNotificationService.sendExpirationAlert(USER_ID);
+
+            // then
+            assertThat(result).isNotNull();
+            verify(webPushSubscriptionRepository, never()).findAllByUser_UserId(anyLong());
+            verify(pushService, never()).send(any());
+        }
+
+        @Test
+        @DisplayName("구독 정보가 없으면 SUBSCRIPTION_NOT_FOUND 예외가 발생한다")
+        void 구독정보없음_예외발생() throws Exception {
+            // given
+            given(user.getMarketingConsent()).willReturn(true);
+            given(userIngredientRepository.existsByUserIdAndExpirationDate(eq(USER_ID), any()))
+                    .willReturn(true);
+            given(webPushSubscriptionRepository.findAllByUser_UserId(USER_ID))
+                    .willReturn(List.of());
+
+            // when & then
+            assertThatThrownBy(() -> webPushNotificationService.sendExpirationAlert(USER_ID))
+                    .isInstanceOf(AppException.class)
+                    .hasMessageContaining(ErrorCode.SUBSCRIPTION_NOT_FOUND.getMessage());
+
+            verify(pushService, never()).send(any());
+        }
+
+        @Test
+        @DisplayName("응답이 410이면 만료된 구독으로 판단하고 삭제한다")
+        void 응답410_구독삭제() throws Exception {
+            // given
+            given(user.getMarketingConsent()).willReturn(true);
+            given(userIngredientRepository.existsByUserIdAndExpirationDate(eq(USER_ID), any()))
+                    .willReturn(true);
+
+            WebPushSubscription subscription = buildSubscription(10L, ENDPOINT, validP256dh, validAuth);
+            given(webPushSubscriptionRepository.findAllByUser_UserId(USER_ID))
+                    .willReturn(List.of(subscription));
+
+            CloseableHttpResponse response = mock(CloseableHttpResponse.class);
+            StatusLine statusLine = mock(StatusLine.class);
+            given(response.getStatusLine()).willReturn(statusLine);
+            given(statusLine.getStatusCode()).willReturn(410);
+            given(pushService.send(any())).willReturn(response);
+
+            // when
+            webPushNotificationService.sendExpirationAlert(USER_ID);
+
+            // then
+            verify(pushService, times(1)).send(any());
+            verify(webPushSubscriptionRepository, times(1)).delete(subscription);
+        }
+
+        @Test
+        @DisplayName("응답이 404이면 만료된 구독으로 판단하고 삭제한다")
+        void 응답404_구독삭제() throws Exception {
+            // given
+            given(user.getMarketingConsent()).willReturn(true);
+            given(userIngredientRepository.existsByUserIdAndExpirationDate(eq(USER_ID), any()))
+                    .willReturn(true);
+
+            WebPushSubscription subscription = buildSubscription(10L, ENDPOINT, validP256dh, validAuth);
+            given(webPushSubscriptionRepository.findAllByUser_UserId(USER_ID))
+                    .willReturn(List.of(subscription));
+
+            CloseableHttpResponse response = mock(CloseableHttpResponse.class);
+            StatusLine statusLine = mock(StatusLine.class);
+            given(response.getStatusLine()).willReturn(statusLine);
+            given(statusLine.getStatusCode()).willReturn(404);
+            given(pushService.send(any())).willReturn(response);
+
+            // when
+            webPushNotificationService.sendExpirationAlert(USER_ID);
+
+            // then
+            verify(pushService, times(1)).send(any());
+            verify(webPushSubscriptionRepository, times(1)).delete(subscription);
+        }
+
+        @Test
+        @DisplayName("push 전송 중 예외가 발생해도 전체 흐름은 중단되지 않고 sent를 반환한다")
+        void 전송중예외발생_전체흐름유지() throws Exception {
+            // given
+            given(user.getMarketingConsent()).willReturn(true);
+            given(userIngredientRepository.existsByUserIdAndExpirationDate(eq(USER_ID), any()))
+                    .willReturn(true);
+
+            WebPushSubscription subscription = buildSubscription(10L, ENDPOINT, validP256dh, validAuth);
+            given(webPushSubscriptionRepository.findAllByUser_UserId(USER_ID))
+                    .willReturn(List.of(subscription));
+
+            given(pushService.send(any())).willThrow(new RuntimeException("push send failed"));
+
+            // when
+            WebPushSendResponseDto result = webPushNotificationService.sendExpirationAlert(USER_ID);
+
+            // then
+            assertThat(result).isNotNull();
+            verify(pushService, times(1)).send(any());
+            verify(webPushSubscriptionRepository, never()).delete(any());
+        }
+
+        @Test
+        @DisplayName("전송 payload에는 title, body, url, type 정보가 포함된다")
+        void payload_내용검증() throws Exception {
+            // given
+            given(user.getMarketingConsent()).willReturn(true);
+            given(userIngredientRepository.existsByUserIdAndExpirationDate(eq(USER_ID), any()))
+                    .willReturn(true);
+
+            WebPushSubscription subscription = buildSubscription(10L, ENDPOINT, validP256dh, validAuth);
+            given(webPushSubscriptionRepository.findAllByUser_UserId(USER_ID))
+                    .willReturn(List.of(subscription));
+
+            CloseableHttpResponse response = mock(CloseableHttpResponse.class);
+            StatusLine statusLine = mock(StatusLine.class);
+            given(response.getStatusLine()).willReturn(statusLine);
+            given(statusLine.getStatusCode()).willReturn(201);
+            given(pushService.send(any())).willReturn(response);
+
+            ArgumentCaptor<nl.martijndwars.webpush.Notification> captor =
+                    ArgumentCaptor.forClass(nl.martijndwars.webpush.Notification.class);
+
+            // when
+            webPushNotificationService.sendExpirationAlert(USER_ID);
+
+            // then
+            verify(pushService).send(captor.capture());
+
+            nl.martijndwars.webpush.Notification sentNotification = captor.getValue();
+            String payload = new String(sentNotification.getPayload(), StandardCharsets.UTF_8);
+
+            assertThat(payload).contains("title");
+            assertThat(payload).contains("body");
+            assertThat(payload).contains("url");
+            assertThat(payload).contains("EXPIRATION");
+        }
+    }
+
     // --- 내부 메서드 ---
 
     // Keys 객체 생성
@@ -270,11 +495,68 @@ public class WebPushSubscriptionServiceTest {
         WebPushSubscription sub = WebPushSubscription.builder()
                 .user(owner)
                 .endpoint(endpoint)
-                .p256dh(P256DH)
-                .auth(AUTH)
+                .p256dh(validP256dh)
+                .auth(validAuth)
                 .build();
         ReflectionTestUtils.setField(sub, "id", id);
         return sub;
+    }
+
+    private WebPushSubscription buildSubscription(Long id, String endpoint, String p256dh, String auth) {
+        WebPushSubscription subscription = WebPushSubscription.builder()
+                .endpoint(endpoint)
+                .p256dh(p256dh)
+                .auth(auth)
+                .build();
+
+        ReflectionTestUtils.setField(subscription, "id", id);
+        return subscription;
+    }
+
+    private String generateValidP256dh() throws Exception {
+        KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance("EC");
+        keyPairGenerator.initialize(256);
+        KeyPair keyPair = keyPairGenerator.generateKeyPair();
+
+        ECPublicKey publicKey = (ECPublicKey) keyPair.getPublic();
+        byte[] x = publicKey.getW().getAffineX().toByteArray();
+        byte[] y = publicKey.getW().getAffineY().toByteArray();
+
+        byte[] uncompressed = new byte[65];
+        uncompressed[0] = 0x04;
+        System.arraycopy(toUnsignedFixedLength(x, 32), 0, uncompressed, 1, 32);
+        System.arraycopy(toUnsignedFixedLength(y, 32), 0, uncompressed, 33, 32);
+
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(uncompressed);
+    }
+
+    private byte[] toUnsignedFixedLength(byte[] value, int length) {
+        byte[] result = new byte[length];
+
+        if (value.length == length) {
+            return value;
+        }
+
+        if (value.length == length + 1 && value[0] == 0) {
+            System.arraycopy(value, 1, result, 0, length);
+            return result;
+        }
+
+        if (value.length < length) {
+            System.arraycopy(value, 0, result, length - value.length, value.length);
+            return result;
+        }
+
+        System.arraycopy(value, value.length - length, result, 0, length);
+        return result;
+    }
+
+    private String generateValidAuth() {
+        byte[] authBytes = new byte[16];
+        for (int i = 0; i < authBytes.length; i++) {
+            authBytes[i] = (byte) (i + 1);
+        }
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(authBytes);
     }
 
 }

--- a/src/test/java/com/cookeep/cookeep/domain/notification/application/WebPushSubscriptionServiceTest.java
+++ b/src/test/java/com/cookeep/cookeep/domain/notification/application/WebPushSubscriptionServiceTest.java
@@ -382,7 +382,7 @@ public class WebPushSubscriptionServiceTest {
             WebPushSendResponseDto result = webPushNotificationService.sendExpirationAlert(USER_ID);
 
             assertThat(result.getSent()).isTrue();
-            assertThat(result.getMessage()).contains("전송되었습니다");
+            assertThat(result.getMessage()).isEqualTo("유통기한임박 알림이 전송되었습니다.");
         }
 
         @Test


### PR DESCRIPTION
# Issue
#203 

# Descritpion
- 웹 푸시(Web Push) 기반 유통기한 만료 알림 기능을 구현
   - VAPID 기반 Web Push 전송 구조 적용
   - 구독(subscription) 관리 + 알림 전송 분리 설계
   - 만료된 구독(410, 404) 자동 정리 처리
- 퍼블릭 키 / 프라이빗 키 등록: https://www.notion.so/2-3383f76f872480d284dae11e4e24c5d7 (GitHub secrets는 등록함)

### 파일 구성
<head></head>
파일 | 경로 | 설명
-- | -- | --
WebPushSendResponseDto.java | api/dto/response | 알림 전송 결과 DTO
WebPushNotificationService.java | domain/notification/application | 웹 푸시 전송 핵심 서비스
WebPushSubscriptionController.java | api/controller | 구독 등록/해제 + public key 제공
PushServiceConfig.java | config | VAPID + PushService 설정

### 전송 흐름
```
[1] GET /api/users/me/web/push/public-key
    - WebPushSubscriptionController.getPublicKey()

[2] 프론트에서 브라우저 subscription 생성
    - 백엔드 메서드 없음

[3] POST /api/users/me/web/push/subscription
    - WebPushSubscriptionController.subscribe()
    - WebPushSubscriptionService.subscribe()

-------------------------
여기까지가 "웹푸시 등록 1회"
-------------------------

[4] GET /api/users/me/alerts
    - PushNotificationController.checkPushNotificationEligibility()
    - PopupNotificationEligibilityService.checkEligibility()

[5] POST /api/users/me/web/push/notifications
    - PushNotificationController.sendAlert()
    - WebPushNotificationService.sendExpirationAlert()
        ├─ buildPayload()
        └─ sendToSubscriptions()
```

# Changes
- 웹 푸시 전송 서비스 추가
   - WebPushNotificationService
   - 유통기한 만료 알림 전송 로직 구현
- 구독 관리 API 수정
   - WebPushSubscriptionController 수정
   - public VAPID key 조회 API 추가 (GET /api/web-push/public-key)
- PushService 설정 추가
   - PushServiceConfig
   - VAPID 기반 PushService Bean 등록
- DTO 추가
   - WebPushSendResponseDto
- 전송 정책 구현
   - 마케팅 미동의 시 전송 중단
   - 만료 재료 없으면 전송 중단
   - 구독 없으면 예외 처리
   - 404 / 410 응답 시 구독 자동 삭제
   - 개별 전송 실패 시 로그만 남기고 계속 진행

# Test Checklist
### WebPushSubscriptionServiceTest
- [x] 신규 구독 등록 성공
- [x] 중복 endpoint 저장 방지
- [x] 존재하지 않는 유저 예외 처리
- [x] invalid request / endpoint 예외 처리
- [x] unsubscribe 정상 동작
- [x] 타 유저 구독 삭제 시 FORBIDDEN 검증
- [x] 구독 존재 여부 체크 (eligible true/false)