### PR TITLE
refactor: 마이쿠킵 레시피 사진 업로드 시 보상 쿠키 지급 여부를 API 응답에 추가 + 쿠키 보상 중복 지급 방지

### DIFF
--- a/src/main/java/com/cookeep/cookeep/api/controller/DailyRecipeController.java
+++ b/src/main/java/com/cookeep/cookeep/api/controller/DailyRecipeController.java
@@ -123,7 +123,7 @@ public class DailyRecipeController {
         );
 
         return ResponseEntity.status(201)
-                .body(DataResponse.created(DailyRecipeCreateResponseDto.from(result.dailyRecipe(), result.weeklyGoalAchieved())));
+                .body(DataResponse.created(DailyRecipeCreateResponseDto.from(result.dailyRecipe(), result.weeklyGoalAchieved(), result.photoCookieAwarded())));
     }
 
     @Operation(
@@ -177,7 +177,7 @@ public class DailyRecipeController {
                 request.getRecipeImageUrl(), request.getDeleteRecipeImage()
         );
 
-        return ResponseEntity.ok(DataResponse.from(DailyRecipeDetailResponseDto.from(result.dailyRecipe(), result.weeklyGoalAchieved())));
+        return ResponseEntity.ok(DataResponse.from(DailyRecipeDetailResponseDto.from(result.dailyRecipe(), result.weeklyGoalAchieved(), result.photoCookieAwarded())));
     }
 
     @Operation(

--- a/src/main/java/com/cookeep/cookeep/api/controller/DailyRecipeController.java
+++ b/src/main/java/com/cookeep/cookeep/api/controller/DailyRecipeController.java
@@ -7,6 +7,7 @@ import com.cookeep.cookeep.api.dto.response.AdoptedAiRecipeDetailResponseDto;
 import com.cookeep.cookeep.api.dto.response.AdoptedAiRecipeListResponseDto;
 import com.cookeep.cookeep.api.dto.response.DailyRecipeCreateResponseDto;
 import com.cookeep.cookeep.api.dto.response.DailyRecipeDetailResponseDto;
+import com.cookeep.cookeep.api.dto.response.DailyRecipeUpdateResponseDto;
 import com.cookeep.cookeep.api.dto.response.DailyRecipeCalendarResponseDto;
 import com.cookeep.cookeep.api.dto.response.DailyRecipeListResponseDto;
 import com.cookeep.cookeep.common.dto.DataResponse;
@@ -166,7 +167,7 @@ public class DailyRecipeController {
             @ApiResponse(responseCode = "404", description = "데일리 레시피를 찾을 수 없음", content = @Content)
     })
     @PatchMapping("/{dailyRecipeId}")
-    public ResponseEntity<DataResponse<DailyRecipeDetailResponseDto>> updateDailyRecipe(
+    public ResponseEntity<DataResponse<DailyRecipeUpdateResponseDto>> updateDailyRecipe(
             @AuthenticationPrincipal(expression = "userId") Long userId,
             @Parameter(description = "데일리 레시피 ID", required = true)
             @PathVariable Long dailyRecipeId,
@@ -177,7 +178,7 @@ public class DailyRecipeController {
                 request.getRecipeImageUrl(), request.getDeleteRecipeImage()
         );
 
-        return ResponseEntity.ok(DataResponse.from(DailyRecipeDetailResponseDto.from(result.dailyRecipe(), result.weeklyGoalAchieved(), result.photoCookieAwarded())));
+        return ResponseEntity.ok(DataResponse.from(DailyRecipeUpdateResponseDto.from(result.dailyRecipe(), result.weeklyGoalAchieved(), result.photoCookieAwarded())));
     }
 
     @Operation(

--- a/src/main/java/com/cookeep/cookeep/api/dto/response/DailyRecipeCreateResponseDto.java
+++ b/src/main/java/com/cookeep/cookeep/api/dto/response/DailyRecipeCreateResponseDto.java
@@ -30,13 +30,17 @@ public class DailyRecipeCreateResponseDto {
     @Schema(description = "이번 액션으로 주간 목표 달성 여부", example = "false")
     private boolean weeklyGoalAchieved;
 
-    public static DailyRecipeCreateResponseDto from(DailyRecipe dailyRecipe, boolean weeklyGoalAchieved) {
+    @Schema(description = "사진 업로드 보상 쿠키 지급 여부", example = "true")
+    private boolean photoCookieAwarded;
+
+    public static DailyRecipeCreateResponseDto from(DailyRecipe dailyRecipe, boolean weeklyGoalAchieved, boolean photoCookieAwarded) {
         return DailyRecipeCreateResponseDto.builder()
                 .dailyRecipeId(dailyRecipe.getId())
                 .title(dailyRecipe.getTitle())
                 .message("새로운 데일리 레시피가 등록되었습니다.")
                 .createdAt(dailyRecipe.getCreatedAt())
                 .weeklyGoalAchieved(weeklyGoalAchieved)
+                .photoCookieAwarded(photoCookieAwarded)
                 .build();
     }
 }

--- a/src/main/java/com/cookeep/cookeep/api/dto/response/DailyRecipeDetailResponseDto.java
+++ b/src/main/java/com/cookeep/cookeep/api/dto/response/DailyRecipeDetailResponseDto.java
@@ -44,11 +44,18 @@ public class DailyRecipeDetailResponseDto {
     @Schema(description = "이번 액션으로 주간 목표 달성 여부 (수정 시에만 유효)", example = "false")
     private boolean weeklyGoalAchieved;
 
+    @Schema(description = "사진 업로드 보상 쿠키 지급 여부 (수정 시에만 유효)", example = "true")
+    private boolean photoCookieAwarded;
+
     public static DailyRecipeDetailResponseDto from(DailyRecipe dailyRecipe) {
-        return from(dailyRecipe, false);
+        return from(dailyRecipe, false, false);
     }
 
     public static DailyRecipeDetailResponseDto from(DailyRecipe dailyRecipe, boolean weeklyGoalAchieved) {
+        return from(dailyRecipe, weeklyGoalAchieved, false);
+    }
+
+    public static DailyRecipeDetailResponseDto from(DailyRecipe dailyRecipe, boolean weeklyGoalAchieved, boolean photoCookieAwarded) {
         return DailyRecipeDetailResponseDto.builder()
                 .dailyRecipeId(dailyRecipe.getId())
                 .title(dailyRecipe.getTitle())
@@ -59,6 +66,7 @@ public class DailyRecipeDetailResponseDto {
                 .aiRecipeId(dailyRecipe.getAiRecipe() != null ? dailyRecipe.getAiRecipe().getId() : null)
                 .createdAt(dailyRecipe.getCreatedAt())
                 .weeklyGoalAchieved(weeklyGoalAchieved)
+                .photoCookieAwarded(photoCookieAwarded)
                 .build();
     }
 }

--- a/src/main/java/com/cookeep/cookeep/api/dto/response/DailyRecipeUpdateResponseDto.java
+++ b/src/main/java/com/cookeep/cookeep/api/dto/response/DailyRecipeUpdateResponseDto.java
@@ -9,12 +9,12 @@ import lombok.Getter;
 import java.time.LocalDateTime;
 
 @Schema(
-        name = "DailyRecipeDetailResponse",
-        description = "데일리 레시피 상세 조회 응답 DTO"
+        name = "DailyRecipeUpdateResponse",
+        description = "데일리 레시피 수정 응답 DTO"
 )
 @Getter
 @Builder
-public class DailyRecipeDetailResponseDto {
+public class DailyRecipeUpdateResponseDto {
 
     @Schema(description = "데일리 레시피 ID", example = "1")
     private Long dailyRecipeId;
@@ -41,8 +41,14 @@ public class DailyRecipeDetailResponseDto {
     @Schema(description = "등록 시각", example = "2026-02-07T14:30:00")
     private LocalDateTime createdAt;
 
-    public static DailyRecipeDetailResponseDto from(DailyRecipe dailyRecipe) {
-        return DailyRecipeDetailResponseDto.builder()
+    @Schema(description = "이번 수정으로 주간 목표 달성 여부", example = "false")
+    private boolean weeklyGoalAchieved;
+
+    @Schema(description = "이번 수정으로 사진 업로드 보상 쿠키 지급 여부", example = "true")
+    private boolean photoCookieAwarded;
+
+    public static DailyRecipeUpdateResponseDto from(DailyRecipe dailyRecipe, boolean weeklyGoalAchieved, boolean photoCookieAwarded) {
+        return DailyRecipeUpdateResponseDto.builder()
                 .dailyRecipeId(dailyRecipe.getId())
                 .title(dailyRecipe.getTitle())
                 .description(dailyRecipe.getDescription())
@@ -51,6 +57,8 @@ public class DailyRecipeDetailResponseDto {
                 .isPublic(dailyRecipe.getIsPublic())
                 .aiRecipeId(dailyRecipe.getAiRecipe() != null ? dailyRecipe.getAiRecipe().getId() : null)
                 .createdAt(dailyRecipe.getCreatedAt())
+                .weeklyGoalAchieved(weeklyGoalAchieved)
+                .photoCookieAwarded(photoCookieAwarded)
                 .build();
     }
 }

--- a/src/main/java/com/cookeep/cookeep/domain/dailyrecipe/application/DailyRecipeService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/dailyrecipe/application/DailyRecipeService.java
@@ -44,7 +44,7 @@ public class DailyRecipeService {
     private final ObjectMapper objectMapper;
     private final S3Service s3Service;
 
-    public record DailyRecipeResult(DailyRecipe dailyRecipe, boolean weeklyGoalAchieved) {}
+    public record DailyRecipeResult(DailyRecipe dailyRecipe, boolean weeklyGoalAchieved, boolean photoCookieAwarded) {}
 
     // 채택된 AI 레시피 목록 조회
     @Transactional(readOnly = true)
@@ -78,12 +78,15 @@ public class DailyRecipeService {
         // title: 사용자 지정값이 있으면 사용, 없으면 AI 레시피 제목
         String resolvedTitle = (title != null && !title.isBlank()) ? title : aiRecipe.getTitle();
 
+        boolean hasPhoto = recipeImageUrl != null && !recipeImageUrl.isBlank();
+
         DailyRecipe dailyRecipe = DailyRecipe.builder()
                 .title(resolvedTitle)
                 .description(description)
                 .content(content)
                 .recipeImageUrl(recipeImageUrl)
                 .isPublic(isPublic != null ? isPublic : false)
+                .photoCookieAwarded(hasPhoto)
                 .user(user)
                 .aiRecipe(aiRecipe)
                 .build();
@@ -95,12 +98,12 @@ public class DailyRecipeService {
 
         // 쿠키 추가 지급: 음식 사진 등록 시 (1개) + 주간 목표 진행
         boolean goalAchieved = false;
-        if (recipeImageUrl != null && !recipeImageUrl.isBlank()) {
+        if (hasPhoto) {
             cookieService.updateCookie(userId, CookieLog.CookieLogType.BASIC_FOOD_PHOTO_REG);
             goalAchieved = weeklyGoalService.handleGoalProgress(userId, GoalActionType.PHOTO_RECORD);
         }
 
-        return new DailyRecipeResult(dailyRecipe, goalAchieved);
+        return new DailyRecipeResult(dailyRecipe, goalAchieved, hasPhoto);
     }
 
     // 데일리 레시피 상세 조회
@@ -146,21 +149,23 @@ public class DailyRecipeService {
             dailyRecipe.updateDescription(description);
         }
 
-        // 기존에 사진이 없었고 새로 사진을 추가하는 경우 쿠키 지급 + 주간 목표 진행
+        // 사진 추가 시 쿠키 지급 (최초 1회) + 주간 목표 진행
         boolean goalAchieved = false;
+        boolean photoCookieAwarded = false;
         if (recipeImageUrl != null && !recipeImageUrl.isBlank()) {
             if (recipeImageUrl.equals(dailyRecipe.getRecipeImageUrl())) {
                 throw new AppException(ErrorCode.DAILY_RECIPE_IMAGE_SAME_URL);
             }
-            boolean isNewPhotoAdded = dailyRecipe.getRecipeImageUrl() == null || dailyRecipe.getRecipeImageUrl().isBlank();
             dailyRecipe.updateRecipeImageUrl(recipeImageUrl);
-            if (isNewPhotoAdded) {
+            if (!dailyRecipe.isPhotoCookieAwarded()) {
+                dailyRecipe.markPhotoCookieAwarded();
                 cookieService.updateCookie(userId, CookieLog.CookieLogType.BASIC_FOOD_PHOTO_REG);
                 goalAchieved = weeklyGoalService.handleGoalProgress(userId, GoalActionType.PHOTO_RECORD);
+                photoCookieAwarded = true;
             }
         }
 
-        return new DailyRecipeResult(dailyRecipe, goalAchieved);
+        return new DailyRecipeResult(dailyRecipe, goalAchieved, photoCookieAwarded);
     }
 
     // 데일리 레시피 공개 범위 수정

--- a/src/main/java/com/cookeep/cookeep/domain/dailyrecipe/application/DailyRecipeService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/dailyrecipe/application/DailyRecipeService.java
@@ -86,7 +86,7 @@ public class DailyRecipeService {
                 .content(content)
                 .recipeImageUrl(recipeImageUrl)
                 .isPublic(isPublic != null ? isPublic : false)
-                .photoCookieAwarded(hasPhoto)
+                .photoRewardCompleted(hasPhoto)
                 .user(user)
                 .aiRecipe(aiRecipe)
                 .build();
@@ -157,8 +157,8 @@ public class DailyRecipeService {
                 throw new AppException(ErrorCode.DAILY_RECIPE_IMAGE_SAME_URL);
             }
             dailyRecipe.updateRecipeImageUrl(recipeImageUrl);
-            if (!dailyRecipe.isPhotoCookieAwarded()) {
-                dailyRecipe.markPhotoCookieAwarded();
+            if (!dailyRecipe.isPhotoRewardCompleted()) {
+                dailyRecipe.markPhotoRewardCompleted();
                 cookieService.updateCookie(userId, CookieLog.CookieLogType.BASIC_FOOD_PHOTO_REG);
                 goalAchieved = weeklyGoalService.handleGoalProgress(userId, GoalActionType.PHOTO_RECORD);
                 photoCookieAwarded = true;

--- a/src/main/java/com/cookeep/cookeep/domain/dailyrecipe/entity/DailyRecipe.java
+++ b/src/main/java/com/cookeep/cookeep/domain/dailyrecipe/entity/DailyRecipe.java
@@ -44,6 +44,10 @@ public class DailyRecipe extends BaseEntity {
     @Column(name = "like_count", nullable = false)
     private Integer likeCount = 0;
 
+    @Builder.Default
+    @Column(name = "photo_cookie_awarded", nullable = false)
+    private boolean photoCookieAwarded = false;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
@@ -66,6 +70,10 @@ public class DailyRecipe extends BaseEntity {
 
     public void updateRecipeImageUrl(String recipeImageUrl) {
         this.recipeImageUrl = recipeImageUrl;
+    }
+
+    public void markPhotoCookieAwarded() {
+        this.photoCookieAwarded = true;
     }
 
     public void incrementLikeCount() {

--- a/src/main/java/com/cookeep/cookeep/domain/dailyrecipe/entity/DailyRecipe.java
+++ b/src/main/java/com/cookeep/cookeep/domain/dailyrecipe/entity/DailyRecipe.java
@@ -45,8 +45,8 @@ public class DailyRecipe extends BaseEntity {
     private Integer likeCount = 0;
 
     @Builder.Default
-    @Column(name = "photo_cookie_awarded", nullable = false)
-    private boolean photoCookieAwarded = false;
+    @Column(name = "is_photo_reward_completed", nullable = false)
+    private boolean photoRewardCompleted = false;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
@@ -72,8 +72,8 @@ public class DailyRecipe extends BaseEntity {
         this.recipeImageUrl = recipeImageUrl;
     }
 
-    public void markPhotoCookieAwarded() {
-        this.photoCookieAwarded = true;
+    public void markPhotoRewardCompleted() {
+        this.photoRewardCompleted = true;
     }
 
     public void incrementLikeCount() {

--- a/src/test/java/com/cookeep/cookeep/domain/dailyrecipe/application/DailyRecipeServiceTest.java
+++ b/src/test/java/com/cookeep/cookeep/domain/dailyrecipe/application/DailyRecipeServiceTest.java
@@ -70,7 +70,7 @@ class DailyRecipeServiceTest {
     }
 
     @Nested
-    @DisplayName("createDailyRecipe - PHOTO_RECORD 목표 연동")
+    @DisplayName("createDailyRecipe")
     class CreateDailyRecipe {
 
         @Test
@@ -108,36 +108,74 @@ class DailyRecipeServiceTest {
 
             assertThat(result.weeklyGoalAchieved()).isFalse();
         }
+
+        @Test
+        @DisplayName("사진 포함 등록 시 photoCookieAwarded=true를 반환한다")
+        void 사진포함_등록_photoCookieAwarded_true() {
+            DailyRecipeService.DailyRecipeResult result =
+                    dailyRecipeService.createDailyRecipe(1L, 10L, null, null, "https://s3.example.com/photo.jpg", false);
+
+            assertThat(result.photoCookieAwarded()).isTrue();
+        }
+
+        @Test
+        @DisplayName("사진 없이 등록 시 photoCookieAwarded=false를 반환한다")
+        void 사진없음_등록_photoCookieAwarded_false() {
+            DailyRecipeService.DailyRecipeResult result =
+                    dailyRecipeService.createDailyRecipe(1L, 10L, null, null, null, false);
+
+            assertThat(result.photoCookieAwarded()).isFalse();
+        }
+
+        @Test
+        @DisplayName("사진 포함 등록 시 BASIC_FOOD_PHOTO_REG 쿠키를 지급한다")
+        void 사진포함_등록_사진쿠키_지급() {
+            dailyRecipeService.createDailyRecipe(1L, 10L, null, null, "https://s3.example.com/photo.jpg", false);
+
+            verify(cookieService).updateCookie(1L, CookieLog.CookieLogType.BASIC_FOOD_PHOTO_REG);
+        }
+
+        @Test
+        @DisplayName("사진 없이 등록 시 BASIC_FOOD_PHOTO_REG 쿠키를 지급하지 않는다")
+        void 사진없음_등록_사진쿠키_미지급() {
+            dailyRecipeService.createDailyRecipe(1L, 10L, null, null, null, false);
+
+            verify(cookieService, never()).updateCookie(1L, CookieLog.CookieLogType.BASIC_FOOD_PHOTO_REG);
+        }
     }
 
     @Nested
-    @DisplayName("updateDailyRecipe - PHOTO_RECORD 목표 연동")
+    @DisplayName("updateDailyRecipe")
     class UpdateDailyRecipe {
 
-        private DailyRecipe existingRecipeWithoutPhoto;
-        private DailyRecipe existingRecipeWithPhoto;
+        // 사진 보상 미완료 상태 (처음 사진 추가 가능)
+        private DailyRecipe rewardPendingRecipe;
+        // 사진 보상 완료 상태 (재지급 불가)
+        private DailyRecipe rewardCompletedRecipe;
 
         @BeforeEach
         void setUp() {
-            existingRecipeWithoutPhoto = DailyRecipe.builder()
+            rewardPendingRecipe = DailyRecipe.builder()
                     .title("기존 레시피")
                     .content("{}")
                     .user(user)
+                    .photoRewardCompleted(false)
                     .build();
 
-            existingRecipeWithPhoto = DailyRecipe.builder()
+            rewardCompletedRecipe = DailyRecipe.builder()
                     .title("기존 레시피")
                     .content("{}")
                     .recipeImageUrl("https://s3.example.com/existing.jpg")
+                    .photoRewardCompleted(true)
                     .user(user)
                     .build();
         }
 
         @Test
-        @DisplayName("사진이 없던 레시피에 사진을 추가하면 PHOTO_RECORD 목표 진행을 호출한다")
+        @DisplayName("보상 미완료 레시피에 처음 사진 추가 시 PHOTO_RECORD 목표 진행을 호출한다")
         void 신규사진_추가_목표진행_호출() {
             given(dailyRecipeRepository.findByIdAndUser(100L, user))
-                    .willReturn(Optional.of(existingRecipeWithoutPhoto));
+                    .willReturn(Optional.of(rewardPendingRecipe));
 
             dailyRecipeService.updateDailyRecipe(1L, 100L, null, null, "https://s3.example.com/new.jpg", false);
 
@@ -145,10 +183,10 @@ class DailyRecipeServiceTest {
         }
 
         @Test
-        @DisplayName("이미 사진이 있는 레시피에 사진을 교체하면 PHOTO_RECORD 목표 진행을 호출하지 않는다")
-        void 기존사진_교체_목표진행_미호출() {
+        @DisplayName("보상 완료된 레시피에 사진 교체 시 PHOTO_RECORD 목표 진행을 호출하지 않는다")
+        void 보상완료_사진교체_목표진행_미호출() {
             given(dailyRecipeRepository.findByIdAndUser(100L, user))
-                    .willReturn(Optional.of(existingRecipeWithPhoto));
+                    .willReturn(Optional.of(rewardCompletedRecipe));
 
             dailyRecipeService.updateDailyRecipe(1L, 100L, null, null, "https://s3.example.com/replaced.jpg", false);
 
@@ -156,16 +194,82 @@ class DailyRecipeServiceTest {
         }
 
         @Test
+        @DisplayName("보상 미완료 레시피에 처음 사진 추가 시 photoCookieAwarded=true를 반환한다")
+        void 신규사진_추가_photoCookieAwarded_true() {
+            given(dailyRecipeRepository.findByIdAndUser(100L, user))
+                    .willReturn(Optional.of(rewardPendingRecipe));
+
+            DailyRecipeService.DailyRecipeResult result =
+                    dailyRecipeService.updateDailyRecipe(1L, 100L, null, null, "https://s3.example.com/new.jpg", false);
+
+            assertThat(result.photoCookieAwarded()).isTrue();
+        }
+
+        @Test
+        @DisplayName("보상 완료된 레시피에 사진 교체 시 photoCookieAwarded=false를 반환한다")
+        void 보상완료_사진교체_photoCookieAwarded_false() {
+            given(dailyRecipeRepository.findByIdAndUser(100L, user))
+                    .willReturn(Optional.of(rewardCompletedRecipe));
+
+            DailyRecipeService.DailyRecipeResult result =
+                    dailyRecipeService.updateDailyRecipe(1L, 100L, null, null, "https://s3.example.com/replaced.jpg", false);
+
+            assertThat(result.photoCookieAwarded()).isFalse();
+        }
+
+        @Test
+        @DisplayName("보상 미완료 레시피에 처음 사진 추가 시 BASIC_FOOD_PHOTO_REG 쿠키를 지급한다")
+        void 신규사진_추가_사진쿠키_지급() {
+            given(dailyRecipeRepository.findByIdAndUser(100L, user))
+                    .willReturn(Optional.of(rewardPendingRecipe));
+
+            dailyRecipeService.updateDailyRecipe(1L, 100L, null, null, "https://s3.example.com/new.jpg", false);
+
+            verify(cookieService).updateCookie(1L, CookieLog.CookieLogType.BASIC_FOOD_PHOTO_REG);
+        }
+
+        @Test
+        @DisplayName("보상 완료된 레시피에 사진 교체 시 BASIC_FOOD_PHOTO_REG 쿠키를 지급하지 않는다")
+        void 보상완료_사진교체_사진쿠키_미지급() {
+            given(dailyRecipeRepository.findByIdAndUser(100L, user))
+                    .willReturn(Optional.of(rewardCompletedRecipe));
+
+            dailyRecipeService.updateDailyRecipe(1L, 100L, null, null, "https://s3.example.com/replaced.jpg", false);
+
+            verify(cookieService, never()).updateCookie(1L, CookieLog.CookieLogType.BASIC_FOOD_PHOTO_REG);
+        }
+
+        @Test
         @DisplayName("신규 사진 추가 시 목표 달성이면 weeklyGoalAchieved=true를 반환한다")
         void 신규사진_추가_목표달성_true반환() {
             given(dailyRecipeRepository.findByIdAndUser(100L, user))
-                    .willReturn(Optional.of(existingRecipeWithoutPhoto));
+                    .willReturn(Optional.of(rewardPendingRecipe));
             given(weeklyGoalService.handleGoalProgress(1L, GoalActionType.PHOTO_RECORD)).willReturn(true);
 
             DailyRecipeService.DailyRecipeResult result =
                     dailyRecipeService.updateDailyRecipe(1L, 100L, null, null, "https://s3.example.com/new.jpg", false);
 
             assertThat(result.weeklyGoalAchieved()).isTrue();
+        }
+
+        @Test
+        @DisplayName("사진 삭제 후 재등록 시 쿠키와 목표 진행이 중복 지급되지 않는다 (어뷰징 방지)")
+        void 사진삭제후재등록_중복지급_방지() {
+            // 이미 사진 보상을 받은 레시피에서 사진을 삭제한 상태 (photoRewardCompleted = true, recipeImageUrl = null)
+            DailyRecipe rewardedButNoPhoto = DailyRecipe.builder()
+                    .title("기존 레시피")
+                    .content("{}")
+                    .recipeImageUrl(null)
+                    .photoRewardCompleted(true)
+                    .user(user)
+                    .build();
+            given(dailyRecipeRepository.findByIdAndUser(100L, user))
+                    .willReturn(Optional.of(rewardedButNoPhoto));
+
+            dailyRecipeService.updateDailyRecipe(1L, 100L, null, null, "https://s3.example.com/re-uploaded.jpg", false);
+
+            verify(cookieService, never()).updateCookie(1L, CookieLog.CookieLogType.BASIC_FOOD_PHOTO_REG);
+            verify(weeklyGoalService, never()).handleGoalProgress(any(), any());
         }
     }
 }


### PR DESCRIPTION
# Related Issue
CLOSE #204 

# Description
데일리 레시피 등록/수정 시 사진을 올리면, 사진 업로드에 대한 보상으로 쿠키 1개가 지급되는데, **그 지급 여부를 API 응답에 포함**합니다.
또한 사진 삭제 후 재등록 시(사진 등록 -> 수정 들어가 사진 삭제 -> 사진 재등록 플로우) 쿠키가 중복 지급되는 어뷰징을 방지합니다.
즉, `사진 보상 쿠키`는 레시피 당 최초 1회만 지급됩니다.

<img width="622" height="536" alt="image" src="https://github.com/user-attachments/assets/7a4fd634-05b7-4a79-b734-db2619a9a7d4" />

# Changes
**feat**
  - DailyRecipe 엔티티에 `is_photo_reward_completed` 컬럼 추가
    - 레시피당 사진 쿠키 최초 1회 지급 여부를 영구 저장합니다.
    -> 사진 삭제 후 재등록 시 재지급 방지를 위함입니다.
  - 데일리 레시피 등록 API(POST) 응답에 photoCookieAwarded 필드 추가
  - 데일리 레시피 수정 API(PATCH) 응답에 photoCookieAwarded, weeklyGoalAchieved 필드 추가

**refactor**
  - 레시피를 상세 조회할 때와 수정할 때 응답 dto를 `DailyRecipeDetailResponseDto`로 함께 쓰고 있었는데, 
     수정 API 응답 DTO를 `DailyRecipeUpdateResponseDto`로 분리했습니다.
    -> 상세 조회 API에서 수정 전용 필드(`photoCookieAwarded`, `weeklyGoalAchieved`)가 불필요하게 노출되던 문제를 제거하기 위함입니다.
    -> 결론: 수정 API 전용 응답 DTO를 따로 만들고, 상세 조회는 기존 `DailyRecipeDetailResponseDto`에서 `photoCookieAwarded`와
  `weeklyGoalAchieved`를 뺐습니다.

# Test
- [x] 레시피 등록 시 사진 포함/미포함에 따른 photoCookieAwarded 반환값 검증
- [x] 레시피 등록 시 사진 포함/미포함에 따른 BASIC_FOOD_PHOTO_REG 쿠키 지급 여부 검증
- [x] 레시피 수정 시 "보상 미완료 레시피"에 첫 사진 추가 → 쿠키 **지급** 및 photoCookieAwarded=true 검증
- [x] 레시피 수정 시 "보상 완료된 레시피"에 사진 교체 → 쿠키 **미지급** 및 photoCookieAwarded=false 검증
- [x] 사진 삭제 후 재등록 시 쿠키 및 주간 목표 카운트 중복 지급 방지 검증

# 참고 사항
DB 마이그레이션이 필요합니다.
새 컬럼 추가 및 기존 데이터 처리:
  -- 1. 컬럼 추가
```sql
  ALTER TABLE daily_recipes
  ADD COLUMN is_photo_reward_completed TINYINT(1) NOT NULL DEFAULT 0;
```

  -- 2. 기존 데이터 마이그레이션 (사진 있는 레시피는 보상 완료 처리)
```sql
  UPDATE daily_recipes
  SET is_photo_reward_completed = 1
  WHERE recipe_image_url IS NOT NULL AND recipe_image_url != '';
```
ddl-auto: update라면 1번 쿼리는 직접 칠 필요 없이 컬럼이 자동 추가되나,(아마도..) 기존 데이터 마이그레이션 쿼리(2번)는 직접 실행 필요합니다!
배포 서버에는 제가 해놓겠습니당
