### PR TITLE
Refacto: ai 레시피 안정성 개선

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,7 @@ dependencies {
 
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	testImplementation 'org.springframework.security:spring-security-test'
+	testImplementation 'com.squareup.okhttp3:mockwebserver:4.12.0'
 
 	implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
 

--- a/src/main/java/com/cookeep/cookeep/domain/recipe/application/GeminiService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/recipe/application/GeminiService.java
@@ -16,8 +16,11 @@ import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
+import reactor.core.publisher.Mono;
+import reactor.util.retry.Retry;
 
 import java.net.URI;
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -79,7 +82,29 @@ public class GeminiService {
                     .contentType(MediaType.APPLICATION_JSON)
                     .bodyValue(requestBody)
                     .retrieve()
+                    .onStatus(
+                            status -> status.is5xxServerError(),
+                            clientResponse -> clientResponse.bodyToMono(String.class)
+                                    .flatMap(body -> Mono.error(
+                                            new WebClientResponseException(
+                                                    clientResponse.statusCode().value(),
+                                                    "Gemini 5xx error: " + body,
+                                                    null, null, null
+                                            )
+                                    ))
+                    )
                     .bodyToMono(String.class)
+                    .timeout(Duration.ofSeconds(120))
+                    .retryWhen(
+                            Retry.backoff(3, Duration.ofSeconds(2))
+                                    .maxBackoff(Duration.ofSeconds(10))
+                                    .filter(this::isRetryableError)
+                                    .doBeforeRetry(retrySignal ->
+                                            log.warn("Gemini 재시도 중... attempt={}, cause={}",
+                                                    retrySignal.totalRetries() + 1,
+                                                    retrySignal.failure().getMessage())
+                                    )
+                    )
                     .block();
 
             log.info("Gemini API 응답 수신 완료");
@@ -197,5 +222,15 @@ public class GeminiService {
                 "5. steps는 단계별 조리 방법을 작성하세요.\n\n" +
                 "[user_ingredients]\n" +
                 ingredientsJson + "\n";
+    }
+
+    private boolean isRetryableError(Throwable e) {
+        if (e instanceof java.util.concurrent.TimeoutException) {
+            return true;
+        }
+        if (e instanceof WebClientResponseException webEx) {
+            return webEx.getStatusCode().is5xxServerError();
+        }
+        return false;
     }
 }

--- a/src/main/java/com/cookeep/cookeep/domain/recipe/application/YoutubeSearchService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/recipe/application/YoutubeSearchService.java
@@ -8,7 +8,10 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -23,8 +26,8 @@ public class YoutubeSearchService {
     private final WebClient webClient;
     private final ObjectMapper objectMapper = new ObjectMapper();
 
-    private static final String YOUTUBE_SEARCH_URL = "https://www.googleapis.com/youtube/v3/search";
     private static final int MAX_RESULTS_PER_QUERY = 1;
+    private static final Duration YOUTUBE_TIMEOUT = Duration.ofSeconds(20);
 
     /**
      * [검색 방법]
@@ -39,52 +42,41 @@ public class YoutubeSearchService {
             return new ArrayList<>();
         }
 
-        List<YoutubeReferenceDto> results = new ArrayList<>();
-
-        for (String query : searchQueries) {
-            try {
-                YoutubeReferenceDto video = searchSingleVideo(query);
-                if (video != null) {
-                    results.add(video);
-                }
-            } catch (Exception e) {
-                // 하나의 검색어가 실패해도 나머지는 계속 진행
-                log.warn("유튜브 검색 실패 (검색어: '{}'): {}", query, e.getMessage());
-            }
-        }
-
-        return results;
+        return Flux.fromIterable(searchQueries)
+                .flatMap(query ->
+                        searchSingleVideo(query)
+                                .onErrorResume(e -> {
+                                    log.warn("유튜브 검색 실패 (검색어: '{}'): {}", query, e.getMessage());
+                                    return Mono.empty();
+                                })
+                )
+                .collectList()
+                .block();
     }
 
     // --- 내부 메서드 ---
 
     // 유튜브 영상 1개 검색 수행
-    private YoutubeReferenceDto searchSingleVideo(String query) {
-        try {
-            String responseBody = webClient.get()
-                    .uri(uriBuilder -> uriBuilder
-                            .scheme("https")
-                            .host("www.googleapis.com")
-                            .path("/youtube/v3/search")
-                            .queryParam("part", "snippet")
-                            .queryParam("q", query)
-                            .queryParam("type", "video")
-                            .queryParam("maxResults", MAX_RESULTS_PER_QUERY)
-                            .queryParam("regionCode", "KR")       // 한국 지역 영상 우선
-                            .queryParam("relevanceLanguage", "ko") // 한국어 영상 우선
-                            .queryParam("key", youtubeApiKey)
-                            .build()
-                    )
-                    .retrieve()
-                    .bodyToMono(String.class)
-                    .block();
-
-            return parseSearchResult(responseBody, query);
-
-        } catch (Exception e) {
-            log.error("YouTube API 호출 실패 (검색어: '{}')", query, e);
-            return null;
-        }
+    private Mono<YoutubeReferenceDto> searchSingleVideo(String query) {
+        return webClient.get()
+                .uri(uriBuilder -> uriBuilder
+                        .scheme("https")
+                        .host("www.googleapis.com")
+                        .path("/youtube/v3/search")
+                        .queryParam("part", "snippet")
+                        .queryParam("q", query)
+                        .queryParam("type", "video")
+                        .queryParam("maxResults", MAX_RESULTS_PER_QUERY)
+                        .queryParam("regionCode", "KR")
+                        .queryParam("relevanceLanguage", "ko")
+                        .queryParam("key", youtubeApiKey)
+                        .build()
+                )
+                .retrieve()
+                .bodyToMono(String.class)
+                .timeout(YOUTUBE_TIMEOUT)
+                .mapNotNull(responseBody -> parseSearchResult(responseBody, query))
+                .doOnError(e -> log.error("YouTube API 호출 실패 (검색어: '{}')", query, e));
     }
 
     // YouTube API 응답 dto로 파싱

--- a/src/test/java/com/cookeep/cookeep/domain/recipe/application/GeminiServiceTest.java
+++ b/src/test/java/com/cookeep/cookeep/domain/recipe/application/GeminiServiceTest.java
@@ -1,0 +1,194 @@
+package com.cookeep.cookeep.domain.recipe.application;
+
+import com.cookeep.cookeep.common.exception.AppException;
+import com.cookeep.cookeep.common.exception.ErrorCode;
+import com.cookeep.cookeep.domain.recipe.dto.GeminiRecipeResponseDto;
+import com.cookeep.cookeep.domain.recipe.entity.Difficulty;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.reactive.function.client.ClientRequest;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@ExtendWith(MockitoExtension.class)
+public class GeminiServiceTest {
+
+    private MockWebServer mockWebServer;
+    private GeminiService geminiService;
+
+    private static final String VALID_GEMINI_RESPONSE = """
+            {
+              "candidates": [
+                {
+                  "content": {
+                    "parts": [
+                      {
+                        "text": "{\\"title\\":\\"테스트 레시피\\",\\"ingredients\\":{\\"user_ingredients\\":[{\\"ingredientId\\":1,\\"name\\":\\"양파\\",\\"quantity\\":1.0,\\"unit\\":\\"개\\"}]},\\"steps\\":[\\"1. 볶는다\\"],\\"youtube_search_queries\\":[\\"양파볶음\\"]}"
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+            """;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        mockWebServer = new MockWebServer();
+        mockWebServer.start();
+
+        WebClient webClient = WebClient.builder()
+                .filter((request, next) -> {
+                    URI originalUri = request.url();
+
+                    // path + query 유지하면서 host만 mock으로 변경
+                    String pathWithQuery = originalUri.getRawPath();
+                    if (originalUri.getRawQuery() != null) {
+                        pathWithQuery += "?" + originalUri.getRawQuery();
+                    }
+
+                    URI newUri = mockWebServer.url(pathWithQuery).uri();
+
+                    return next.exchange(
+                            ClientRequest.from(request)
+                                    .url(newUri)
+                                    .build()
+                    );
+                })
+                .build();
+
+        geminiService = new GeminiService(webClient);
+        ReflectionTestUtils.setField(geminiService, "apiKey", "test-key");
+        ReflectionTestUtils.setField(geminiService, "model", "gemini-test");
+    }
+
+    @AfterEach
+    void tearDown() throws IOException {
+        mockWebServer.shutdown();
+    }
+
+    @Nested
+    @DisplayName("generateRecipeByPrompt - 정상 응답")
+    class SuccessResponse {
+
+        @Test
+        @DisplayName("정상 응답 시 레시피를 파싱하여 반환한다")
+        void 정상응답_레시피_파싱_반환() {
+            mockWebServer.enqueue(new MockResponse()
+                    .setResponseCode(200)
+                    .setBody(VALID_GEMINI_RESPONSE)
+                    .addHeader("Content-Type", "application/json"));
+
+            GeminiRecipeResponseDto result = geminiService.generateRecipeByPrompt("테스트 프롬프트");
+
+            assertThat(result).isNotNull();
+            assertThat(result.getTitle()).isEqualTo("테스트 레시피");
+            assertThat(result.getSteps()).hasSize(1);
+        }
+    }
+
+    @Nested
+    @DisplayName("generateRecipeByPrompt - 재시도 (Retry)")
+    class RetryBehavior {
+
+        @Test
+        @DisplayName("503 응답 후 정상 응답 시 재시도로 성공한다")
+        void response503_재시도_성공() {
+            // 1차: 503 실패
+            mockWebServer.enqueue(new MockResponse()
+                    .setResponseCode(503)
+                    .setBody("error")
+                    .addHeader("Content-Type", "text/plain"));
+            // 2차: 정상
+            mockWebServer.enqueue(new MockResponse()
+                    .setBody(VALID_GEMINI_RESPONSE)
+                    .addHeader("Content-Type", "application/json"));
+
+            GeminiRecipeResponseDto result = geminiService.generateRecipeByPrompt("테스트 프롬프트");
+
+            assertThat(result).isNotNull();
+            assertThat(result.getTitle()).isEqualTo("테스트 레시피");
+            // 총 2회 요청
+            assertThat(mockWebServer.getRequestCount()).isEqualTo(2);
+        }
+
+        @Test
+        @DisplayName("500 응답이 연속 3회면 최대 재시도 후 AI_SEARCH_FAILED 예외를 던진다")
+        void response500_3회_재시도_실패() {
+            // 4회 (원본 1 + 재시도 3) 모두 500
+            for (int i = 0; i < 4; i++) {
+                mockWebServer.enqueue(new MockResponse()
+                        .setResponseCode(500)
+                        .setBody("error")
+                        .addHeader("Content-Type", "text/plain"));
+            }
+
+            assertThatThrownBy(() -> geminiService.generateRecipeByPrompt("테스트 프롬프트"))
+                    .isInstanceOf(AppException.class)
+                    .satisfies(ex -> assertThat(((AppException) ex).getErrorCode())
+                            .isIn(ErrorCode.AI_SEARCH_FAILED, ErrorCode.AI_RATE_LIMIT_EXCEEDED));
+
+            // 원본 1회 + 재시도 최대 3회 = 총 4회
+            assertThat(mockWebServer.getRequestCount()).isEqualTo(4);
+        }
+
+        @Test
+        @DisplayName("400 응답은 재시도 없이 즉시 AI_SEARCH_FAILED 예외를 던진다")
+        void response400_재시도없음_즉시실패() {
+            mockWebServer.enqueue(new MockResponse()
+                    .setResponseCode(400)
+                    .setBody("bad request"));
+
+            assertThatThrownBy(() -> geminiService.generateRecipeByPrompt("테스트 프롬프트"))
+                    .isInstanceOf(AppException.class);
+
+            // 4xx는 재시도 없이 1회만 요청
+            assertThat(mockWebServer.getRequestCount()).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("429 응답은 재시도 없이 AI_RATE_LIMIT_EXCEEDED 예외를 던진다")
+        void response429_재시도없음_RATE_LIMIT_예외() {
+            mockWebServer.enqueue(new MockResponse()
+                    .setResponseCode(429)
+                    .setBody("bad request"));
+
+            assertThatThrownBy(() -> geminiService.generateRecipeByPrompt("테스트 프롬프트"))
+                    .isInstanceOf(AppException.class)
+                    .satisfies(ex -> assertThat(((AppException) ex).getErrorCode())
+                            .isEqualTo(ErrorCode.AI_RATE_LIMIT_EXCEEDED));
+
+            assertThat(mockWebServer.getRequestCount()).isEqualTo(1);
+        }
+    }
+
+    @Nested
+    @DisplayName("generateRecipeByPrompt - 타임아웃")
+    class TimeoutBehavior {
+
+        @Test
+        @DisplayName("응답이 120초 이내에 오지 않으면 예외가 발생한다")
+        void 타임아웃_예외발생() {
+            // 130초 지연 (TIMEOUT = 120초 초과)
+            mockWebServer.enqueue(new MockResponse()
+                    .setBody(VALID_GEMINI_RESPONSE)
+                    .setBodyDelay(130, TimeUnit.SECONDS));
+
+            // 타임아웃으로 인한 예외 발생 확인
+            // 타임아웃 설정값 자체가 올바르게 적용되는지를 검증
+            assertThatThrownBy(() -> geminiService.generateRecipeByPrompt("테스트 프롬프트"))
+                    .isInstanceOf(Exception.class); // TimeoutException or AppException
+        }
+    }
+}

--- a/src/test/java/com/cookeep/cookeep/domain/recipe/application/YoutubeSearchServiceTest.java
+++ b/src/test/java/com/cookeep/cookeep/domain/recipe/application/YoutubeSearchServiceTest.java
@@ -1,0 +1,240 @@
+package com.cookeep.cookeep.domain.recipe.application;
+
+import com.cookeep.cookeep.domain.recipe.dto.YoutubeReferenceDto;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(MockitoExtension.class)
+public class YoutubeSearchServiceTest {
+
+    private MockWebServer mockWebServer;
+    private YoutubeSearchService youtubeSearchService;
+
+    // 정상 응답 JSON 템플릿
+    private static final String SUCCESS_RESPONSE = """
+            {
+              "items": [
+                {
+                  "id": { "videoId": "abc123" },
+                  "snippet": {
+                    "title": "테스트 영상",
+                    "thumbnails": {
+                      "medium": { "url": "https://img.youtube.com/vi/abc123/mqdefault.jpg" }
+                    }
+                  }
+                }
+              ]
+            }
+            """;
+
+    // 검색 결과 없는 응답 JSON
+    private static final String EMPTY_RESPONSE = """
+            { "items": [] }
+            """;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        mockWebServer = new MockWebServer();
+        mockWebServer.start();
+
+        WebClient webClient = WebClient.builder()
+                .baseUrl(mockWebServer.url("/").toString())
+                .build();
+
+        youtubeSearchService = new YoutubeSearchService(webClient);
+        // MockWebServer 주소로 override (실제 googleapis.com 대신)
+        ReflectionTestUtils.setField(youtubeSearchService, "youtubeApiKey", "test-api-key");
+    }
+
+    @AfterEach
+    void tearDown() throws IOException {
+        mockWebServer.shutdown();
+    }
+
+    @Nested
+    @DisplayName("searchVideos - null/빈 입력 처리")
+    class NullAndEmptyInput {
+
+        @Test
+        @DisplayName("null이 들어오면 빈 리스트를 반환한다")
+        void null_입력_빈리스트_반환() {
+            List<YoutubeReferenceDto> result = youtubeSearchService.searchVideos(null);
+
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        @DisplayName("빈 리스트가 들어오면 빈 리스트를 반환한다")
+        void 빈리스트_입력_빈리스트_반환() {
+            List<YoutubeReferenceDto> result = youtubeSearchService.searchVideos(List.of());
+
+            assertThat(result).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("searchVideos - 정상 응답 처리")
+    class SuccessResponse {
+
+        @Test
+        @DisplayName("검색어 1개에 대해 정상 응답이면 DTO 1개를 반환한다")
+        void 검색어_1개_정상응답_DTO_1개() {
+            mockWebServer.enqueue(new MockResponse()
+                    .setBody(SUCCESS_RESPONSE)
+                    .addHeader("Content-Type", "application/json"));
+
+            List<YoutubeReferenceDto> result = youtubeSearchService.searchVideos(List.of("김치볶음밥"));
+
+            assertThat(result).hasSize(1);
+            assertThat(result.get(0).getTitle()).isEqualTo("테스트 영상");
+            assertThat(result.get(0).getUrl()).isEqualTo("https://www.youtube.com/watch?v=abc123");
+            assertThat(result.get(0).getThumbnail()).isEqualTo("https://img.youtube.com/vi/abc123/mqdefault.jpg");
+        }
+
+        @Test
+        @DisplayName("검색 결과가 없으면 해당 검색어는 결과에 포함되지 않는다")
+        void 검색결과없음_결과_미포함() {
+            mockWebServer.enqueue(new MockResponse()
+                    .setBody(EMPTY_RESPONSE)
+                    .addHeader("Content-Type", "application/json"));
+
+            List<YoutubeReferenceDto> result = youtubeSearchService.searchVideos(List.of("검색결과없는쿼리"));
+
+            assertThat(result).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("searchVideos - 병렬 처리 및 부분 실패")
+    class ParallelAndPartialFailure {
+
+        @Test
+        @DisplayName("검색어 3개 중 1개 실패해도 나머지 2개 결과를 반환한다")
+        void 검색어3개_1개실패_나머지2개_반환() {
+            // 1번: 성공
+            mockWebServer.enqueue(new MockResponse()
+                    .setBody(SUCCESS_RESPONSE)
+                    .addHeader("Content-Type", "application/json"));
+            // 2번: 500 에러
+            mockWebServer.enqueue(new MockResponse().setResponseCode(500));
+            // 3번: 성공
+            mockWebServer.enqueue(new MockResponse()
+                    .setBody(SUCCESS_RESPONSE)
+                    .addHeader("Content-Type", "application/json"));
+
+            List<YoutubeReferenceDto> result = youtubeSearchService.searchVideos(
+                    List.of("쿼리1", "쿼리2실패", "쿼리3"));
+
+            // 실패한 1개는 제외, 성공한 2개만 반환
+            assertThat(result).hasSize(2);
+        }
+
+        @Test
+        @DisplayName("모든 검색어가 실패하면 빈 리스트를 반환한다")
+        void 모든검색어_실패_빈리스트_반환() {
+            mockWebServer.enqueue(new MockResponse().setResponseCode(500));
+            mockWebServer.enqueue(new MockResponse().setResponseCode(500));
+
+            List<YoutubeReferenceDto> result = youtubeSearchService.searchVideos(
+                    List.of("쿼리1", "쿼리2"));
+
+            assertThat(result).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("searchVideos - 타임아웃 처리")
+    class TimeoutHandling {
+
+        @Test
+        @DisplayName("응답이 타임아웃 내에 오지 않으면 해당 검색어는 건너뛴다")
+        void 타임아웃_발생_해당검색어_스킵() throws InterruptedException {
+            // 응답을 25초 지연 (YOUTUBE_TIMEOUT = 20초보다 길게)
+            mockWebServer.enqueue(new MockResponse()
+                    .setBody(SUCCESS_RESPONSE)
+                    .addHeader("Content-Type", "application/json")
+                    .setBodyDelay(25, TimeUnit.SECONDS));
+            // 두 번째 검색어는 정상 응답
+            mockWebServer.enqueue(new MockResponse()
+                    .setBody(SUCCESS_RESPONSE)
+                    .addHeader("Content-Type", "application/json"));
+
+            long start = System.currentTimeMillis();
+            List<YoutubeReferenceDto> result = youtubeSearchService.searchVideos(
+                    List.of("타임아웃쿼리", "정상쿼리"));
+            long elapsed = System.currentTimeMillis() - start;
+
+            // 타임아웃이 적용되므로 25초까지 기다리지 않음
+            assertThat(elapsed).isLessThan(25_000L);
+            // 타임아웃된 첫 번째는 제외, 두 번째 성공 결과만 반환 (또는 빈 리스트)
+            // flatMap 병렬 처리 + onErrorResume이므로 성공한 것만 포함
+            assertThat(result.size()).isLessThanOrEqualTo(1);
+        }
+    }
+
+    @Nested
+    @DisplayName("searchVideos - 응답 파싱")
+    class ResponseParsing {
+
+        @Test
+        @DisplayName("videoId가 없는 응답은 결과에서 제외된다")
+        void videoId_없는_응답_제외() {
+            String noVideoIdResponse = """
+                    {
+                      "items": [
+                        {
+                          "id": {},
+                          "snippet": { "title": "제목" }
+                        }
+                      ]
+                    }
+                    """;
+            mockWebServer.enqueue(new MockResponse()
+                    .setBody(noVideoIdResponse)
+                    .addHeader("Content-Type", "application/json"));
+
+            List<YoutubeReferenceDto> result = youtubeSearchService.searchVideos(List.of("쿼리"));
+
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        @DisplayName("썸네일 URL이 없으면 기본 썸네일 URL이 적용된다")
+        void 썸네일_없으면_기본URL_적용() {
+            String noThumbnailResponse = """
+                    {
+                      "items": [
+                        {
+                          "id": { "videoId": "xyz789" },
+                          "snippet": {
+                            "title": "썸네일없는영상",
+                            "thumbnails": {}
+                          }
+                        }
+                      ]
+                    }
+                    """;
+            mockWebServer.enqueue(new MockResponse()
+                    .setBody(noThumbnailResponse)
+                    .addHeader("Content-Type", "application/json"));
+
+            List<YoutubeReferenceDto> result = youtubeSearchService.searchVideos(List.of("쿼리"));
+
+            assertThat(result).hasSize(1);
+            // 기본 썸네일 URL 형식 적용
+            assertThat(result.get(0).getThumbnail())
+                    .isEqualTo("https://img.youtube.com/vi/xyz789/mqdefault.jpg");
+        }
+    }
+}

--- a/src/test/java/com/cookeep/cookeep/domain/recipe/application/YoutubeSearchServiceTest.java
+++ b/src/test/java/com/cookeep/cookeep/domain/recipe/application/YoutubeSearchServiceTest.java
@@ -7,9 +7,11 @@ import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.reactive.function.client.ClientRequest;
 import org.springframework.web.reactive.function.client.WebClient;
 
 import java.io.IOException;
+import java.net.URI;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
@@ -49,12 +51,26 @@ public class YoutubeSearchServiceTest {
         mockWebServer.start();
 
         WebClient webClient = WebClient.builder()
-                .baseUrl(mockWebServer.url("/").toString())
+                .filter((request, next) -> {
+                    URI originalUri = request.url();
+
+                    String pathWithQuery = originalUri.getRawPath();
+                    if (originalUri.getRawQuery() != null) {
+                        pathWithQuery += "?" + originalUri.getRawQuery();
+                    }
+
+                    URI newUri = mockWebServer.url(pathWithQuery).uri();
+
+                    return next.exchange(
+                            ClientRequest.from(request)
+                                    .url(newUri)
+                                    .build()
+                    );
+                })
                 .build();
 
         youtubeSearchService = new YoutubeSearchService(webClient);
-        // MockWebServer 주소로 override (실제 googleapis.com 대신)
-        ReflectionTestUtils.setField(youtubeSearchService, "youtubeApiKey", "test-api-key");
+        ReflectionTestUtils.setField(youtubeSearchService, "youtubeApiKey", "test-key");
     }
 
     @AfterEach


### PR DESCRIPTION
# Issue
#189 

# Description
AI 레시피 생성 과정에서 발생하던 503 서비스 불가 및 응답 지연 문제를 해결하기 위해
Gemini API 호출에 타임아웃·재시도 전략을 적용하고,
YouTube 검색을 순차 처리에서 병렬 처리로 전환하였습니다.
### 배경
- Gemini API는 복잡한 레시피 생성 시 최대 2분까지 소요될 수 있음
- 일시적인 5xx 오류 발생 시 재시도 없이 즉시 실패하여 사용자 경험 저하
- YouTube 검색어가 N개일 때 순차 block() N회 호출로 불필요한 지연 발생

# Changes
### GeminiService.java
- Timeout 적용: Gemini API 호출에 .timeout(Duration.ofSeconds(120)) 추가
   - 레시피 생성 특성상 과부하 없는 상황에서도 최대 2분 소요 가능한 점을 반영
- Retry 적용: Retry.backoff(3, Duration.ofSeconds(2)).maxBackoff(Duration.ofSeconds(10)) 추가
   - 재시도 대상: 5xx 응답 및 TimeoutException만 대상으로 제한
   - 재시도 비대상: 4xx (잘못된 요청), 429 (Rate Limit) — 즉시 실패 처리
   - 최대 3회 재시도 (원본 포함 총 4회 요청)
- isRetryableError() 헬퍼 메서드 추가: 재시도 가능 여부 판별 로직 분리
- 재시도 시 doBeforeRetry 로그 출력으로 디버깅 용이성 확보
```
// 변경 전
.bodyToMono(String.class)
.block();

// 변경 후
.bodyToMono(String.class)
.timeout(Duration.ofSeconds(120))
.retryWhen(
    Retry.backoff(3, Duration.ofSeconds(2))
        .maxBackoff(Duration.ofSeconds(10))
        .filter(this::isRetryableError)
        .doBeforeRetry(signal -> log.warn("Gemini 재시도 중... attempt={}", signal.totalRetries() + 1))
)
.block();
```
### YoutubeSearchService.java
- searchSingleVideo 반환 타입 변경: YoutubeReferenceDto → Mono<YoutubeReferenceDto>
   - 기존: 동기 메서드로 flatMap 내부에서 타입 불일치 발생
   - 변경: Mono 반환으로 Flux.flatMap 병렬 처리 가능하도록 수정
- 병렬 처리 적용: Flux.fromIterable().flatMap() 으로 N개 검색어 동시 처리
   - 기존: 검색어 N개 → 순차 N번 block() → 직렬 처리
   - 변경: 검색어 N개 → 동시 요청 → 결과 수집 (속도 개선)
- Timeout 적용: 개별 검색에 .timeout(Duration.ofSeconds(20)) 적용
- 부분 실패 허용: onErrorResume(Mono.empty()) 로 일부 검색어 실패 시 나머지 결과 정상 반환
- 기존 try-catch 기반 동기 코드 제거
```
// 변경 전: 반환 타입 불일치로 컴파일 에러
private YoutubeReferenceDto searchSingleVideo(String query) { ... }

// 변경 후
private Mono<YoutubeReferenceDto> searchSingleVideo(String query) {
    return webClient.get()
        ...
        .bodyToMono(String.class)
        .timeout(YOUTUBE_TIMEOUT)
        .mapNotNull(body -> parseSearchResult(body, query));
}
```

# Test Checklist
### GeminiService 테스트 (GeminiServiceTest.java) — 신규
- [x] 정상 응답 시 레시피를 파싱하여 반환한다
- [x]  503 응답 후 재시도로 정상 응답 시 성공한다
- [x]  500 응답 3회 연속 시 최대 재시도 후 AI_SEARCH_FAILED 예외를 던진다 (총 4회 요청 확인)
- [x]  400 응답은 재시도 없이 즉시 실패한다 (총 1회 요청 확인)
- [x]  429 응답은 재시도 없이 AI_RATE_LIMIT_EXCEEDED 예외를 던진다
- [x]  타임아웃 초과 시 예외가 발생한다

### YoutubeSearchService 테스트 (YoutubeSearchServiceTest.java) — 신규
- [x]  null 입력 시 빈 리스트 반환
- [x]  빈 리스트 입력 시 빈 리스트 반환
- [x]  검색어 1개, 정상 응답 → DTO 1개 반환 (title, url, thumbnail 필드 검증)
- [x]  검색 결과 없는 응답 (items: []) → 빈 리스트 반환
- [x]  검색어 3개 중 1개 500 에러 → 나머지 2개 결과 반환 (부분 실패 허용)
- [x]  모든 검색어 실패 → 빈 리스트 반환
- [x]  타임아웃 초과 시 해당 검색어 스킵, 전체 결과에 영향 없음
- [x]  videoId 없는 응답 → 결과 제외
- [x]  썸네일 URL 없는 응답 → 기본 썸네일 URL 적용

### 기존 테스트 영향 검토
- [x]  AiRecipeServiceTest — youtubeSearchService.searchVideos() mock 반환값 형식 동일 (List<YoutubeReferenceDto>), 변경 없음
- [x]  GeminiService는 Service 레이어에서 block() 유지 → Controller, Service 계층 테스트 영향 없음
- [x]  YoutubeSearchService의 public 메서드 시그니처(searchVideos) 변경 없음 → 호출부 변경 없음
---
### 참고 — 적용된 설정 요약

항목 | 설정값 | 이유
-- | -- | --
Gemini Timeout | 120초 | 레시피 생성은 정상 상황에서도 최대 2분 소요 가능
Gemini Retry 횟수 | 최대 3회 (총 4회) | 503 등 일시적 장애 자동 복구
Gemini Retry 조건 | 5xx + TimeoutException | 4xx/429는 재시도 불필요
Gemini Retry backoff | 2초 시작, 최대 10초 | 급격한 재요청으로 인한 과부하 방지
YouTube Timeout | 20초 | 유튜브 검색은 레시피 핵심 기능이 아니므로 짧게 설정
YouTube 처리 방식 | Flux.flatMap 병렬 | N개 검색어 동시 처리로 응답 속도 개선

