### PR TITLE
refactor: 로그인, 액세스 토큰 재발급 시 응답값에 isRewarded 추가

### DIFF
--- a/src/main/java/com/cookeep/cookeep/api/dto/response/LoginResponseDTO.java
+++ b/src/main/java/com/cookeep/cookeep/api/dto/response/LoginResponseDTO.java
@@ -4,6 +4,6 @@ import com.cookeep.cookeep.domain.user.entity.UserStatus;
 
 public record LoginResponseDTO(
 	Long userId, String accessToken,
-	String refreshToken, UserStatus userStatus
+	String refreshToken, UserStatus userStatus, boolean isRewarded // isRewarded - 14일 이상 미접속 후 접속 시 쿠키 보상, 해당 보상 지급 여부
 ) {
 }

--- a/src/main/java/com/cookeep/cookeep/api/dto/response/SocialLoginResponseDTO.java
+++ b/src/main/java/com/cookeep/cookeep/api/dto/response/SocialLoginResponseDTO.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 public record SocialLoginResponseDTO(
 	Long userId, String accessToken,
 	String refreshToken, UserStatus userStatus,
-	NextStep nextStep // nullable
+	NextStep nextStep, // nullable
+	boolean isRewarded // isRewarded - 14일 이상 미접속 후 접속 시 쿠키 보상, 해당 보상 지급 여부
 ) {
 }

--- a/src/main/java/com/cookeep/cookeep/api/dto/response/TokenRefreshResponseDTO.java
+++ b/src/main/java/com/cookeep/cookeep/api/dto/response/TokenRefreshResponseDTO.java
@@ -1,6 +1,7 @@
 package com.cookeep.cookeep.api.dto.response;
 
 public record TokenRefreshResponseDTO(
-	String accessToken
+	String accessToken,
+	boolean isRewarded
 ) {
 }

--- a/src/main/java/com/cookeep/cookeep/domain/user/application/AuthService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/user/application/AuthService.java
@@ -82,14 +82,13 @@ public class AuthService {
 		}
 
 		User user = userReader.readById(userId);
-
-		issueComebackReward(user);
+		boolean isRewarded = issueComebackReward(user);
 		user.updateLastAccessAt(LocalDateTime.now());
 
 		// 새로운 액세스토큰 발급
 		String accessToken = jwtTokenProvider.createAccessToken(user.getUserId());
 
-		return new TokenRefreshResponseDTO(accessToken);
+		return new TokenRefreshResponseDTO(accessToken, isRewarded);
 	}
 
 	private void validateRefreshToken(String refreshToken) {
@@ -101,12 +100,12 @@ public class AuthService {
 		}
 	}
 
-	private void issueComebackReward(User user) {
+	private boolean issueComebackReward(User user) {
 		LocalDateTime lastAccessAt = user.getLastAccessAt();
 
 		if (lastAccessAt == null) {
 			log.warn("lastAccessAt가 null입니다. userId=", user.getUserId());
-			return;
+			return false;
 		}
 
 		LocalDateTime now = LocalDateTime.now();
@@ -114,11 +113,13 @@ public class AuthService {
 		long inactivedDays = ChronoUnit.DAYS.between(lastAccessAt, now);
 
 		if (inactivedDays < 14) {
-			// 14일 미만일 경우 해당되지 않으므로 return하고 끝냄
-			return;
+			// 14일 미만일 경우 해당되지 않으므로 false 리턴하고 끝냄
+			return false;
 		}
 
 		cookieService.updateCookie(user.getUserId(), CookieLog.CookieLogType.BONUS_RETENTION_REWARD);
+
+		return true;
 	}
 
 	private Long extractUserIdFromRefreshToken(String refreshToken) {
@@ -131,7 +132,8 @@ public class AuthService {
 	}
 
 	private TokenPair issueTokensAndUpsertSession(User user) {
-		issueComebackReward(user);
+		// 미접속 일수 기반 식물 상태 계산 및 성장 정지 처리
+		boolean isRewarded = issueComebackReward(user);
 		user.updateLastAccessAt(LocalDateTime.now());
 
 		// 액세스 토큰, 리프레쉬 토큰 발급
@@ -148,7 +150,7 @@ public class AuthService {
 
 		userSessionRepository.save(userSession);
 
-		return new TokenPair(accessToken, refreshToken);
+		return new TokenPair(accessToken, refreshToken, isRewarded);
 	}
 
 	// 닉네임 제약 위반 시 재시도 횟수를 제한하기 위한 값 (무한 반복 방지)
@@ -216,7 +218,7 @@ public class AuthService {
 
 		return new SocialLoginResponseDTO(
 			user.getUserId(), tokenPair.accessToken(), tokenPair.refreshToken(),
-			userStatus, nextStep
+			userStatus, nextStep, tokenPair.isRewarded()
 		);
 	}
 
@@ -419,7 +421,7 @@ public class AuthService {
 		UserStatus userStatus = user.getUserStatus();
 
 		return new LoginResponseDTO(
-			user.getUserId(), tokenPair.accessToken(), tokenPair.refreshToken(), userStatus
+			user.getUserId(), tokenPair.accessToken(), tokenPair.refreshToken(), userStatus, tokenPair.isRewarded()
 		);
 	}
 

--- a/src/main/java/com/cookeep/cookeep/domain/user/application/AuthService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/user/application/AuthService.java
@@ -132,7 +132,6 @@ public class AuthService {
 	}
 
 	private TokenPair issueTokensAndUpsertSession(User user) {
-		// 미접속 일수 기반 식물 상태 계산 및 성장 정지 처리
 		boolean isRewarded = issueComebackReward(user);
 		user.updateLastAccessAt(LocalDateTime.now());
 

--- a/src/main/java/com/cookeep/cookeep/domain/user/dto/TokenPair.java
+++ b/src/main/java/com/cookeep/cookeep/domain/user/dto/TokenPair.java
@@ -1,6 +1,7 @@
 package com.cookeep.cookeep.domain.user.dto;
 
 public record TokenPair(
-	String accessToken, String refreshToken
+	String accessToken, String refreshToken, boolean isRewarded
+	// isRewarded - 14일 이상 미접속 후 접속 시 쿠키 보상, 해당 보상 지급 여부
 ) {
 }


### PR DESCRIPTION
# Related Issue

#219 

</br></br>

# Description

## 로그인, 액세스 토큰 재발급 시 응답값에 isRewarded 추가

- 14일 이상 미접속 후 재접속 시 쿠키 보상 지급 여부
- 프론트 확인 및 처리를 위해 isRewarded 추가

</br></br>

# Changes

- `isRewarded()` 추가