### PR TITLE
Fix: BONUS_URGENT_INGREDIENT_USE 쿠키 지급 여부 응답에 포함

### DIFF
--- a/src/main/java/com/cookeep/cookeep/api/controller/AiRecipeController.java
+++ b/src/main/java/com/cookeep/cookeep/api/controller/AiRecipeController.java
@@ -178,6 +178,7 @@ public class AiRecipeController {
             @ApiResponse(responseCode = "404", description = """
                     리소스를 찾을 수 없습니다. 다음 오류가 발생할 수 있습니다:
                     - AI_SESSION_NOT_FOUND: AI 레시피 세션을 찾을 수 없습니다.
+                    - USER_NOT_FOUND: 사용자를 찾을 수 없습니다.
                     """, content = @Content),
             @ApiResponse(responseCode = "500", description = """
                     서버 오류입니다. 다음 오류가 발생할 수 있습니다:

--- a/src/main/java/com/cookeep/cookeep/api/dto/response/AiRecipeAdoptResponseDto.java
+++ b/src/main/java/com/cookeep/cookeep/api/dto/response/AiRecipeAdoptResponseDto.java
@@ -55,4 +55,10 @@ public class AiRecipeAdoptResponseDto {
             example = "true"
     )
     private boolean recipeRewardGranted;
+
+    @Schema(
+            description = "임박 재료 사용 쿠키 지급 여부 (BONUS_URGENT_INGREDIENT_USE)",
+            example = "true"
+    )
+    private boolean urgentIngredientRewardGranted;
 }

--- a/src/main/java/com/cookeep/cookeep/domain/recipe/application/AiRecipeService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/recipe/application/AiRecipeService.java
@@ -583,9 +583,9 @@ public class AiRecipeService {
     }
 
     // 임박 식재료 레시피 채택 시 리워드 지급
-    private void grantUrgentCookieRewardIfEligible(Long userId, List<Long> ingredientIds) {
+    private boolean grantUrgentCookieRewardIfEligible(Long userId, List<Long> ingredientIds) {
         if (ingredientIds == null || ingredientIds.isEmpty()) {
-            return;
+            return false;
         }
 
         // 세션에 요청된 재료 중 leftDays == 0인 항목이 있는지 확인
@@ -593,14 +593,14 @@ public class AiRecipeService {
                 .findAllByIngredientIdInAndUser_UserId(ingredientIds, userId);
 
         if (targets.isEmpty()) {
-            return;
+            return false;
         }
 
         boolean hasUrgent = targets.stream()
                 .anyMatch(ui -> ui.getLeftDays() == URGENT);
 
         if (!hasUrgent) {
-            return;
+            return false;
         }
 
         CookieLog.CookieLogType urgentType =
@@ -615,6 +615,8 @@ public class AiRecipeService {
         } else {
             log.info("임박 재료 쿠키 오늘 이미 지급됨 - userId={}", userId);
         }
+
+        return granted;
 
     }
 

--- a/src/main/java/com/cookeep/cookeep/domain/recipe/application/AiRecipeService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/recipe/application/AiRecipeService.java
@@ -270,7 +270,7 @@ public class AiRecipeService {
         }
 
         // 7. 임박 재료(leftDays=0) 포함 세션이면 쿠키 지급 (하루 1회)
-        grantUrgentCookieRewardIfEligible(userId, ingredientIds);
+        boolean urgentRewardGranted = grantUrgentCookieRewardIfEligible(userId, ingredientIds);
 
         // 8. 요청 재료 소비 처리 후 USE_EXPIRING_INGREDIENT 주간 목표 카운트 증가
         boolean expiringGoalAchieved = consumeIngredientsAndTrackExpiringGoal(userId, ingredientIds);
@@ -285,6 +285,7 @@ public class AiRecipeService {
                 .completedAt(session.getCompletedAt())
                 .weeklyGoalAchieved(weeklyGoalAchieved)
                 .recipeRewardGranted(rewardGranted)
+                .urgentIngredientRewardGranted(urgentRewardGranted)
                 .build();
     }
 


### PR DESCRIPTION
# Issue
#220 

# Description
- 레시피 채택 시. BONUS_URGENT_INGREDIENT_USE 쿠키 지급 여부를 응답에 포함

# Changes
- AiRecipeAdoptResponseDto
   - urgentIngredientRewardGranted 필드 추가
- AiRecipeService
   - grantUrgentCookieRewardIfEligible에 쿠키 지급 여부 boolean으로 응답
   - adoptRecipe에 urgentRewardGranted 필드 추가
- 레시피 채택 관련 API 명세서 수정
- 컨트롤러에 누락된 에러코드 추가

# Test Checklist
- [x] 응답 정상 출력 확인