### PR TITLE
refactor: 랭킹 레시피 응답에 작성자 닉네임 추가 및 N+1 방지를 위한 JOIN FETCH 적용

### DIFF
--- a/src/main/java/com/cookeep/cookeep/api/dto/response/RankingResponseDto.java
+++ b/src/main/java/com/cookeep/cookeep/api/dto/response/RankingResponseDto.java
@@ -26,6 +26,7 @@ public class RankingResponseDto {
 	public static class RecipeRankDto {
 		private Long dailyRecipeId;
 		private Integer rank;
+		private String nickname;
 		private String title;
 		private Long likeCount;
 		private String recipeImageUrl;

--- a/src/main/java/com/cookeep/cookeep/domain/cookeeps/application/CookeepsService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/cookeeps/application/CookeepsService.java
@@ -100,6 +100,7 @@ public class CookeepsService {
 				return RecipeRankDto.builder()
 						.dailyRecipeId(recipe.getId())
 						.rank(index + 1)
+						.nickname(recipe.getUser().getNickname())
 						.title(recipe.getTitle())
 						.likeCount(recipe.getLikeCount().longValue())
 						.recipeImageUrl(recipe.getRecipeImageUrl())

--- a/src/main/java/com/cookeep/cookeep/domain/dailyrecipe/dao/DailyRecipeRepository.java
+++ b/src/main/java/com/cookeep/cookeep/domain/dailyrecipe/dao/DailyRecipeRepository.java
@@ -42,7 +42,7 @@ public interface DailyRecipeRepository extends JpaRepository<DailyRecipe, Long> 
     boolean existsByAiRecipe_Session_Id(Long sessionId);
 
     // 이번 주 공개 레시피 중 좋아요 랭킹 Top N 조회 (좋아요 내림차순, 동점 시 등록 오래된 순)
-    @Query("SELECT dr FROM DailyRecipe dr WHERE dr.isPublic = true " +
+    @Query("SELECT dr FROM DailyRecipe dr JOIN FETCH dr.user WHERE dr.isPublic = true " +
             "AND dr.createdAt >= :start AND dr.createdAt < :end " +
             "ORDER BY dr.likeCount DESC, dr.createdAt ASC")
     List<DailyRecipe> findTopRankedRecipes(


### PR DESCRIPTION
# Related Issue
CLOSE #208 

# Description
UI 디자인 변경에 따라 랭킹 API(`GET api/cookeeps/ranking`)의 레시피 랭킹 응답 데이터에 작성자 닉네임을 추가합니다.
(기존에는 `RecipeRankDto`에 닉네임 필드가 없어 클라이언트에서 작성자를 식별할 수 없었음)
또한 `user` 연관 엔티티에 대한 LAZY 로딩으로 인해 N+1 문제가 발생할 수 있어 함께 수정합니다.

# Changes
- `RecipeRankDto`에 `nickname` 필드 추가
- `CookeepsService.getRecipeRanking()`에서 `recipe.getUser().getNickname()`으로 닉네임 세팅
- `DailyRecipeRepository.findTopRankedRecipes()` 쿼리에 `JOIN FETCH dr.user` 적용하여 N+1 방지

# Test
- [x] Swagger로 nickname 필드 반환 확인 완료