### PR TITLE
Fix: 웹 푸시 알림 스케줄러 구현

### DIFF
--- a/src/main/java/com/cookeep/cookeep/api/controller/PushNotificationController.java
+++ b/src/main/java/com/cookeep/cookeep/api/controller/PushNotificationController.java
@@ -64,42 +64,42 @@ public class PushNotificationController {
         return ResponseEntity.ok(DataResponse.from(response));
     }
 
-    @Operation(
-            summary = "2. 유통기한 임박 웹 팝업 알림 전송",
-            description = """
-                    유통기한이 당일(D-0)인 식재료가 있는 경우 웹 푸시 알림을 전송합니다.
-                    
-                    **전송 조건 (모두 충족 시 전송)**
-                    1. 마케팅 수신 동의(marketingConsent) = true
-                    2. 냉장고 속 leftDays = 0 인 식재료 존재
-                    3. 서버에 구독 정보(WebPushSubscription) 존재
-                    
-                    - 조건 미충족 시 sent = false 반환 (에러 아님)
-                    - 만료된 구독(410/404 응답)은 자동 삭제
-                    - 알림 타입: EXPIRATION (유통기한 임박)
-                    """
-    )
-    @ApiErrorCodeExamples({
-            ErrorCode.UNAUTHORIZED,
-            ErrorCode.USER_NOT_FOUND,
-            ErrorCode.SUBSCRIPTION_NOT_FOUND,
-            ErrorCode.INTERNAL_SERVER_ERROR
-    })
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "알림 전송 성공 또는 전송 조건 미충족 (sent 필드로 구분)"),
-            @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content),
-            @ApiResponse(responseCode = "404", description = """
-                    리소스를 찾을 수 없습니다.
-                    - USER_NOT_FOUND: 사용자 없음
-                    - SUBSCRIPTION_NOT_FOUND: 구독 없음
-                    """, content = @Content),
-            @ApiResponse(responseCode = "500", description = "서버 오류", content = @Content)
-    })
-    @PostMapping("/web/push/notifications")
-    public ResponseEntity<DataResponse<WebPushSendResponseDto>> sendAlert(
-            @AuthenticationPrincipal(expression = "userId") Long userId
-    ) {
-        WebPushSendResponseDto response = webPushNotificationService.sendExpirationAlert(userId);
-        return ResponseEntity.ok(DataResponse.from(response));
-    }
+//    @Operation(
+//            summary = "2. 유통기한 임박 웹 팝업 알림 전송",
+//            description = """
+//                    유통기한이 당일(D-0)인 식재료가 있는 경우 웹 푸시 알림을 전송합니다.
+//
+//                    **전송 조건 (모두 충족 시 전송)**
+//                    1. 마케팅 수신 동의(marketingConsent) = true
+//                    2. 냉장고 속 leftDays = 0 인 식재료 존재
+//                    3. 서버에 구독 정보(WebPushSubscription) 존재
+//
+//                    - 조건 미충족 시 sent = false 반환 (에러 아님)
+//                    - 만료된 구독(410/404 응답)은 자동 삭제
+//                    - 알림 타입: EXPIRATION (유통기한 임박)
+//                    """
+//    )
+//    @ApiErrorCodeExamples({
+//            ErrorCode.UNAUTHORIZED,
+//            ErrorCode.USER_NOT_FOUND,
+//            ErrorCode.SUBSCRIPTION_NOT_FOUND,
+//            ErrorCode.INTERNAL_SERVER_ERROR
+//    })
+//    @ApiResponses(value = {
+//            @ApiResponse(responseCode = "200", description = "알림 전송 성공 또는 전송 조건 미충족 (sent 필드로 구분)"),
+//            @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content),
+//            @ApiResponse(responseCode = "404", description = """
+//                    리소스를 찾을 수 없습니다.
+//                    - USER_NOT_FOUND: 사용자 없음
+//                    - SUBSCRIPTION_NOT_FOUND: 구독 없음
+//                    """, content = @Content),
+//            @ApiResponse(responseCode = "500", description = "서버 오류", content = @Content)
+//    })
+//    @PostMapping("/web/push/notifications")
+//    public ResponseEntity<DataResponse<WebPushSendResponseDto>> sendAlert(
+//            @AuthenticationPrincipal(expression = "userId") Long userId
+//    ) {
+//        WebPushSendResponseDto response = webPushNotificationService.sendExpirationAlert(userId);
+//        return ResponseEntity.ok(DataResponse.from(response));
+//    }
 }

--- a/src/main/java/com/cookeep/cookeep/api/dto/response/WebPushSendResponseDto.java
+++ b/src/main/java/com/cookeep/cookeep/api/dto/response/WebPushSendResponseDto.java
@@ -38,4 +38,9 @@ public class WebPushSendResponseDto {
         return new WebPushSendResponseDto(false, "유효한 구독이 없어 알림을 전송하지 못했습니다.");
     }
 
+    // 구독 정보 없음
+    public static WebPushSendResponseDto noSubscription() {
+        return new WebPushSendResponseDto(false, "구독 정보가 없습니다.");
+    }
+
 }

--- a/src/main/java/com/cookeep/cookeep/domain/ingredient/useringredient/application/UserIngredientScheduler.java
+++ b/src/main/java/com/cookeep/cookeep/domain/ingredient/useringredient/application/UserIngredientScheduler.java
@@ -24,6 +24,7 @@ public class UserIngredientScheduler {
 
     private final UserIngredientRepository userIngredientRepository;
     private final ConsumptionReportService consumptionReportService;
+    private final WebPushNotificationService webPushNotificationService;
 
     /**
      * 매일 자정(00:00)에 모든 식재료의 남은 일수(leftDays) 업데이트
@@ -62,9 +63,6 @@ public class UserIngredientScheduler {
             // 에러가 발생해도 스케줄러는 계속 실행되어야 함
         }
     }
-
-    @Autowired
-    private WebPushNotificationService webPushNotificationService;
 
     @Scheduled(cron = "0 0 9 * * *", zone = "Asia/Seoul")
     public void sendDailyExpirationPush() {

--- a/src/main/java/com/cookeep/cookeep/domain/ingredient/useringredient/application/UserIngredientScheduler.java
+++ b/src/main/java/com/cookeep/cookeep/domain/ingredient/useringredient/application/UserIngredientScheduler.java
@@ -64,7 +64,7 @@ public class UserIngredientScheduler {
         }
     }
 
-    @Scheduled(cron = "0 0 9 * * *", zone = "Asia/Seoul")
+    @Scheduled(cron = "0 0 11 * * *", zone = "Asia/Seoul")
     public void sendDailyExpirationPush() {
         log.info("=== Starting daily expiration push notification ===");
 

--- a/src/main/java/com/cookeep/cookeep/domain/ingredient/useringredient/application/UserIngredientScheduler.java
+++ b/src/main/java/com/cookeep/cookeep/domain/ingredient/useringredient/application/UserIngredientScheduler.java
@@ -3,8 +3,10 @@ package com.cookeep.cookeep.domain.ingredient.useringredient.application;
 import com.cookeep.cookeep.domain.ingredient.useringredient.dao.UserIngredientRepository;
 import com.cookeep.cookeep.domain.ingredient.useringredient.entity.UserIngredient;
 import com.cookeep.cookeep.domain.mycookeep.application.ConsumptionReportService;
+import com.cookeep.cookeep.domain.notification.application.WebPushNotificationService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -59,6 +61,29 @@ public class UserIngredientScheduler {
             log.error("=== Error updating leftDays ===", e);
             // 에러가 발생해도 스케줄러는 계속 실행되어야 함
         }
+    }
+
+    @Autowired
+    private WebPushNotificationService webPushNotificationService;
+
+    @Scheduled(cron = "0 0 9 * * *", zone = "Asia/Seoul")
+    public void sendDailyExpirationPush() {
+        log.info("=== Starting daily expiration push notification ===");
+
+        List<Long> targetUserIds = userIngredientRepository
+                .findUserIdsWithExpiringTodayAndMarketingConsent(LocalDate.now());
+
+        log.info("푸시 알림 대상 유저 수: {}", targetUserIds.size());
+
+        for (Long userId : targetUserIds) {
+            try {
+                webPushNotificationService.sendExpirationAlert(userId);
+            } catch (Exception e) {
+                log.error("푸시 알림 전송 실패. userId={}, error={}", userId, e.getMessage());
+            }
+        }
+
+        log.info("=== 푸시 알림 전송 완료 ===");
     }
 
     /**

--- a/src/main/java/com/cookeep/cookeep/domain/ingredient/useringredient/dao/UserIngredientRepository.java
+++ b/src/main/java/com/cookeep/cookeep/domain/ingredient/useringredient/dao/UserIngredientRepository.java
@@ -15,29 +15,6 @@ import java.util.Optional;
 
 public interface UserIngredientRepository extends JpaRepository<UserIngredient, Long> {
 
-    @Query("""
-        SELECT ui
-        FROM UserIngredient ui
-        WHERE ui.user.userId = :userId
-          AND ui.type = :type
-          AND ui.referenceId = :referenceId
-        ORDER BY ui.ingredientId ASC
-        LIMIT 1
-    """)
-    Optional<UserIngredient> findByUserIdAndTypeAndReferenceId(
-            @Param("userId") Long userId,
-            @Param("type") Type type,
-            @Param("referenceId")Long referenceId
-    );
-
-    @Query("SELECT ui FROM UserIngredient ui WHERE ui.user.userId = :userId " +
-            "AND ui.type = :type AND ui.referenceId IN :referenceIds")
-    List<UserIngredient> findUserIngredients(
-            @Param("userId") Long userId,
-            @Param("type") Type type,
-            @Param("referenceIds") List<Long> referenceIds
-    );
-
     List<UserIngredient> findAllByIngredientIdInAndUser_UserId(
             List<Long> ingredientIds,
             Long userId
@@ -115,19 +92,6 @@ public interface UserIngredientRepository extends JpaRepository<UserIngredient, 
         ) THEN true ELSE false END
     """)
     boolean existsByUserIdAndExpirationDate(
-            @Param("userId") Long userId,
-            @Param("expirationDate") LocalDate expirationDate
-    );
-
-    // 유통기한 당일(D-0) 식재료 조회
-    @Query("""
-        SELECT ui
-        FROM UserIngredient ui
-        WHERE ui.user.userId = :userId
-        AND ui.expirationDate = :expirationDate
-        ORDER BY ui.ingredientId ASC
-    """)
-    List<UserIngredient> findByUserIdAndExpirationDateOrderByIngredientIdAsc(
             @Param("userId") Long userId,
             @Param("expirationDate") LocalDate expirationDate
     );

--- a/src/main/java/com/cookeep/cookeep/domain/ingredient/useringredient/dao/UserIngredientRepository.java
+++ b/src/main/java/com/cookeep/cookeep/domain/ingredient/useringredient/dao/UserIngredientRepository.java
@@ -145,4 +145,15 @@ public interface UserIngredientRepository extends JpaRepository<UserIngredient, 
             @Param("batchId") String batchId
     );
 
+    @Query("""
+        SELECT DISTINCT ui.user.userId
+        FROM UserIngredient ui
+        JOIN ui.user u
+        WHERE ui.expirationDate = :today
+          AND u.marketingConsent = true
+    """)
+    List<Long> findUserIdsWithExpiringTodayAndMarketingConsent(
+            @Param("today") LocalDate today
+    );
+
 }

--- a/src/main/java/com/cookeep/cookeep/domain/notification/application/WebPushNotificationService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/notification/application/WebPushNotificationService.java
@@ -55,7 +55,8 @@ public class WebPushNotificationService {
                 webPushSubscriptionRepository.findAllByUser_UserId(userId);
 
         if (subscriptions.isEmpty()) {
-            throw new AppException(ErrorCode.SUBSCRIPTION_NOT_FOUND);
+            log.debug("웹 푸시 알림 미전송 - 구독 정보 없음. userId={}", userId);
+            return WebPushSendResponseDto.noSubscription();
         }
 
         // 4. 알림 페이로드 생성
@@ -129,4 +130,5 @@ public class WebPushNotificationService {
         return successCount;
 
     }
+
 }

--- a/src/test/java/com/cookeep/cookeep/domain/notification/application/NotificationSchedulerTest.java
+++ b/src/test/java/com/cookeep/cookeep/domain/notification/application/NotificationSchedulerTest.java
@@ -1,0 +1,115 @@
+package com.cookeep.cookeep.domain.notification.application;
+
+import com.cookeep.cookeep.domain.ingredient.useringredient.application.UserIngredientScheduler;
+import com.cookeep.cookeep.domain.ingredient.useringredient.dao.UserIngredientRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class NotificationSchedulerTest {
+
+    @InjectMocks
+    private UserIngredientScheduler scheduler;
+
+    @Mock
+    private UserIngredientRepository userIngredientRepository;
+
+    @Mock
+    private WebPushNotificationService webPushNotificationService;
+
+    @Nested
+    @DisplayName("sendDailyExpirationPush - 스케줄러 알림 전송")
+    class SendDailyExpirationPush {
+
+        @Test
+        @DisplayName("대상 유저가 없으면 sendExpirationAlert를 호출하지 않는다")
+        void 대상유저없음_전송안함() {
+            given(userIngredientRepository
+                    .findUserIdsWithExpiringTodayAndMarketingConsent(LocalDate.now()))
+                    .willReturn(List.of());
+
+            scheduler.sendDailyExpirationPush();
+
+            verify(webPushNotificationService, never()).sendExpirationAlert(anyLong());
+        }
+
+        @Test
+        @DisplayName("대상 유저가 3명이면 sendExpirationAlert를 3회 호출한다")
+        void 대상유저3명_3회호출() {
+            given(userIngredientRepository
+                    .findUserIdsWithExpiringTodayAndMarketingConsent(LocalDate.now()))
+                    .willReturn(List.of(1L, 2L, 3L));
+
+            scheduler.sendDailyExpirationPush();
+
+            verify(webPushNotificationService, times(1)).sendExpirationAlert(1L);
+            verify(webPushNotificationService, times(1)).sendExpirationAlert(2L);
+            verify(webPushNotificationService, times(1)).sendExpirationAlert(3L);
+        }
+
+        @Test
+        @DisplayName("특정 유저 전송 중 예외가 발생해도 나머지 유저는 계속 전송한다")
+        void 특정유저_예외발생_나머지_계속전송() {
+            given(userIngredientRepository
+                    .findUserIdsWithExpiringTodayAndMarketingConsent(LocalDate.now()))
+                    .willReturn(List.of(1L, 2L, 3L));
+
+            // 2번 유저에서만 예외 발생
+            doThrow(new RuntimeException("전송 실패"))
+                    .when(webPushNotificationService).sendExpirationAlert(2L);
+
+            scheduler.sendDailyExpirationPush();
+
+            // 예외 발생해도 1, 3번 유저는 정상 호출
+            verify(webPushNotificationService, times(1)).sendExpirationAlert(1L);
+            verify(webPushNotificationService, times(1)).sendExpirationAlert(2L);
+            verify(webPushNotificationService, times(1)).sendExpirationAlert(3L);
+        }
+
+        @Test
+        @DisplayName("모든 유저 전송 중 예외가 발생해도 스케줄러가 중단되지 않는다")
+        void 모든유저_예외발생_스케줄러_중단안됨() {
+            given(userIngredientRepository
+                    .findUserIdsWithExpiringTodayAndMarketingConsent(LocalDate.now()))
+                    .willReturn(List.of(1L, 2L));
+
+            doThrow(new RuntimeException("전송 실패"))
+                    .when(webPushNotificationService).sendExpirationAlert(anyLong());
+
+            // 예외가 외부로 전파되지 않아야 함
+            org.assertj.core.api.Assertions.assertThatNoException()
+                    .isThrownBy(() -> scheduler.sendDailyExpirationPush());
+
+            verify(webPushNotificationService, times(1)).sendExpirationAlert(1L);
+            verify(webPushNotificationService, times(1)).sendExpirationAlert(2L);
+        }
+
+        @Test
+        @DisplayName("DB 조회 자체에서 예외가 발생하면 sendExpirationAlert는 호출되지 않는다")
+        void DB조회_예외발생_전송안함() {
+            given(userIngredientRepository
+                    .findUserIdsWithExpiringTodayAndMarketingConsent(LocalDate.now()))
+                    .willThrow(new RuntimeException("DB 오류"));
+
+            // DB 예외는 스케줄러 밖으로 전파될 수 있음 (의도적 미처리)
+            org.assertj.core.api.Assertions.assertThatThrownBy(
+                    () -> scheduler.sendDailyExpirationPush()
+            ).isInstanceOf(RuntimeException.class);
+
+            verify(webPushNotificationService, never()).sendExpirationAlert(anyLong());
+        }
+    }
+
+}

--- a/src/test/java/com/cookeep/cookeep/domain/notification/application/NotificationSchedulerTest.java
+++ b/src/test/java/com/cookeep/cookeep/domain/notification/application/NotificationSchedulerTest.java
@@ -103,7 +103,7 @@ public class NotificationSchedulerTest {
                     .findUserIdsWithExpiringTodayAndMarketingConsent(LocalDate.now()))
                     .willThrow(new RuntimeException("DB 오류"));
 
-            // DB 예외는 스케줄러 밖으로 전파될 수 있음 (의도적 미처리)
+            // DB 예외는 throw
             org.assertj.core.api.Assertions.assertThatThrownBy(
                     () -> scheduler.sendDailyExpirationPush()
             ).isInstanceOf(RuntimeException.class);

--- a/src/test/java/com/cookeep/cookeep/domain/notification/application/WebPushSubscriptionServiceTest.java
+++ b/src/test/java/com/cookeep/cookeep/domain/notification/application/WebPushSubscriptionServiceTest.java
@@ -332,20 +332,18 @@ public class WebPushSubscriptionServiceTest {
         }
 
         @Test
-        @DisplayName("구독 정보가 없으면 SUBSCRIPTION_NOT_FOUND 예외가 발생하고 pushService는 호출되지 않는다")
-        void 구독정보없음_예외발생() throws Exception {
-            // given
+        @DisplayName("구독 정보가 없으면 sent=false와 구독없음 메시지를 반환한다")
+        void 구독정보없음_sent_false() throws Exception {
             given(user.getMarketingConsent()).willReturn(true);
             given(userIngredientRepository.existsByUserIdAndExpirationDate(eq(USER_ID), any()))
                     .willReturn(true);
             given(webPushSubscriptionRepository.findAllByUser_UserId(USER_ID))
                     .willReturn(List.of());
 
-            // when & then
-            assertThatThrownBy(() -> webPushNotificationService.sendExpirationAlert(USER_ID))
-                    .isInstanceOf(AppException.class)
-                    .hasMessageContaining(ErrorCode.SUBSCRIPTION_NOT_FOUND.getMessage());
+            WebPushSendResponseDto result = webPushNotificationService.sendExpirationAlert(USER_ID);
 
+            assertThat(result.getSent()).isFalse();
+            assertThat(result.getMessage()).isEqualTo("구독 정보가 없습니다.");
             verify(pushService, never()).send(any());
         }
 


### PR DESCRIPTION
# Issue
#224 

# Description
유통기한 D-0 재료가 있는 유저에게 웹 접속 여부와 관계없이 매일 오전 11시(추후 수정 가능) 자동으로 웹 푸시 알림을 전송하는 스케줄러를 구현합니다.
백엔드 스케줄러가 조건을 확인하고 자동 전송하는 방식으로 변경합니다.
API 명세서 참고: https://www.notion.so/1-1-3333f76f87248063a054e5687baf04b7

# Changes
### UserIngredientRepository
- findUserIdsWithExpiringTodayAndMarketingConsent() 쿼리 메서드 추가
   - 마케팅 수신 동의 + D-0 재료 존재 유저 ID 목록 조회
### WebPushNotificationService
- sendExpirationAlert() 내 구독 없을 때 동작 변경
   - 기존: SUBSCRIPTION_NOT_FOUND 예외 throw
   - 변경: sent=false 반환 (스케줄러에서 안전하게 스킵하기 위함)
- WebPushSendResponseDto에 noSubscription() 팩토리 메서드 추가
### UserIngredientScheduler
- sendDailyExpirationPush() 메서드 추가
   - 매일 11:00 (Asia/Seoul) 자동 실행
   - 조건 충족 유저 전체 조회 후 유저별 sendExpirationAlert() 호출
   - 개별 유저 전송 실패 시 로그만 남기고 나머지 유저 계속 전송
### PushNotificationController
- sendAlert() 메서드 삭제 (스케줄러로 대체)

# Test Checklist
### WebPushSubscriptionServiceTest - 기존 테스트 수정
- [x] 구독 없을 때 예외 발생 → sent=false + 구독없음 메시지 반환으로 변경
### NotificationSchedulerTest - 신규
- [x] 대상 유저가 없으면 sendExpirationAlert 호출하지 않음
- [x] 대상 유저가 3명이면 sendExpirationAlert 3회 호출
- [x] 특정 유저 전송 중 예외 발생해도 나머지 유저는 계속 전송
- [x] 모든 유저 전송 중 예외 발생해도 스케줄러가 중단되지 않음
- [x] DB 조회 자체에서 예외 발생 시 sendExpirationAlert 호출되지 않음