### PR TITLE
feat: 식물 상태 변화(시들고 있는 중, 성장 정지)에 따른 웹 푸시 알림 기능 추가

### DIFF
--- a/src/main/java/com/cookeep/cookeep/api/controller/PushNotificationController.java
+++ b/src/main/java/com/cookeep/cookeep/api/controller/PushNotificationController.java
@@ -7,6 +7,7 @@ import com.cookeep.cookeep.config.ApiErrorCodeExamples;
 import com.cookeep.cookeep.domain.notification.application.PopupNotificationEligibilityService;
 import com.cookeep.cookeep.domain.notification.application.WebPushNotificationService;
 import com.cookeep.cookeep.domain.notification.dto.PushNotificationEligibilityResponseDto;
+import com.cookeep.cookeep.domain.notification.entity.NotificationType;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -102,4 +103,35 @@ public class PushNotificationController {
 //        WebPushSendResponseDto response = webPushNotificationService.sendExpirationAlert(userId);
 //        return ResponseEntity.ok(DataResponse.from(response));
 //    }
+
+    // ===== 아래는 FCM 실제 연동 테스트용 엔드포인트입니다. =====
+
+    @Operation(summary = "[테스트] 식물 시듦 알림 전송", description = "로그인한 유저에게 PLANT_WILTING 웹 푸시를 즉시 전송합니다. (FCM 연동 테스트용)")
+    @PostMapping("/web/push/test/plant-wilting")
+    public ResponseEntity<DataResponse<WebPushSendResponseDto>> testPlantWiltingPush(
+            @AuthenticationPrincipal(expression = "userId") Long userId
+    ) {
+        WebPushSendResponseDto response =
+                webPushNotificationService.sendPlantStatusAlert(userId, NotificationType.PLANT_WILTING);
+        return ResponseEntity.ok(DataResponse.from(response));
+    }
+
+    @Operation(summary = "[테스트] 식물 성장정지 알림 전송", description = "로그인한 유저에게 PLANT_GROWTH_STOP 웹 푸시를 즉시 전송합니다. (FCM 연동 테스트용)")
+    @PostMapping("/web/push/test/plant-frozen")
+    public ResponseEntity<DataResponse<WebPushSendResponseDto>> testPlantFrozenPush(
+            @AuthenticationPrincipal(expression = "userId") Long userId
+    ) {
+        WebPushSendResponseDto response =
+                webPushNotificationService.sendPlantStatusAlert(userId, NotificationType.PLANT_GROWTH_STOP);
+        return ResponseEntity.ok(DataResponse.from(response));
+    }
+
+    @Operation(summary = "[테스트] 유통기한 임박 알림 전송", description = "로그인한 유저에게 EXPIRATION 웹 푸시를 즉시 전송합니다. (FCM 연동 테스트용)")
+    @PostMapping("/web/push/test/expiration")
+    public ResponseEntity<DataResponse<WebPushSendResponseDto>> testExpirationPush(
+            @AuthenticationPrincipal(expression = "userId") Long userId
+    ) {
+        WebPushSendResponseDto response = webPushNotificationService.sendExpirationAlert(userId);
+        return ResponseEntity.ok(DataResponse.from(response));
+    }
 }

--- a/src/main/java/com/cookeep/cookeep/domain/notification/application/WebPushNotificationService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/notification/application/WebPushNotificationService.java
@@ -75,6 +75,37 @@ public class WebPushNotificationService {
 
     }
 
+    public WebPushSendResponseDto sendPlantStatusAlert(Long userId, NotificationType type) {
+
+        User user = userReader.readById(userId);
+
+        // 1. 마케팅 수신 동의 확인 (쿼리에서 이미 필터링되나 방어적 검증)
+        if (!Boolean.TRUE.equals(user.getMarketingConsent())) {
+            log.debug("식물 상태 푸시 알림 미전송 - 수신 미동의. userId={}", userId);
+            return WebPushSendResponseDto.notConsented();
+        }
+
+        // 2. 구독 정보 조회
+        List<WebPushSubscription> subscriptions =
+                webPushSubscriptionRepository.findAllByUser_UserId(userId);
+
+        if (subscriptions.isEmpty()) {
+            log.debug("식물 상태 푸시 알림 미전송 - 구독 정보 없음. userId={}, type={}", userId, type);
+            return WebPushSendResponseDto.noSubscription();
+        }
+
+        // 3. 페이로드 생성 및 전송
+        String payload = buildPayload(type);
+        int successCount = sendToSubscriptions(subscriptions, payload);
+
+        log.info("식물 상태 푸시 알림 전송 완료. userId={}, type={}, total={}, success={}",
+                userId, type, subscriptions.size(), successCount);
+
+        return successCount > 0
+                ? WebPushSendResponseDto.sent(type)
+                : WebPushSendResponseDto.allSubscriptionsExpired();
+    }
+
     // --- 내부 메서드 ---
 
     // 알림 내용 생성

--- a/src/main/java/com/cookeep/cookeep/domain/notification/entity/NotificationType.java
+++ b/src/main/java/com/cookeep/cookeep/domain/notification/entity/NotificationType.java
@@ -14,18 +14,16 @@ public enum NotificationType {
             "오늘 유통기한이 만료되는 재료가 있어요! \n 지금 확인하고 요리해볼까요?",
             "/api/users/me/refrigerator/home"),
 
-    //필요시수정(to.현정)
     PLANT_WILTING(
             "시듦",
-            "시듦",
-            "식물이 시들었어요!",
+            "식물이 시들기 시작했어요",
+            "오늘 한 끼만 챙겨주면 다시 살아나요🌱",
             "/api/users/me"),
     PLANT_GROWTH_STOP(
             "성장정지",
-            "성장정지",
-            "성장정지되었어요",
-            "/api/users/me"
-            );
+            "🛑식물 성장이 멈췄어요",
+            "지금 돌아오면 다시 키울 수 있어요!",
+            "/api/users/me");
     private final String displayName;
     private final String title;
     private final String body;

--- a/src/main/java/com/cookeep/cookeep/domain/notification/entity/NotificationType.java
+++ b/src/main/java/com/cookeep/cookeep/domain/notification/entity/NotificationType.java
@@ -12,18 +12,18 @@ public enum NotificationType {
             "유통기한임박",
             "유통기한임박",
             "오늘 유통기한이 만료되는 재료가 있어요! \n 지금 확인하고 요리해볼까요?",
-            "/api/users/me/refrigerator/home"),
+            "/fridge"),
 
     PLANT_WILTING(
             "시듦",
             "식물이 시들기 시작했어요",
             "오늘 한 끼만 챙겨주면 다시 살아나요🌱",
-            "/api/users/me"),
+            "/cookeeps"),
     PLANT_GROWTH_STOP(
             "성장정지",
             "🛑식물 성장이 멈췄어요",
             "지금 돌아오면 다시 키울 수 있어요!",
-            "/api/users/me");
+            "/cookeeps");
     private final String displayName;
     private final String title;
     private final String body;

--- a/src/main/java/com/cookeep/cookeep/domain/plant/application/UserPlantScheduler.java
+++ b/src/main/java/com/cookeep/cookeep/domain/plant/application/UserPlantScheduler.java
@@ -1,6 +1,10 @@
 package com.cookeep.cookeep.domain.plant.application;
 
+import com.cookeep.cookeep.domain.notification.application.WebPushNotificationService;
+import com.cookeep.cookeep.domain.notification.entity.NotificationType;
 import com.cookeep.cookeep.domain.plant.dao.UserPlantRepository;
+import com.cookeep.cookeep.domain.plant.entity.PlantStatus;
+import com.cookeep.cookeep.domain.user.dao.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -15,6 +19,8 @@ public class UserPlantScheduler {
 
     private final UserPlantRepository userPlantRepository;
     private final UserPlantService userPlantService;
+    private final UserRepository userRepository;
+    private final WebPushNotificationService webPushNotificationService;
 
     /**
      * 매일 00:10에 현재 식물을 키우는 유저의 plantStatus 갱신
@@ -39,5 +45,42 @@ public class UserPlantScheduler {
         }
 
         log.info("=== Successfully updated plantStatus for {}/{} users ===", successCount, userIds.size());
+    }
+
+    /**
+     * 매일 12:00에 식물 상태(WILTING/FROZEN)인 유저에게 웹 푸시 알림 발송
+     * 00:10 plantStatus 갱신 스케줄러 이후 실행되어 최신 상태 반영
+     */
+    @Scheduled(cron = "0 0 12 * * *", zone = "Asia/Seoul")
+    public void sendDailyPlantStatusPush() {
+        log.info("=== Starting daily plant status push notification ===");
+
+        // 1. WILTING 유저 알림
+        List<Long> wiltingUserIds = userRepository
+                .findUserIdsByPlantStatusAndMarketingConsent(PlantStatus.WILTING);
+        log.info("시듦 알림 대상 유저 수: {}", wiltingUserIds.size());
+
+        for (Long userId : wiltingUserIds) {
+            try {
+                webPushNotificationService.sendPlantStatusAlert(userId, NotificationType.PLANT_WILTING);
+            } catch (Exception e) {
+                log.error("시듦 푸시 알림 전송 실패. userId={}, error={}", userId, e.getMessage());
+            }
+        }
+
+        // 2. FROZEN 유저 알림
+        List<Long> frozenUserIds = userRepository
+                .findUserIdsByPlantStatusAndMarketingConsent(PlantStatus.FROZEN);
+        log.info("성장 정지 알림 대상 유저 수: {}", frozenUserIds.size());
+
+        for (Long userId : frozenUserIds) {
+            try {
+                webPushNotificationService.sendPlantStatusAlert(userId, NotificationType.PLANT_GROWTH_STOP);
+            } catch (Exception e) {
+                log.error("성장 정지 푸시 알림 전송 실패. userId={}, error={}", userId, e.getMessage());
+            }
+        }
+
+        log.info("=== 식물 상태 푸시 알림 전송 완료 ===");
     }
 }

--- a/src/main/java/com/cookeep/cookeep/domain/plant/application/UserPlantScheduler.java
+++ b/src/main/java/com/cookeep/cookeep/domain/plant/application/UserPlantScheduler.java
@@ -1,0 +1,43 @@
+package com.cookeep.cookeep.domain.plant.application;
+
+import com.cookeep.cookeep.domain.plant.dao.UserPlantRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class UserPlantScheduler {
+
+    private final UserPlantRepository userPlantRepository;
+    private final UserPlantService userPlantService;
+
+    /**
+     * 매일 00:10에 현재 식물을 키우는 유저의 plantStatus 갱신
+     * 자정(00:00) 식재료 스케줄러와 부하 분산을 위해 10분 뒤 실행
+     * Cron: "초 분 시 일 월 요일"
+     */
+    @Scheduled(cron = "0 10 0 * * *", zone = "Asia/Seoul")
+    public void updatePlantStatusDaily() {
+        log.info("=== Starting daily plantStatus update ===");
+
+        List<Long> userIds = userPlantRepository.findUserIdsWithGrowingPlant();
+        log.info("Total users with growing plant: {}", userIds.size());
+
+        int successCount = 0;
+        for (Long userId : userIds) {
+            try {
+                userPlantService.checkAndUpdatePlantStatusById(userId);
+                successCount++;
+            } catch (Exception e) {
+                log.error("plantStatus 업데이트 실패. userId={}, error={}", userId, e.getMessage());
+            }
+        }
+
+        log.info("=== Successfully updated plantStatus for {}/{} users ===", successCount, userIds.size());
+    }
+}

--- a/src/main/java/com/cookeep/cookeep/domain/plant/application/UserPlantService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/plant/application/UserPlantService.java
@@ -37,16 +37,10 @@ public class UserPlantService {
     private final CookieService cookieService;
     private final UserReader userReader;
 
-    // 스케줄러용: userId로 유저를 직접 로드해 식물 상태 갱신 (트랜잭션 경계 내에서 managed 상태 유지)
+    // 미접속 일수 기반 식물 상태 계산 및 성장 정지 처리 (스케줄러에서 호출)
     @Transactional
     public void checkAndUpdatePlantStatusById(Long userId) {
         User user = userReader.readById(userId);
-        checkAndUpdatePlantStatus(user);
-    }
-
-    // 로그인/토큰 갱신 시 호출: 미접속 일수 기반 식물 상태 계산 및 성장 정지 처리
-    @Transactional
-    public void checkAndUpdatePlantStatus(User user) {
         LocalDateTime lastAccess = user.getLastAccessAt();
 
         // lastAccessAt이 null이면 (기존 유저 or 최초 적용) NORMAL 처리

--- a/src/main/java/com/cookeep/cookeep/domain/plant/application/UserPlantService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/plant/application/UserPlantService.java
@@ -37,6 +37,13 @@ public class UserPlantService {
     private final CookieService cookieService;
     private final UserReader userReader;
 
+    // 스케줄러용: userId로 유저를 직접 로드해 식물 상태 갱신 (트랜잭션 경계 내에서 managed 상태 유지)
+    @Transactional
+    public void checkAndUpdatePlantStatusById(Long userId) {
+        User user = userReader.readById(userId);
+        checkAndUpdatePlantStatus(user);
+    }
+
     // 로그인/토큰 갱신 시 호출: 미접속 일수 기반 식물 상태 계산 및 성장 정지 처리
     @Transactional
     public void checkAndUpdatePlantStatus(User user) {

--- a/src/main/java/com/cookeep/cookeep/domain/plant/application/UserPlantService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/plant/application/UserPlantService.java
@@ -139,6 +139,10 @@ public class UserPlantService {
         // 5. 자동 모드(isProfileAutoUpdate=true)일 때만 프로필 갱신
         user.setProfilePlantAuto(newUserPlant);
 
+        // 6. 새 식물 등록 시 plantStatus를 NORMAL로 초기화
+        // (키우는 식물 없이 14일+ 미접속 후 로그인하면 FROZEN이 설정될 수 있으므로)
+        user.updatePlantStatus(PlantStatus.NORMAL);
+
         String message = isFirstPlant ? "첫 식물 등록이 완료되었습니다." : "식물 등록이 완료되었습니다.";
         return new RegisterPlantResponseDto(newUserPlant.getUserPlantId(), message);
     }

--- a/src/main/java/com/cookeep/cookeep/domain/plant/dao/UserPlantRepository.java
+++ b/src/main/java/com/cookeep/cookeep/domain/plant/dao/UserPlantRepository.java
@@ -4,6 +4,7 @@ import com.cookeep.cookeep.domain.plant.entity.UserPlant;
 import com.cookeep.cookeep.domain.user.entity.User;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -25,4 +26,8 @@ public interface UserPlantRepository extends JpaRepository<UserPlant, Long>{
 
     // 유저가 보유한 식물이 존재하는지 확인
     boolean existsByUser(User user);
+
+    // 현재 키우는 식물이 있는 유저 ID 목록 조회 (스케줄러용)
+    @Query("SELECT up.user.userId FROM UserPlant up WHERE up.isHarvested = false")
+    List<Long> findUserIdsWithGrowingPlant();
 }

--- a/src/main/java/com/cookeep/cookeep/domain/user/application/AuthService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/user/application/AuthService.java
@@ -42,8 +42,6 @@ import com.cookeep.cookeep.domain.user.entity.UserStatus;
 import com.cookeep.cookeep.common.exception.AppException;
 import com.cookeep.cookeep.common.exception.ErrorCode;
 
-import com.cookeep.cookeep.domain.plant.application.UserPlantService;
-
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -59,7 +57,6 @@ public class AuthService {
 	private final UserReader userReader;
 	private final PasswordEncoder passwordEncoder;
 	private final NicknameGenerator nicknameGenerator;
-	private final UserPlantService userPlantService;
 	private final SmsVerificationService smsVerificationService;
 
 	// 액세스 토큰이 만료되었을 경우 리프레쉬 토큰으로 액세스 토큰 갱신
@@ -81,8 +78,6 @@ public class AuthService {
 
 		User user = userReader.readById(userId);
 
-		// 미접속 일수 기반 식물 상태 계산 및 성장 정지 처리
-		userPlantService.checkAndUpdatePlantStatus(user);
 		user.updateLastAccessAt(LocalDateTime.now());
 
 		// 새로운 액세스토큰 발급
@@ -111,8 +106,6 @@ public class AuthService {
 	}
 
 	private TokenPair issueTokensAndUpsertSession(User user) {
-		// 미접속 일수 기반 식물 상태 계산 및 성장 정지 처리
-		userPlantService.checkAndUpdatePlantStatus(user);
 		user.updateLastAccessAt(LocalDateTime.now());
 
 		// 액세스 토큰, 리프레쉬 토큰 발급

--- a/src/main/java/com/cookeep/cookeep/domain/user/dao/UserRepository.java
+++ b/src/main/java/com/cookeep/cookeep/domain/user/dao/UserRepository.java
@@ -3,6 +3,7 @@ package com.cookeep.cookeep.domain.user.dao;
 import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import com.cookeep.cookeep.domain.plant.entity.PlantStatus;
 import com.cookeep.cookeep.domain.user.entity.User;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
@@ -29,6 +30,18 @@ public interface UserRepository extends JpaRepository<User, Long> {
     // 푸시 알림 동의한 사용자 조회
     @Query("SELECT u FROM User u WHERE u.marketingPush = true")
     List<User> findAllByMarketingPushTrue();
+
+    // 특정 plantStatus이고 marketingConsent 동의한 + 키우는 식물 보유 유저 ID 조회 (식물 상태 푸시 알림용)
+    @Query("""
+        SELECT DISTINCT u.userId
+        FROM User u
+        JOIN UserPlant up ON up.user.userId = u.userId
+        WHERE u.plantStatus = :plantStatus
+          AND u.marketingConsent = true
+          AND up.isHarvested = false
+    """)
+    List<Long> findUserIdsByPlantStatusAndMarketingConsent(
+            @Param("plantStatus") PlantStatus plantStatus);
 
     boolean existsByEmail(String email);
 }


### PR DESCRIPTION
# Related Issue
CLOSE #210 

# Description
                                                                                                                                                                       
식물 상태(PlantStatus) 변화에 따른 웹 푸시 알림 기능을 추가했습니다.                                                                
식물이 WILTING(시듦) 또는 FROZEN(성장 정지) 상태에 진입한 유저에게 매일 12시에 웹 푸시 알림을 발송하여, 사용자가 앱으로 돌아오도록 유도합니다.       
              
아울러 기존에 로그인/토큰 갱신 시점에 분산되어 있던 plantStatus 갱신 로직을 
매일 00:10 스케줄러로 일원화하여, UserPlantService내에서만 식물 상태를 갱신하도록 리팩토링하여 갱신 시점의 일관성을 확보했습니다.                     
                                                                                                                                                                                    
# Changes        
          
UserPlantScheduler (신규)
  - `@Scheduled(cron = "0 10 0 * * *")` — 매일 00:10, 식물을 키우는 모든 유저의 plantStatus 일괄 갱신                                                                    
  - `@Scheduled(cron = "0 0 12 * * *")` — 매일 12:00, WILTING / FROZEN 상태 유저에게 웹 푸시 알림 발송                                                                   
                                                                                                                                                                       
WebPushNotificationService                                                                                                                                           
  - sendPlantStatusAlert(userId, type) 메서드 추가 — PLANT_WILTING / PLANT_GROWTH_STOP 타입 웹 푸시 전송 (마케팅 동의·구독 여부 검증 포함)                             
                                                                                                                                                                       
UserPlantService                                                                                                                                                     
  - checkAndUpdatePlantStatus(User) → checkAndUpdatePlantStatusById(Long userId) 로 변경 — 스케줄러에서 userId 기반으로 직접 호출할 수 있도록 시그니처 수정            
  - 새 식물 등록 시 plantStatus를 NORMAL로 초기화 — 장기 미접속 후 등록 시 FROZEN이 잔존하는 버그 수정                                                                 
   
AuthService                                                                                                                                                          
  - 로그인·토큰 갱신 시 호출하던 checkAndUpdatePlantStatus() 제거 — 스케줄러로 일원화
                                                                                                                                                                       
NotificationType
  - EXPIRATION url: /fridge, PLANT_WILTING / PLANT_GROWTH_STOP url: /cookeeps 로 변경 (기존 백엔드 API 경로 → 프론트 라우팅 경로) 

# Test
html 파일 활용해 구글 크롬 브라우저에서 구독 등록 -> 수동 알림 요청 방식으로 실제 FCM 서버와 연동 테스트 완료.

# 참고사항
FE 팀에서 구독 등록 후 Swagger에서 바로 호출해서 알림 동작 확인하실 수 있는 테스트용 API 엔드포인트 3개를 추가했으니 참고 부탁드립니다!
```
POST /api/users/me/web/push/test/plant-wilting
POST /api/users/me/web/push/test/plant-frozen
POST /api/users/me/web/push/test/expiration 
```