### PR TITLE
Refactor: 쿠키 지급 시 응답에 추가

### DIFF
--- a/src/main/java/com/cookeep/cookeep/api/dto/response/AiRecipeAdoptResponseDto.java
+++ b/src/main/java/com/cookeep/cookeep/api/dto/response/AiRecipeAdoptResponseDto.java
@@ -1,10 +1,12 @@
 package com.cookeep.cookeep.api.dto.response;
 
+import com.cookeep.cookeep.domain.cookie.entity.CookieLog;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Schema(
         name = "AiRecipeAdoptResponse",
@@ -61,4 +63,22 @@ public class AiRecipeAdoptResponseDto {
             example = "true"
     )
     private boolean urgentIngredientRewardGranted;
+
+    @Schema(description = "이번 채택으로 지급된 리워드 정보")
+    private RewardInfo reward;
+
+    @Getter
+    @Builder
+    public static class RewardInfo {
+        @Schema(description = "리워드 지급 여부", example = "true")
+        private Boolean granted;
+
+        @Schema(description = "지급된 총 쿠키 포인트", example = "4")
+        private Integer points;
+
+        @Schema(description = "지급된 쿠키 로그 타입 목록",
+                example = "[\"ONBOARDING_RECIPE\", \"BONUS_WEEKLY_GOAL_ACHIEVE\", \"BONUS_URGENT_INGREDIENT_USE\"]")
+        private List<CookieLog.CookieLogType> grantedTypes;
+    }
+
 }

--- a/src/main/java/com/cookeep/cookeep/api/dto/response/ConsumeIngredientsResponseDto.java
+++ b/src/main/java/com/cookeep/cookeep/api/dto/response/ConsumeIngredientsResponseDto.java
@@ -23,6 +23,9 @@ public class ConsumeIngredientsResponseDto {
     )
     private RewardInfo reward;
 
+    @Schema(description = "오늘 첫 소비 쿠키(BASIC_DAILY_FIRST_CONSUME) 지급 여부", example = "true")
+    private boolean dailyFirstConsumeAchieved;
+
     @Schema(description = "이번 소비로 주간 목표(COOKING) 달성 여부", example = "false")
     private boolean weeklyGoalAchieved;
 
@@ -56,6 +59,7 @@ public class ConsumeIngredientsResponseDto {
             boolean granted,
             int points,
             List<CookieLog.CookieLogType> grantedTypes,
+            boolean dailyFirstConsumeAchieved,
             boolean weeklyGoalAchieved) {
         return ConsumeIngredientsResponseDto.builder()
                 .reward(RewardInfo.builder()
@@ -63,6 +67,7 @@ public class ConsumeIngredientsResponseDto {
                         .points(points)
                         .grantedTypes(grantedTypes)
                         .build())
+                .dailyFirstConsumeAchieved(dailyFirstConsumeAchieved)
                 .weeklyGoalAchieved(weeklyGoalAchieved)
                 .build();
     }

--- a/src/main/java/com/cookeep/cookeep/api/dto/response/ConsumeIngredientsResponseDto.java
+++ b/src/main/java/com/cookeep/cookeep/api/dto/response/ConsumeIngredientsResponseDto.java
@@ -31,7 +31,7 @@ public class ConsumeIngredientsResponseDto {
     @AllArgsConstructor
     public static class RewardInfo {
         @Schema(
-                description = "오늘 리워드 지급 여부",
+                description = "리워드 지급 여부",
                 example = "true",
                 requiredMode = Schema.RequiredMode.REQUIRED
         )

--- a/src/main/java/com/cookeep/cookeep/api/dto/response/UserIngredientListCreateResponseDto.java
+++ b/src/main/java/com/cookeep/cookeep/api/dto/response/UserIngredientListCreateResponseDto.java
@@ -1,7 +1,9 @@
 package com.cookeep.cookeep.api.dto.response;
 
+import com.cookeep.cookeep.domain.cookie.entity.CookieLog;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 
 import java.util.List;
@@ -20,14 +22,42 @@ public class UserIngredientListCreateResponseDto {
     @Schema(description = "온보딩 쿠키 지급 여부", example = "true")
     private boolean ingredientRewardGranted;
 
+    @Schema(description = "이번 등록으로 지급된 리워드 정보")
+    private RewardInfo reward;
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    public static class RewardInfo {
+        @Schema(description = "리워드 지급 여부", example = "true")
+        private Boolean granted;
+
+        @Schema(description = "지급된 총 쿠키 포인트", example = "1")
+        private Integer points;
+
+        @Schema(description = "지급된 쿠키 로그 타입 목록", example = "[\"ONBOARDING_INGREDIENT\"]")
+        private List<CookieLog.CookieLogType> grantedTypes;
+    }
+
     public static UserIngredientListCreateResponseDto of(
             List<UserIngredientCreateResponseDto> ingredients,
             boolean ingredientRewardGranted) {
 
+        List<CookieLog.CookieLogType> grantedTypes = ingredientRewardGranted
+                ? List.of(CookieLog.CookieLogType.ONBOARDING_INGREDIENT)
+                : List.of();
+
+        RewardInfo rewardInfo = RewardInfo.builder()
+                .granted(ingredientRewardGranted)
+                .points(ingredientRewardGranted ? CookieLog.CookieLogType.ONBOARDING_INGREDIENT.getDefaultAmount() : 0)
+                .grantedTypes(grantedTypes)
+                .build();
+
         return new UserIngredientListCreateResponseDto(
                 ingredients,
                 ingredients.size(),
-                ingredientRewardGranted
+                ingredientRewardGranted,
+                rewardInfo
         );
     }
 

--- a/src/main/java/com/cookeep/cookeep/domain/ingredient/useringredient/application/ConsumeIngredientService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/ingredient/useringredient/application/ConsumeIngredientService.java
@@ -79,17 +79,7 @@ public class ConsumeIngredientService {
         // 6. 재료 삭제
         userIngredientRepository.deleteAll(userIngredients);
 
-        // 7. 임박 재료 1일 1회 쿠키 지급 (BONUS_URGENT_INGREDIENT_USE)
-        if (urgentCount > 0) {
-            CookieLog.CookieLogType urgentType = CookieLog.CookieLogType.BONUS_URGENT_INGREDIENT_USE;
-            boolean urgentGranted = cookieService.grantDailyCookie(userId, urgentType);
-            if (urgentGranted) {
-                grantedTypes.add(urgentType);
-                points += urgentType.getDefaultAmount();
-            }
-        }
-
-        // 8. 임박 재료 개수만큼 주간 목표(USE_EXPIRING_INGREDIENT) 카운트 증가
+        // 7. 임박 재료 개수만큼 주간 목표(USE_EXPIRING_INGREDIENT) 카운트 증가
         boolean weeklyGoalAchieved = false;
         for (int i = 0; i < urgentCount; i++) {
             // handleGoalProgress는 이미 달성된 경우 false를 반환하므로 중복 지급 없음
@@ -107,7 +97,9 @@ public class ConsumeIngredientService {
         log.info("User {} consumed {} ingredients. dailyGranted: {}, urgentCount: {}, weeklyGoalAchieved: {}",
                 userId, userIngredients.size(), dailyGranted, urgentCount, weeklyGoalAchieved);
 
-        return ConsumeIngredientsResponseDto.of(!grantedTypes.isEmpty(), points, grantedTypes, weeklyGoalAchieved);
+        return ConsumeIngredientsResponseDto.of(
+                !grantedTypes.isEmpty(), points, grantedTypes, dailyGranted, weeklyGoalAchieved);
+
     }
 
 }

--- a/src/main/java/com/cookeep/cookeep/domain/ingredient/useringredient/application/ConsumeIngredientService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/ingredient/useringredient/application/ConsumeIngredientService.java
@@ -16,7 +16,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -61,25 +60,36 @@ public class ConsumeIngredientService {
 
         // 3. 기본 일일 소비 리워드 처리
         CookieLog.CookieLogType dailyType = CookieLog.CookieLogType.BASIC_DAILY_FIRST_CONSUME;
-        boolean granted = cookieService.grantDailyCookie(userId, dailyType);
+        boolean dailyGranted = cookieService.grantDailyCookie(userId, dailyType);
 
-        int points = granted ? dailyType.getDefaultAmount() : 0;
+        int points = dailyGranted ? dailyType.getDefaultAmount() : 0;
         List<CookieLog.CookieLogType> grantedTypes = new ArrayList<>();
-        if (granted) {
+        if (dailyGranted) {
             grantedTypes.add(dailyType);
         }
 
         // 4. 주간 소비 리포트 기록 (삭제 전에 호출해야 leftDays 읽기 가능)
         consumptionReportService.markConsumed(userId, userIngredients);
 
-        // 5. 재료 삭제
-        userIngredientRepository.deleteAll(userIngredients);
-
-        // 6. 임박 재료(leftDays=0) 개수만큼 주간 목표(USE_EXPIRING_INGREDIENT) 카운트 증가
+        // 5. 임박 재료(leftDays=0) 개수만큼 주간 목표(USE_EXPIRING_INGREDIENT) 카운트 증가
         long urgentCount = userIngredients.stream()
                 .filter(ui -> ui.getLeftDays() == URGENT)
                 .count();
 
+        // 6. 재료 삭제
+        userIngredientRepository.deleteAll(userIngredients);
+
+        // 7. 임박 재료 1일 1회 쿠키 지급 (BONUS_URGENT_INGREDIENT_USE)
+        if (urgentCount > 0) {
+            CookieLog.CookieLogType urgentType = CookieLog.CookieLogType.BONUS_URGENT_INGREDIENT_USE;
+            boolean urgentGranted = cookieService.grantDailyCookie(userId, urgentType);
+            if (urgentGranted) {
+                grantedTypes.add(urgentType);
+                points += urgentType.getDefaultAmount();
+            }
+        }
+
+        // 8. 임박 재료 개수만큼 주간 목표(USE_EXPIRING_INGREDIENT) 카운트 증가
         boolean weeklyGoalAchieved = false;
         for (int i = 0; i < urgentCount; i++) {
             // handleGoalProgress는 이미 달성된 경우 false를 반환하므로 중복 지급 없음
@@ -88,11 +98,16 @@ public class ConsumeIngredientService {
             }
         }
 
-        log.info("User {} consumed {} ingredients via manual action. " +
-                        "Reward granted: {}, points: {}, urgentCount: {}, weeklyGoalAchieved: {}",
-                userId, userIngredients.size(), granted, points, urgentCount, weeklyGoalAchieved);
+        // 쿠키 타입 기록 (주간 목표 달성 쿠키는 WeeklyGoalService 내부에서 지급)
+        if (weeklyGoalAchieved) {
+            grantedTypes.add(CookieLog.CookieLogType.BONUS_WEEKLY_GOAL_ACHIEVE);
+            points += CookieLog.CookieLogType.BONUS_WEEKLY_GOAL_ACHIEVE.getDefaultAmount();
+        }
 
-        return ConsumeIngredientsResponseDto.of(granted, points, grantedTypes, weeklyGoalAchieved);
+        log.info("User {} consumed {} ingredients. dailyGranted: {}, urgentCount: {}, weeklyGoalAchieved: {}",
+                userId, userIngredients.size(), dailyGranted, urgentCount, weeklyGoalAchieved);
+
+        return ConsumeIngredientsResponseDto.of(!grantedTypes.isEmpty(), points, grantedTypes, weeklyGoalAchieved);
     }
 
 }

--- a/src/main/java/com/cookeep/cookeep/domain/recipe/application/AiRecipeService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/recipe/application/AiRecipeService.java
@@ -254,10 +254,10 @@ public class AiRecipeService {
         // 5. 레시피 채택 시 COOKING 목표 카운트 증가
         boolean cookingGoalAchieved = weeklyGoalService.handleGoalProgress(userId, GoalActionType.COOKING);
 
-        // 최초 레시피 채택 온보딩 쿠키 지급 (일회성)
+        // 6. 최초 레시피 채택 온보딩 쿠키 지급 (일회성)
         boolean rewardGranted = grantFirstRecipeRewardIfEligible(userId);
 
-        // 6. 세션의 ingredientIds 조회
+        // 7. 세션의 ingredientIds 조회
         List<Long> ingredientIds;
         try {
             ingredientIds = objectMapper.readValue(
@@ -269,14 +269,31 @@ public class AiRecipeService {
             throw new AppException(ErrorCode.INTERNAL_SERVER_ERROR);
         }
 
-        // 7. 임박 재료(leftDays=0) 포함 세션이면 쿠키 지급 (하루 1회)
+        // 8. 임박 재료(leftDays=0) 포함 세션이면 쿠키 지급 (하루 1회)
         boolean urgentRewardGranted = grantUrgentCookieRewardIfEligible(userId, ingredientIds);
 
-        // 8. 요청 재료 소비 처리 후 USE_EXPIRING_INGREDIENT 주간 목표 카운트 증가
+        // 9. 요청 재료 소비 처리 후 USE_EXPIRING_INGREDIENT 주간 목표 카운트 증가
         boolean expiringGoalAchieved = consumeIngredientsAndTrackExpiringGoal(userId, ingredientIds);
 
-        // 9. COOKING / USE_EXPIRING_INGREDIENT 중 하나라도 달성되면 weeklyGoalAchieved = true
+        // 10. COOKING / USE_EXPIRING_INGREDIENT 중 하나라도 달성되면 weeklyGoalAchieved = true
         boolean weeklyGoalAchieved = cookingGoalAchieved || expiringGoalAchieved;
+
+        // 11. RewardInfo 빌드
+        List<CookieLog.CookieLogType> grantedTypes = new java.util.ArrayList<>();
+        int totalPoints = 0;
+        if (rewardGranted) {
+            grantedTypes.add(CookieLog.CookieLogType.ONBOARDING_RECIPE);
+            totalPoints += CookieLog.CookieLogType.ONBOARDING_RECIPE.getDefaultAmount();
+        }
+        if (urgentRewardGranted) {
+            grantedTypes.add(CookieLog.CookieLogType.BONUS_URGENT_INGREDIENT_USE);
+            totalPoints += CookieLog.CookieLogType.BONUS_URGENT_INGREDIENT_USE.getDefaultAmount();
+        }
+        AiRecipeAdoptResponseDto.RewardInfo rewardInfo = AiRecipeAdoptResponseDto.RewardInfo.builder()
+                .granted(!grantedTypes.isEmpty())
+                .points(totalPoints)
+                .grantedTypes(grantedTypes)
+                .build();
 
         return AiRecipeAdoptResponseDto.builder()
                 .sessionId(session.getId())
@@ -286,6 +303,7 @@ public class AiRecipeService {
                 .weeklyGoalAchieved(weeklyGoalAchieved)
                 .recipeRewardGranted(rewardGranted)
                 .urgentIngredientRewardGranted(urgentRewardGranted)
+                .reward(rewardInfo)
                 .build();
     }
 

--- a/src/test/java/com/cookeep/cookeep/domain/ingredient/application/ConsumeIngredientServiceTest.java
+++ b/src/test/java/com/cookeep/cookeep/domain/ingredient/application/ConsumeIngredientServiceTest.java
@@ -228,6 +228,20 @@ public class ConsumeIngredientServiceTest {
         }
 
         @Test
+        @DisplayName("하루 첫 소비 시 dailyFirstConsumeAchieved=true를 반환한다")
+        void 첫소비_dailyFirstConsumeAchieved_true() {
+            given(userIngredientRepository.findAllByIngredientIdInAndUser_UserId(anyList(), anyLong()))
+                    .willReturn(List.of(buildNormalIngredient()));
+            given(cookieService.grantDailyCookie(1L, CookieLog.CookieLogType.BASIC_DAILY_FIRST_CONSUME))
+                    .willReturn(true);
+
+            ConsumeIngredientsResponseDto result =
+                    consumeIngredientService.consumeIngredients(1L, buildRequest(List.of(1L)));
+
+            assertThat(result.isDailyFirstConsumeAchieved()).isTrue();
+        }
+
+        @Test
         @DisplayName("당일 이미 지급된 경우 granted=false, points=0을 반환한다")
         void 중복소비_쿠키미지급() {
             given(userIngredientRepository.findAllByIngredientIdInAndUser_UserId(anyList(), anyLong()))
@@ -240,6 +254,20 @@ public class ConsumeIngredientServiceTest {
 
             assertThat(result.getReward().getGranted()).isFalse();
             assertThat(result.getReward().getPoints()).isZero();
+        }
+
+        @Test
+        @DisplayName("당일 이미 지급된 경우 dailyFirstConsumeAchieved=false를 반환한다")
+        void 중복소비_dailyFirstConsumeAchieved_false() {
+            given(userIngredientRepository.findAllByIngredientIdInAndUser_UserId(anyList(), anyLong()))
+                    .willReturn(List.of(buildNormalIngredient()));
+            given(cookieService.grantDailyCookie(1L, CookieLog.CookieLogType.BASIC_DAILY_FIRST_CONSUME))
+                    .willReturn(false);
+
+            ConsumeIngredientsResponseDto result =
+                    consumeIngredientService.consumeIngredients(1L, buildRequest(List.of(1L)));
+
+            assertThat(result.isDailyFirstConsumeAchieved()).isFalse();
         }
 
         @Test
@@ -287,102 +315,22 @@ public class ConsumeIngredientServiceTest {
     }
 
     @Nested
-    @DisplayName("consumeIngredients - BONUS_URGENT_INGREDIENT_USE 쿠키 지급")
-    class UrgentCookieGrant {
-
-        @Test
-        @DisplayName("임박 재료 소비 시 BONUS_URGENT_INGREDIENT_USE 쿠키 지급 시도를 1회 한다")
-        void 임박재료_소비_urgent_쿠키_지급_시도() {
-            given(userIngredientRepository.findAllByIngredientIdInAndUser_UserId(anyList(), anyLong()))
-                    .willReturn(List.of(buildUrgentIngredient()));
-
-            consumeIngredientService.consumeIngredients(1L, buildRequest(List.of(1L)));
-
-            verify(cookieService).grantDailyCookie(1L, CookieLog.CookieLogType.BONUS_URGENT_INGREDIENT_USE);
-        }
-
-        @Test
-        @DisplayName("일반 재료만 소비 시 BONUS_URGENT_INGREDIENT_USE 쿠키 지급을 시도하지 않는다")
-        void 일반재료만_소비_urgent_쿠키_미시도() {
-            given(userIngredientRepository.findAllByIngredientIdInAndUser_UserId(anyList(), anyLong()))
-                    .willReturn(List.of(buildNormalIngredient()));
-
-            consumeIngredientService.consumeIngredients(1L, buildRequest(List.of(1L)));
-
-            verify(cookieService, never()).grantDailyCookie(1L, CookieLog.CookieLogType.BONUS_URGENT_INGREDIENT_USE);
-        }
-
-        @Test
-        @DisplayName("임박 재료 소비 + BONUS_URGENT 지급 시 grantedTypes에 포함된다")
-        void 임박재료_소비_grantedTypes_포함() {
-            given(userIngredientRepository.findAllByIngredientIdInAndUser_UserId(anyList(), anyLong()))
-                    .willReturn(List.of(buildUrgentIngredient()));
-            given(cookieService.grantDailyCookie(1L, CookieLog.CookieLogType.BONUS_URGENT_INGREDIENT_USE))
-                    .willReturn(true);
-
-            ConsumeIngredientsResponseDto result =
-                    consumeIngredientService.consumeIngredients(1L, buildRequest(List.of(1L)));
-
-            assertThat(result.getReward().getGrantedTypes())
-                    .contains(CookieLog.CookieLogType.BONUS_URGENT_INGREDIENT_USE);
-        }
-
-        @Test
-        @DisplayName("임박 재료 소비했지만 오늘 이미 BONUS_URGENT 지급 시 grantedTypes에 포함되지 않는다")
-        void 임박재료_소비_오늘이미지급_grantedTypes_미포함() {
-            given(userIngredientRepository.findAllByIngredientIdInAndUser_UserId(anyList(), anyLong()))
-                    .willReturn(List.of(buildUrgentIngredient()));
-            given(cookieService.grantDailyCookie(1L, CookieLog.CookieLogType.BONUS_URGENT_INGREDIENT_USE))
-                    .willReturn(false);
-
-            ConsumeIngredientsResponseDto result =
-                    consumeIngredientService.consumeIngredients(1L, buildRequest(List.of(1L)));
-
-            assertThat(result.getReward().getGrantedTypes())
-                    .doesNotContain(CookieLog.CookieLogType.BONUS_URGENT_INGREDIENT_USE);
-        }
-
-        @Test
-        @DisplayName("임박 재료 소비 + BONUS_URGENT 지급 시 points에 3이 더해진다")
-        void 임박재료_소비_points_3추가() {
-            given(userIngredientRepository.findAllByIngredientIdInAndUser_UserId(anyList(), anyLong()))
-                    .willReturn(List.of(buildUrgentIngredient()));
-            given(cookieService.grantDailyCookie(1L, CookieLog.CookieLogType.BONUS_URGENT_INGREDIENT_USE))
-                    .willReturn(true);
-            given(cookieService.grantDailyCookie(1L, CookieLog.CookieLogType.BASIC_DAILY_FIRST_CONSUME))
-                    .willReturn(false); // 기본 미지급
-
-            ConsumeIngredientsResponseDto result =
-                    consumeIngredientService.consumeIngredients(1L, buildRequest(List.of(1L)));
-
-            assertThat(result.getReward().getPoints()).isEqualTo(3);
-        }
-    }
-
-    @Nested
     @DisplayName("consumeIngredients - RewardInfo grantedTypes 종합 검증")
     class RewardInfoGrantedTypes {
 
         @Test
-        @DisplayName("기본 리워드 + 임박 리워드 모두 지급 시 grantedTypes에 두 타입 모두 포함된다")
-        void 기본_임박_모두지급_grantedTypes_두타입() {
+        @DisplayName("기본 리워드 지급 시 grantedTypes에 BASIC_DAILY_FIRST_CONSUME이 포함된다")
+        void 기본리워드_지급_grantedTypes_포함() {
             given(userIngredientRepository.findAllByIngredientIdInAndUser_UserId(anyList(), anyLong()))
-                    .willReturn(List.of(buildUrgentIngredient()));
+                    .willReturn(List.of(buildNormalIngredient()));
             given(cookieService.grantDailyCookie(1L, CookieLog.CookieLogType.BASIC_DAILY_FIRST_CONSUME))
-                    .willReturn(true);
-            given(cookieService.grantDailyCookie(1L, CookieLog.CookieLogType.BONUS_URGENT_INGREDIENT_USE))
                     .willReturn(true);
 
             ConsumeIngredientsResponseDto result =
                     consumeIngredientService.consumeIngredients(1L, buildRequest(List.of(1L)));
 
             assertThat(result.getReward().getGrantedTypes())
-                    .containsExactlyInAnyOrder(
-                            CookieLog.CookieLogType.BASIC_DAILY_FIRST_CONSUME,
-                            CookieLog.CookieLogType.BONUS_URGENT_INGREDIENT_USE
-                    );
-            assertThat(result.getReward().getGranted()).isTrue();
-            assertThat(result.getReward().getPoints()).isEqualTo(4); // 1 + 3
+                    .containsExactly(CookieLog.CookieLogType.BASIC_DAILY_FIRST_CONSUME);
         }
 
         @Test
@@ -414,6 +362,21 @@ public class ConsumeIngredientServiceTest {
 
             assertThat(result.getReward().getGrantedTypes())
                     .contains(CookieLog.CookieLogType.BONUS_WEEKLY_GOAL_ACHIEVE);
+        }
+
+        @Test
+        @DisplayName("BONUS_URGENT_INGREDIENT_USE는 직접 소비에서 지급되지 않는다")
+        void 직접소비_BONUS_URGENT_미지급() {
+            given(userIngredientRepository.findAllByIngredientIdInAndUser_UserId(anyList(), anyLong()))
+                    .willReturn(List.of(buildUrgentIngredient()));
+
+            ConsumeIngredientsResponseDto result =
+                    consumeIngredientService.consumeIngredients(1L, buildRequest(List.of(1L)));
+
+            assertThat(result.getReward().getGrantedTypes())
+                    .doesNotContain(CookieLog.CookieLogType.BONUS_URGENT_INGREDIENT_USE);
+            verify(cookieService, never())
+                    .grantDailyCookie(anyLong(), eq(CookieLog.CookieLogType.BONUS_URGENT_INGREDIENT_USE));
         }
     }
 

--- a/src/test/java/com/cookeep/cookeep/domain/ingredient/application/ConsumeIngredientServiceTest.java
+++ b/src/test/java/com/cookeep/cookeep/domain/ingredient/application/ConsumeIngredientServiceTest.java
@@ -286,4 +286,135 @@ public class ConsumeIngredientServiceTest {
         }
     }
 
+    @Nested
+    @DisplayName("consumeIngredients - BONUS_URGENT_INGREDIENT_USE 쿠키 지급")
+    class UrgentCookieGrant {
+
+        @Test
+        @DisplayName("임박 재료 소비 시 BONUS_URGENT_INGREDIENT_USE 쿠키 지급 시도를 1회 한다")
+        void 임박재료_소비_urgent_쿠키_지급_시도() {
+            given(userIngredientRepository.findAllByIngredientIdInAndUser_UserId(anyList(), anyLong()))
+                    .willReturn(List.of(buildUrgentIngredient()));
+
+            consumeIngredientService.consumeIngredients(1L, buildRequest(List.of(1L)));
+
+            verify(cookieService).grantDailyCookie(1L, CookieLog.CookieLogType.BONUS_URGENT_INGREDIENT_USE);
+        }
+
+        @Test
+        @DisplayName("일반 재료만 소비 시 BONUS_URGENT_INGREDIENT_USE 쿠키 지급을 시도하지 않는다")
+        void 일반재료만_소비_urgent_쿠키_미시도() {
+            given(userIngredientRepository.findAllByIngredientIdInAndUser_UserId(anyList(), anyLong()))
+                    .willReturn(List.of(buildNormalIngredient()));
+
+            consumeIngredientService.consumeIngredients(1L, buildRequest(List.of(1L)));
+
+            verify(cookieService, never()).grantDailyCookie(1L, CookieLog.CookieLogType.BONUS_URGENT_INGREDIENT_USE);
+        }
+
+        @Test
+        @DisplayName("임박 재료 소비 + BONUS_URGENT 지급 시 grantedTypes에 포함된다")
+        void 임박재료_소비_grantedTypes_포함() {
+            given(userIngredientRepository.findAllByIngredientIdInAndUser_UserId(anyList(), anyLong()))
+                    .willReturn(List.of(buildUrgentIngredient()));
+            given(cookieService.grantDailyCookie(1L, CookieLog.CookieLogType.BONUS_URGENT_INGREDIENT_USE))
+                    .willReturn(true);
+
+            ConsumeIngredientsResponseDto result =
+                    consumeIngredientService.consumeIngredients(1L, buildRequest(List.of(1L)));
+
+            assertThat(result.getReward().getGrantedTypes())
+                    .contains(CookieLog.CookieLogType.BONUS_URGENT_INGREDIENT_USE);
+        }
+
+        @Test
+        @DisplayName("임박 재료 소비했지만 오늘 이미 BONUS_URGENT 지급 시 grantedTypes에 포함되지 않는다")
+        void 임박재료_소비_오늘이미지급_grantedTypes_미포함() {
+            given(userIngredientRepository.findAllByIngredientIdInAndUser_UserId(anyList(), anyLong()))
+                    .willReturn(List.of(buildUrgentIngredient()));
+            given(cookieService.grantDailyCookie(1L, CookieLog.CookieLogType.BONUS_URGENT_INGREDIENT_USE))
+                    .willReturn(false);
+
+            ConsumeIngredientsResponseDto result =
+                    consumeIngredientService.consumeIngredients(1L, buildRequest(List.of(1L)));
+
+            assertThat(result.getReward().getGrantedTypes())
+                    .doesNotContain(CookieLog.CookieLogType.BONUS_URGENT_INGREDIENT_USE);
+        }
+
+        @Test
+        @DisplayName("임박 재료 소비 + BONUS_URGENT 지급 시 points에 3이 더해진다")
+        void 임박재료_소비_points_3추가() {
+            given(userIngredientRepository.findAllByIngredientIdInAndUser_UserId(anyList(), anyLong()))
+                    .willReturn(List.of(buildUrgentIngredient()));
+            given(cookieService.grantDailyCookie(1L, CookieLog.CookieLogType.BONUS_URGENT_INGREDIENT_USE))
+                    .willReturn(true);
+            given(cookieService.grantDailyCookie(1L, CookieLog.CookieLogType.BASIC_DAILY_FIRST_CONSUME))
+                    .willReturn(false); // 기본 미지급
+
+            ConsumeIngredientsResponseDto result =
+                    consumeIngredientService.consumeIngredients(1L, buildRequest(List.of(1L)));
+
+            assertThat(result.getReward().getPoints()).isEqualTo(3);
+        }
+    }
+
+    @Nested
+    @DisplayName("consumeIngredients - RewardInfo grantedTypes 종합 검증")
+    class RewardInfoGrantedTypes {
+
+        @Test
+        @DisplayName("기본 리워드 + 임박 리워드 모두 지급 시 grantedTypes에 두 타입 모두 포함된다")
+        void 기본_임박_모두지급_grantedTypes_두타입() {
+            given(userIngredientRepository.findAllByIngredientIdInAndUser_UserId(anyList(), anyLong()))
+                    .willReturn(List.of(buildUrgentIngredient()));
+            given(cookieService.grantDailyCookie(1L, CookieLog.CookieLogType.BASIC_DAILY_FIRST_CONSUME))
+                    .willReturn(true);
+            given(cookieService.grantDailyCookie(1L, CookieLog.CookieLogType.BONUS_URGENT_INGREDIENT_USE))
+                    .willReturn(true);
+
+            ConsumeIngredientsResponseDto result =
+                    consumeIngredientService.consumeIngredients(1L, buildRequest(List.of(1L)));
+
+            assertThat(result.getReward().getGrantedTypes())
+                    .containsExactlyInAnyOrder(
+                            CookieLog.CookieLogType.BASIC_DAILY_FIRST_CONSUME,
+                            CookieLog.CookieLogType.BONUS_URGENT_INGREDIENT_USE
+                    );
+            assertThat(result.getReward().getGranted()).isTrue();
+            assertThat(result.getReward().getPoints()).isEqualTo(4); // 1 + 3
+        }
+
+        @Test
+        @DisplayName("아무 리워드도 지급되지 않으면 granted=false이고 grantedTypes는 비어있다")
+        void 미지급_granted_false_grantedTypes_empty() {
+            given(userIngredientRepository.findAllByIngredientIdInAndUser_UserId(anyList(), anyLong()))
+                    .willReturn(List.of(buildNormalIngredient()));
+            given(cookieService.grantDailyCookie(1L, CookieLog.CookieLogType.BASIC_DAILY_FIRST_CONSUME))
+                    .willReturn(false);
+
+            ConsumeIngredientsResponseDto result =
+                    consumeIngredientService.consumeIngredients(1L, buildRequest(List.of(1L)));
+
+            assertThat(result.getReward().getGranted()).isFalse();
+            assertThat(result.getReward().getGrantedTypes()).isEmpty();
+            assertThat(result.getReward().getPoints()).isZero();
+        }
+
+        @Test
+        @DisplayName("주간 목표 달성 시 BONUS_WEEKLY_GOAL_ACHIEVE가 grantedTypes에 포함된다")
+        void 주간목표_달성_grantedTypes_포함() {
+            given(userIngredientRepository.findAllByIngredientIdInAndUser_UserId(anyList(), anyLong()))
+                    .willReturn(List.of(buildUrgentIngredient()));
+            given(weeklyGoalService.handleGoalProgress(1L, GoalActionType.USE_EXPIRING_INGREDIENT))
+                    .willReturn(true);
+
+            ConsumeIngredientsResponseDto result =
+                    consumeIngredientService.consumeIngredients(1L, buildRequest(List.of(1L)));
+
+            assertThat(result.getReward().getGrantedTypes())
+                    .contains(CookieLog.CookieLogType.BONUS_WEEKLY_GOAL_ACHIEVE);
+        }
+    }
+
 }

--- a/src/test/java/com/cookeep/cookeep/domain/ingredient/application/UserIngredientServiceRewardTest.java
+++ b/src/test/java/com/cookeep/cookeep/domain/ingredient/application/UserIngredientServiceRewardTest.java
@@ -1,0 +1,207 @@
+package com.cookeep.cookeep.domain.ingredient.application;
+
+import com.cookeep.cookeep.api.dto.request.UserIngredientCreateRequestDto;
+import com.cookeep.cookeep.api.dto.response.UserIngredientListCreateResponseDto;
+import com.cookeep.cookeep.domain.cookie.application.CookieService;
+import com.cookeep.cookeep.domain.cookie.entity.CookieLog;
+import com.cookeep.cookeep.domain.ingredient.common.domain.Storage;
+import com.cookeep.cookeep.domain.ingredient.common.domain.Type;
+import com.cookeep.cookeep.domain.ingredient.common.domain.Unit;
+import com.cookeep.cookeep.domain.ingredient.customingredient.dao.CustomIngredientRepository;
+import com.cookeep.cookeep.domain.ingredient.defaultingredient.dao.DefaultIngredientRepository;
+import com.cookeep.cookeep.domain.ingredient.defaultingredient.entity.DefaultIngredient;
+import com.cookeep.cookeep.domain.ingredient.useringredient.application.RecentIngredientService;
+import com.cookeep.cookeep.domain.ingredient.useringredient.application.UserIngredientServiceImpl;
+import com.cookeep.cookeep.domain.ingredient.useringredient.dao.UserIngredientRepository;
+import com.cookeep.cookeep.domain.ingredient.useringredient.entity.UserIngredient;
+import com.cookeep.cookeep.domain.mycookeep.application.ConsumptionReportService;
+import com.cookeep.cookeep.domain.user.dao.UserRepository;
+import com.cookeep.cookeep.domain.user.entity.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class UserIngredientServiceRewardTest {
+
+    @Mock private UserIngredientRepository userIngredientRepository;
+    @Mock private DefaultIngredientRepository defaultIngredientRepository;
+    @Mock private ConsumptionReportService consumptionReportService;
+    @Mock private UserRepository userRepository;
+    @Mock private RecentIngredientService recentIngredientService;
+    @Mock private CookieService cookieService;
+
+    @InjectMocks
+    private UserIngredientServiceImpl userIngredientService;
+
+    private User firstTimeUser;   // ONBOARDING_INGREDIENT 미지급 상태
+    private User rewardedUser;    // ONBOARDING_INGREDIENT 이미 지급 상태
+    private DefaultIngredient defaultIngredient;
+
+    @BeforeEach
+    void setUp() {
+        firstTimeUser = User.builder()
+                .nickname("신규유저")
+                .isFirstIngredientReward(false)
+                .build();
+
+        rewardedUser = User.builder()
+                .nickname("기존유저")
+                .isFirstIngredientReward(true)
+                .build();
+
+        defaultIngredient = mock(DefaultIngredient.class);
+        given(defaultIngredient.getId()).willReturn(1L);
+        given(defaultIngredient.getIngredient()).willReturn("양파");
+        given(defaultIngredient.getImageUrl()).willReturn("https://example.com/onion.png");
+        given(defaultIngredient.getUnit()).willReturn(Unit.PIECE);
+        given(defaultIngredient.getDefaultStorage()).willReturn(Storage.FRIDGE);
+        given(defaultIngredient.getDefaultExpirationDays()).willReturn(7);
+
+        given(defaultIngredientRepository.findById(1L)).willReturn(Optional.of(defaultIngredient));
+        given(userIngredientRepository.save(any(UserIngredient.class)))
+                .willAnswer(inv -> inv.getArgument(0));
+        doNothing().when(consumptionReportService).createLogForNewIngredient(any(), any());
+        doNothing().when(recentIngredientService).saveBatch(anyLong(), any());
+    }
+
+    private UserIngredientCreateRequestDto buildRequest() {
+        UserIngredientCreateRequestDto req = new UserIngredientCreateRequestDto();
+        ReflectionTestUtils.setField(req, "type", Type.DEFAULT);
+        ReflectionTestUtils.setField(req, "referenceId", 1L);
+        return req;
+    }
+
+    @Nested
+    @DisplayName("createAll - ONBOARDING_INGREDIENT 쿠키 지급 검증")
+    class OnboardingIngredientReward {
+
+        @Test
+        @DisplayName("최초 식재료 등록 시 ingredientRewardGranted=true를 반환한다")
+        void 최초등록_ingredientRewardGranted_true() {
+            given(userRepository.findById(anyLong())).willReturn(Optional.of(firstTimeUser));
+
+            UserIngredientListCreateResponseDto result =
+                    userIngredientService.createAll(1L, List.of(buildRequest()));
+
+            assertThat(result.isIngredientRewardGranted()).isTrue();
+        }
+
+        @Test
+        @DisplayName("최초 식재료 등록 시 RewardInfo.granted=true를 반환한다")
+        void 최초등록_RewardInfo_granted_true() {
+            given(userRepository.findById(anyLong())).willReturn(Optional.of(firstTimeUser));
+
+            UserIngredientListCreateResponseDto result =
+                    userIngredientService.createAll(1L, List.of(buildRequest()));
+
+            assertThat(result.getReward()).isNotNull();
+            assertThat(result.getReward().getGranted()).isTrue();
+        }
+
+        @Test
+        @DisplayName("최초 식재료 등록 시 RewardInfo.grantedTypes에 ONBOARDING_INGREDIENT가 포함된다")
+        void 최초등록_RewardInfo_grantedTypes_포함() {
+            given(userRepository.findById(anyLong())).willReturn(Optional.of(firstTimeUser));
+
+            UserIngredientListCreateResponseDto result =
+                    userIngredientService.createAll(1L, List.of(buildRequest()));
+
+            assertThat(result.getReward().getGrantedTypes())
+                    .containsExactly(CookieLog.CookieLogType.ONBOARDING_INGREDIENT);
+        }
+
+        @Test
+        @DisplayName("최초 식재료 등록 시 RewardInfo.points=1을 반환한다")
+        void 최초등록_RewardInfo_points_1() {
+            given(userRepository.findById(anyLong())).willReturn(Optional.of(firstTimeUser));
+
+            UserIngredientListCreateResponseDto result =
+                    userIngredientService.createAll(1L, List.of(buildRequest()));
+
+            assertThat(result.getReward().getPoints()).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("이미 보상을 받은 유저는 ingredientRewardGranted=false를 반환한다")
+        void 기존유저_ingredientRewardGranted_false() {
+            given(userRepository.findById(anyLong())).willReturn(Optional.of(rewardedUser));
+
+            UserIngredientListCreateResponseDto result =
+                    userIngredientService.createAll(1L, List.of(buildRequest()));
+
+            assertThat(result.isIngredientRewardGranted()).isFalse();
+        }
+
+        @Test
+        @DisplayName("이미 보상을 받은 유저는 RewardInfo.granted=false를 반환한다")
+        void 기존유저_RewardInfo_granted_false() {
+            given(userRepository.findById(anyLong())).willReturn(Optional.of(rewardedUser));
+
+            UserIngredientListCreateResponseDto result =
+                    userIngredientService.createAll(1L, List.of(buildRequest()));
+
+            assertThat(result.getReward().getGranted()).isFalse();
+        }
+
+        @Test
+        @DisplayName("이미 보상을 받은 유저는 RewardInfo.grantedTypes가 비어있다")
+        void 기존유저_RewardInfo_grantedTypes_empty() {
+            given(userRepository.findById(anyLong())).willReturn(Optional.of(rewardedUser));
+
+            UserIngredientListCreateResponseDto result =
+                    userIngredientService.createAll(1L, List.of(buildRequest()));
+
+            assertThat(result.getReward().getGrantedTypes()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("이미 보상을 받은 유저는 RewardInfo.points=0을 반환한다")
+        void 기존유저_RewardInfo_points_0() {
+            given(userRepository.findById(anyLong())).willReturn(Optional.of(rewardedUser));
+
+            UserIngredientListCreateResponseDto result =
+                    userIngredientService.createAll(1L, List.of(buildRequest()));
+
+            assertThat(result.getReward().getPoints()).isZero();
+        }
+
+        @Test
+        @DisplayName("최초 등록 시 cookieService.updateCookie가 ONBOARDING_INGREDIENT 타입으로 호출된다")
+        void 최초등록_cookieService_호출() {
+            given(userRepository.findById(anyLong())).willReturn(Optional.of(firstTimeUser));
+
+            userIngredientService.createAll(1L, List.of(buildRequest()));
+
+            verify(cookieService).updateCookie(1L, CookieLog.CookieLogType.ONBOARDING_INGREDIENT);
+        }
+
+        @Test
+        @DisplayName("이미 보상을 받은 유저는 cookieService.updateCookie가 호출되지 않는다")
+        void 기존유저_cookieService_미호출() {
+            given(userRepository.findById(anyLong())).willReturn(Optional.of(rewardedUser));
+
+            userIngredientService.createAll(1L, List.of(buildRequest()));
+
+            verify(cookieService, never()).updateCookie(anyLong(), any());
+        }
+    }
+}

--- a/src/test/java/com/cookeep/cookeep/domain/ingredient/application/UserIngredientServiceRewardTest.java
+++ b/src/test/java/com/cookeep/cookeep/domain/ingredient/application/UserIngredientServiceRewardTest.java
@@ -29,6 +29,7 @@ import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -59,12 +60,12 @@ public class UserIngredientServiceRewardTest {
     @BeforeEach
     void setUp() {
         firstTimeUser = User.builder()
-                .nickname("신규유저")
+                .userId(1L)
                 .isFirstIngredientReward(false)
                 .build();
 
         rewardedUser = User.builder()
-                .nickname("기존유저")
+                .userId(1L)
                 .isFirstIngredientReward(true)
                 .build();
 
@@ -78,7 +79,11 @@ public class UserIngredientServiceRewardTest {
 
         given(defaultIngredientRepository.findById(1L)).willReturn(Optional.of(defaultIngredient));
         given(userIngredientRepository.save(any(UserIngredient.class)))
-                .willAnswer(inv -> inv.getArgument(0));
+                .willAnswer(inv -> {
+                    UserIngredient entity = inv.getArgument(0);
+                    ReflectionTestUtils.setField(entity, "createdAt", LocalDateTime.now());
+                    return entity;
+                });
         doNothing().when(consumptionReportService).createLogForNewIngredient(any(), any());
         doNothing().when(recentIngredientService).saveBatch(anyLong(), any());
     }

--- a/src/test/java/com/cookeep/cookeep/domain/recipe/application/AiRecipeServiceTest.java
+++ b/src/test/java/com/cookeep/cookeep/domain/recipe/application/AiRecipeServiceTest.java
@@ -4,6 +4,7 @@ import com.cookeep.cookeep.api.dto.response.AiRecipeAdoptResponseDto;
 import com.cookeep.cookeep.common.exception.AppException;
 import com.cookeep.cookeep.common.exception.ErrorCode;
 import com.cookeep.cookeep.domain.cookie.application.CookieService;
+import com.cookeep.cookeep.domain.cookie.entity.CookieLog;
 import com.cookeep.cookeep.domain.dailyrecipe.dao.DailyRecipeRepository;
 import com.cookeep.cookeep.domain.ingredient.common.domain.Storage;
 import com.cookeep.cookeep.domain.ingredient.common.domain.Type;
@@ -19,6 +20,7 @@ import com.cookeep.cookeep.domain.recipe.dao.AiMessageRepository;
 import com.cookeep.cookeep.domain.recipe.dao.AiRecipeRepository;
 import com.cookeep.cookeep.domain.recipe.dao.AiSessionRepository;
 import com.cookeep.cookeep.domain.recipe.entity.*;
+import com.cookeep.cookeep.domain.user.application.UserReader;
 import com.cookeep.cookeep.domain.user.dao.UserRepository;
 import com.cookeep.cookeep.domain.user.entity.User;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -63,6 +65,7 @@ public class AiRecipeServiceTest {
     @Mock private WeeklyGoalService weeklyGoalService;
     @Mock private AiRateLimitService rateLimitService;
     @Mock private UserRepository userRepository;
+    @Mock private UserReader userReader;
 
     @Spy
     private ObjectMapper objectMapper = new ObjectMapper();
@@ -92,6 +95,9 @@ public class AiRecipeServiceTest {
     @BeforeEach
     void setUp() throws Exception {
         user = User.builder().nickname("테스터").build();
+
+        given(userReader.readById(anyLong()))
+                .willReturn(user);
 
         given(userRepository.findById(anyLong()))
                 .willReturn(Optional.of(user));
@@ -271,57 +277,73 @@ public class AiRecipeServiceTest {
     }
 
     @Nested
-    @DisplayName("adoptRecipe - COOKING + USE_EXPIRING_INGREDIENT 조합")
-    class BothGoals {
+    @DisplayName("adoptRecipe - RewardInfo 검증")
+    class AdoptRecipeRewardInfo {
 
         @Test
-        @DisplayName("COOKING만 달성 시 weeklyGoalAchieved=true를 반환한다")
-        void COOKING만_달성_true() {
+        @DisplayName("ONBOARDING_RECIPE 최초 지급 시 RewardInfo에 포함된다")
+        void ONBOARDING_RECIPE_지급_RewardInfo_포함() {
             given(userIngredientRepository.findAllByIngredientIdInAndUser_UserId(anyList(), eq(1L)))
                     .willReturn(List.of(buildNormalIngredient()));
-            given(weeklyGoalService.handleGoalProgress(1L, GoalActionType.COOKING)).willReturn(true);
+            // grantFirstRecipeRewardIfEligible가 true를 반환하려면 user.isFirstRecipeReward()=false이어야 함
+            // setUp의 user는 isFirstRecipeReward=false (기본값)
 
             AiRecipeAdoptResponseDto result = aiRecipeService.adoptRecipe(1L, 10L);
 
-            assertThat(result.isWeeklyGoalAchieved()).isTrue();
+            assertThat(result.getReward()).isNotNull();
+            assertThat(result.getReward().getGrantedTypes())
+                    .contains(CookieLog.CookieLogType.ONBOARDING_RECIPE);
+            assertThat(result.isRecipeRewardGranted()).isTrue();
         }
 
         @Test
-        @DisplayName("USE_EXPIRING만 달성 시 weeklyGoalAchieved=true를 반환한다")
-        void USE_EXPIRING만_달성_true() {
+        @DisplayName("임박 재료 포함 + BONUS_URGENT 지급 시 RewardInfo에 포함된다")
+        void BONUS_URGENT_지급_RewardInfo_포함() {
             given(userIngredientRepository.findAllByIngredientIdInAndUser_UserId(anyList(), eq(1L)))
                     .willReturn(List.of(buildUrgentIngredient()));
-            given(weeklyGoalService.handleGoalProgress(1L, GoalActionType.COOKING)).willReturn(false);
-            given(weeklyGoalService.handleGoalProgress(1L, GoalActionType.USE_EXPIRING_INGREDIENT)).willReturn(true);
+            given(cookieService.grantDailyCookie(1L, CookieLog.CookieLogType.BONUS_URGENT_INGREDIENT_USE))
+                    .willReturn(true);
 
             AiRecipeAdoptResponseDto result = aiRecipeService.adoptRecipe(1L, 10L);
 
-            assertThat(result.isWeeklyGoalAchieved()).isTrue();
+            assertThat(result.getReward().getGrantedTypes())
+                    .contains(CookieLog.CookieLogType.BONUS_URGENT_INGREDIENT_USE);
+            assertThat(result.isUrgentIngredientRewardGranted()).isTrue();
         }
 
         @Test
-        @DisplayName("COOKING과 USE_EXPIRING 모두 달성 시 weeklyGoalAchieved=true를 반환한다")
-        void 둘다_달성_true() {
-            given(userIngredientRepository.findAllByIngredientIdInAndUser_UserId(anyList(), eq(1L)))
-                    .willReturn(List.of(buildUrgentIngredient()));
-            given(weeklyGoalService.handleGoalProgress(1L, GoalActionType.COOKING)).willReturn(true);
-            given(weeklyGoalService.handleGoalProgress(1L, GoalActionType.USE_EXPIRING_INGREDIENT)).willReturn(true);
-
-            AiRecipeAdoptResponseDto result = aiRecipeService.adoptRecipe(1L, 10L);
-
-            assertThat(result.isWeeklyGoalAchieved()).isTrue();
-        }
-
-        @Test
-        @DisplayName("COOKING과 USE_EXPIRING 모두 미달성 시 weeklyGoalAchieved=false를 반환한다")
-        void 둘다_미달성_false() {
+        @DisplayName("아무 리워드도 없으면 RewardInfo.granted=false이고 grantedTypes는 비어있다")
+        void 미지급_RewardInfo_granted_false() {
+            // user.isFirstRecipeReward=true 상태 모킹 (이미 받은 상태)
+            User rewardedUser = User.builder()
+                    .nickname("테스터")
+                    .isFirstRecipeReward(true)
+                    .build();
+            given(userReader.readById(anyLong()))
+                    .willReturn(rewardedUser);
             given(userIngredientRepository.findAllByIngredientIdInAndUser_UserId(anyList(), eq(1L)))
                     .willReturn(List.of(buildNormalIngredient()));
-            // 기본값이 false이므로 별도 stubbing 불필요
 
             AiRecipeAdoptResponseDto result = aiRecipeService.adoptRecipe(1L, 10L);
 
-            assertThat(result.isWeeklyGoalAchieved()).isFalse();
+            assertThat(result.getReward().getGranted()).isFalse();
+            assertThat(result.getReward().getGrantedTypes()).isEmpty();
+            assertThat(result.getReward().getPoints()).isZero();
+        }
+
+        @Test
+        @DisplayName("ONBOARDING_RECIPE + BONUS_URGENT 모두 지급 시 points 합산이 맞다")
+        void 두개_지급_points_합산() {
+            given(userIngredientRepository.findAllByIngredientIdInAndUser_UserId(anyList(), eq(1L)))
+                    .willReturn(List.of(buildUrgentIngredient()));
+            given(cookieService.grantDailyCookie(1L, CookieLog.CookieLogType.BONUS_URGENT_INGREDIENT_USE))
+                    .willReturn(true);
+
+            AiRecipeAdoptResponseDto result = aiRecipeService.adoptRecipe(1L, 10L);
+
+            // ONBOARDING_RECIPE(1) + BONUS_URGENT(3) = 4
+            assertThat(result.getReward().getPoints()).isEqualTo(4);
+            assertThat(result.getReward().getGranted()).isTrue();
         }
     }
 


### PR DESCRIPTION
# Issue
#222 

# Description
쿠키 보상 응답 구조가 API마다 불일치하여 클라이언트 해석이 어려운 문제를 해결하기 위해,
모든 보상 응답을 RewardInfo(granted, points, grantedTypes) 형태로 통일했습니다.
또한 각 API별 쿠키 지급 정책을 명확히 반영하도록 서비스 로직과 테스트를 정비했습니다.

# Changes
### 1. 응답 구조 통일 (RewardInfo 도입)
- AiRecipeAdoptResponseDto → RewardInfo 추가
- UserIngredientListCreateResponseDto → RewardInfo 추가
- ConsumeIngredientsResponseDto
   - granted 의미를 “실제 지급 여부” 기준으로 명확화
   - grantedTypes 실제 지급된 쿠키 타입만 포함하도록 수정
   - dailyFirstConsumeAchieved 필드 추가
### 2. 서비스 및 테스트 정비
- 각 서비스에서 실제 지급된 쿠키 기준으로 RewardInfo 구성하도록 수정
- API별 쿠키 정책 명확화 및 반영
   - 식재료 등록 → ONBOARDING_INGREDIENT 1회 지급
   - 재료 소비 → BASIC_DAILY_FIRST_CONSUME, BONUS_WEEKLY_GOAL_ACHIEVE
   - 레시피 채택 → ONBOARDING_RECIPE, BONUS_URGENT_INGREDIENT_USE
- 테스트 코드 전면 수정
   - granted / points / grantedTypes 검증 추가
   - 중복 지급 방지 및 미지급 케이스 검증 강화
   - API별 쿠키 정책과 테스트 일치하도록 정리

# Test Checklist
## 1. 식재료 등록 (UserIngredientService)
### ONBOARDING_INGREDIENT 쿠키
- [x] 최초 식재료 등록 시 ONBOARDING_INGREDIENT 쿠키가 1회 지급된다
- [x] 지급 시
   - RewardInfo.granted = true
   - RewardInfo.points = 1
   - RewardInfo.grantedTypes = [ONBOARDING_INGREDIENT]
- [x] cookieService.updateCookie(userId, ONBOARDING_INGREDIENT) 호출됨
- [x] 이미 지급된 유저는
   - 쿠키 재지급되지 않음
   - granted = false, points = 0, grantedTypes = empty
   - cookieService.updateCookie 호출되지 않음

## 2. 재료 소비 (ConsumeIngredientService)
### BASIC_DAILY_FIRST_CONSUME 쿠키
- [x] 하루 첫 재료 소비 시
   - BASIC_DAILY_FIRST_CONSUME 쿠키 지급 시도
   - 지급 성공 시:
      - granted = true
      - points = 1
      - grantedTypes에 포함
- [x] 이미 당일 지급된 경우:
   - granted = false
   - points = 0
   - grantedTypes = empty
### BONUS_WEEKLY_GOAL_ACHIEVE 쿠키
- [x] 임박 재료 소비로 주간 목표 달성 시:
   - BONUS_WEEKLY_GOAL_ACHIEVE가 grantedTypes에 포함됨
   - points에 해당 값 추가됨
### BONUS_URGENT_INGREDIENT_USE 정책
- [x] 재료 소비 API에서는 지급되지 않음
- [x]  cookieService.grantDailyCookie(... BONUS_URGENT ...) 호출되지 않음

## 3. 레시피 채택 (AiRecipeService)
### ONBOARDING_RECIPE 쿠키
- [x] 최초 레시피 채택 시
   - ONBOARDING_RECIPE 쿠키 지급
   - RewardInfo.grantedTypes에 포함
   - recipeRewardGranted = true
### BONUS_URGENT_INGREDIENT_USE 쿠키
- [x] 레시피 채택 시 임박 재료 포함 + 지급 조건 만족 시
   - BONUS_URGENT_INGREDIENT_USE 쿠키 지급
   - urgentIngredientRewardGranted = true
  - grantedTypes에 포함됨
### 복합 지급
- [x] ONBOARDING + BONUS_URGENT 동시 지급 가능
- [x] points는 합산된다
   - ex) 1 + 3 = 4
### 미지급 케이스
- [x] 모든 조건 불충족 시:
   - granted = false
   - points = 0
   - grantedTypes = empty