### PR TITLE
hotfix: deploy.yml에 VAPID 환경변수 추가

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -71,5 +71,7 @@ jobs:
               -e SMS_KEY=${{ secrets.SMS_KEY }} \
               -e SMS_SECRET=${{ secrets.SMS_SECRET }} \
               -e SMS_SENDER=${{ secrets.SMS_SENDER }} \
+              -e VAPID_PUBLIC_KEY=${{ secrets.VAPID_PUBLIC_KEY }} \
+              -e VAPID_PRIVATE_KEY=${{ secrets.VAPID_PRIVATE_KEY }} \
               ${{ secrets.DOCKER_USERNAME }}/cookeep:latest
             docker image prune -f


### PR DESCRIPTION
 ## Description                                                                                                                                                       
  develop 브랜치 기준 서버가 기동되지 않는 문제 수정.                                                                                                                  
                                                                                                                                                                       
  `WebPushConfig`에서 `${vapid.public-key}`, `${vapid.private-key}`를 주입받으려 하는데,                                                                               
  `deploy.yml`의 `docker run` 명령어에 `VAPID_PUBLIC_KEY`, `VAPID_PRIVATE_KEY` 환경변수가 누락되어                                                                     
  Spring 컨텍스트 로드 시 `PlaceholderResolutionException`이 발생하며 서버가 종료되고 있었음. 

즉 도커 컨테이너를 실행(docker run)할 때 환경변수를 넘겨주지 않아서 발생한 것.

[자세한 흐름] ⬇️          
1. application.yaml에 `vapid.public-key: ${VAPID_PUBLIC_KEY}` 설정이 있음
2. WebPushConfig.java가 `@Value("${vapid.public-key}")`로 이 값을 주입받으려 함
3. WebPushConfig 빈이 생성되어야 `WebPushNotificationService` 빈이 만들어지고, 그게 되어야 `PushNotificationController` 빈이 만들어짐
4. 그런데 docker run 명령어에 `-e VAPID_PUBLIC_KEY`, `-e VAPID_PRIVATE_KEY`가 빠져 있어서 컨테이너 안에 해당 환경 변수가 없음
5. **Spring이 `${VAPID_PUBLIC_KEY}`를 resolve 못해 `PlaceholderResolutionException` 발생 → 빈 생성 실패 → 서버 부팅 실패**                                                              
                                                                                                                                                                       
  ## Changes                                                                                                                                                           
  - `.github/workflows/deploy.yml`: `docker run` 명령어에 `VAPID_PUBLIC_KEY`, `VAPID_PRIVATE_KEY` 환경변수 추가