### PR TITLE
fix: 성장 정지된 식물 포기하기 선택 시 500 에러

### DIFF
--- a/src/main/java/com/cookeep/cookeep/domain/plant/application/UserPlantService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/plant/application/UserPlantService.java
@@ -201,7 +201,7 @@ public class UserPlantService {
         userPlant.giveWater();
 
         WateringLog log = WateringLog.builder()
-                .userPlant(userPlant)
+                .userPlantId(userPlant.getUserPlantId())
                 .user(user)
                 .build();
         wateringLogRepository.save(log);

--- a/src/main/java/com/cookeep/cookeep/domain/plant/entity/WateringLog.java
+++ b/src/main/java/com/cookeep/cookeep/domain/plant/entity/WateringLog.java
@@ -18,9 +18,8 @@ public class WateringLog extends BaseEntity {
     @Column(name = "watering_log_id")
     private Long wateringLogId;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_plant_id", nullable = false)
-    private UserPlant userPlant; // 어떤 식물에 물을 줬는지
+    @Column(name = "user_plant_id")
+    private Long userPlantId; // 어떤 식물에 물을 줬는지 (FK 없이 ID만 보관)
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)


### PR DESCRIPTION
# Related Issue
CLOSE #233 

# Description
`DELETE /api/my-plants/{userPlantId}` (식물 포기하기) 호출 시 
MySQL FK 제약 위반으로 500 에러가 발생하던 버그를 수정합니다.                                            
                                                                                                                                                                       
`watering_logs` 테이블이 `user_plants`를 FK로 참조하고 있어, 
`UserPlant` 삭제 시 해당 식물의 물주기 로그가 남아있으면 DELETE 쿼리가 실패했습니다. 
물주기 로그는 랭킹 집계 용도로 식물 삭제 후에도 유지되어야 하므로, 
FK 관계를 끊고 ID만 보관하는 방식으로 변경했습니다.                                                                       
                                                                                                                                                                       
# Changes                                                                                                                                                              
                                                                                                                                                                       
  - `WateringLog`: `@ManyToOne UserPlant userPlant` → `Long userPlantId` (FK 제거, ID만 보관)                                                                                
  - `UserPlantService`: `WateringLog` 생성 시 `.userPlant(userPlant) → .userPlantId(userPlant.getUserPlantId())`
  - DB: `watering_logs.user_plant_id` 컬럼의 FK 제약 조건 제거 필요 (DDL 직접 적용) 

# 참고사항
로컬 DB에 제약조건키 삭제하는 명령문 실행이 필요합니다! (RDS에는 제가 해놓겠습니다)
```sql
alter table watering_logs drop foreign key FK262q5uhw3kh4fpohcn1w73b6j;
```