### PR TITLE
feat: 쿠킵스 랭킹 조회 API에 Redis 캐싱 도입

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,12 +46,25 @@ jobs:
           key: ${{ secrets.EC2_SSH_KEY }}
           script: |
             docker pull ${{ secrets.DOCKER_USERNAME }}/cookeep:latest
+            docker network create cookeep-network 2>/dev/null || true
+            docker run -d \
+              --name cookeep-redis \
+              --network cookeep-network \
+              --restart unless-stopped \
+              -v redis-data:/data \
+              redis:7.2-alpine \
+              redis-server --appendonly yes --requirepass ${{ secrets.REDIS_PASSWORD }} \
+              2>/dev/null || true
             docker stop cookeep || true
             docker rm cookeep || true
             docker run -d \
               --name cookeep \
+              --network cookeep-network \
               -p 8080:8080 \
               -e TZ=Asia/Seoul \
+              -e REDIS_HOST=cookeep-redis \
+              -e REDIS_PORT=6379 \
+              -e REDIS_PASSWORD=${{ secrets.REDIS_PASSWORD }} \
               -e DB_URL=${{ secrets.DB_URL }} \
               -e DB_USERNAME=${{ secrets.DB_USERNAME }} \
               -e DB_PASSWORD=${{ secrets.DB_PASSWORD }} \

--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,8 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	implementation 'org.springframework.boot:spring-boot-starter-cache'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+services:
+  redis:
+    image: redis:7.2-alpine
+    container_name: cookeep-redis
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis-data:/data
+    command: redis-server --appendonly yes
+    restart: unless-stopped
+
+volumes:
+  redis-data:

--- a/src/main/java/com/cookeep/cookeep/api/dto/response/RankingResponseDto.java
+++ b/src/main/java/com/cookeep/cookeep/api/dto/response/RankingResponseDto.java
@@ -1,12 +1,16 @@
 package com.cookeep.cookeep.api.dto.response;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.util.List;
 
 @Getter
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class RankingResponseDto {
 	private List<WateringRankDto> wateringRanking;
 	private List<RecipeRankDto> recipeRanking;
@@ -14,6 +18,8 @@ public class RankingResponseDto {
 
 	@Getter
 	@Builder
+	@NoArgsConstructor
+	@AllArgsConstructor
 	public static class WateringRankDto {
 		private Integer rank;
 		private String nickname;
@@ -23,6 +29,8 @@ public class RankingResponseDto {
 
 	@Getter
 	@Builder
+	@NoArgsConstructor
+	@AllArgsConstructor
 	public static class RecipeRankDto {
 		private Long dailyRecipeId;
 		private Integer rank;

--- a/src/main/java/com/cookeep/cookeep/config/RedisConfig.java
+++ b/src/main/java/com/cookeep/cookeep/config/RedisConfig.java
@@ -38,14 +38,14 @@ public class RedisConfig {
         StringRedisSerializer keySerializer = new StringRedisSerializer();
 
         RedisCacheConfiguration wateringConfig = RedisCacheConfiguration.defaultCacheConfig()
-            .entryTtl(Duration.ofHours(1))
+            .entryTtl(Duration.ofMinutes(10))
             .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(keySerializer))
             .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(
                 typedSerializer(objectMapper, wateringType)))
             .disableCachingNullValues();
 
         RedisCacheConfiguration recipeConfig = RedisCacheConfiguration.defaultCacheConfig()
-            .entryTtl(Duration.ofMinutes(30))
+            .entryTtl(Duration.ofMinutes(10))
             .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(keySerializer))
             .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(
                 typedSerializer(objectMapper, recipeType)))

--- a/src/main/java/com/cookeep/cookeep/config/RedisConfig.java
+++ b/src/main/java/com/cookeep/cookeep/config/RedisConfig.java
@@ -1,0 +1,83 @@
+package com.cookeep.cookeep.config;
+
+import com.cookeep.cookeep.api.dto.response.RankingResponseDto.RecipeRankDto;
+import com.cookeep.cookeep.api.dto.response.RankingResponseDto.WateringRankDto;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.RedisSerializer;
+import org.springframework.data.redis.serializer.SerializationException;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import java.time.Duration;
+import java.util.List;
+
+@Configuration
+@EnableCaching
+public class RedisConfig {
+
+    @Bean
+    public RedisCacheManager cacheManager(RedisConnectionFactory connectionFactory) {
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+        objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+
+        JavaType wateringType = objectMapper.getTypeFactory()
+            .constructCollectionType(List.class, WateringRankDto.class);
+        JavaType recipeType = objectMapper.getTypeFactory()
+            .constructCollectionType(List.class, RecipeRankDto.class);
+
+        StringRedisSerializer keySerializer = new StringRedisSerializer();
+
+        RedisCacheConfiguration wateringConfig = RedisCacheConfiguration.defaultCacheConfig()
+            .entryTtl(Duration.ofHours(1))
+            .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(keySerializer))
+            .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(
+                typedSerializer(objectMapper, wateringType)))
+            .disableCachingNullValues();
+
+        RedisCacheConfiguration recipeConfig = RedisCacheConfiguration.defaultCacheConfig()
+            .entryTtl(Duration.ofMinutes(30))
+            .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(keySerializer))
+            .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(
+                typedSerializer(objectMapper, recipeType)))
+            .disableCachingNullValues();
+
+        return RedisCacheManager.builder(connectionFactory)
+            .withCacheConfiguration("wateringRanking", wateringConfig)
+            .withCacheConfiguration("recipeRanking", recipeConfig)
+            .build();
+    }
+
+    private static RedisSerializer<Object> typedSerializer(ObjectMapper objectMapper, JavaType type) {
+        return new RedisSerializer<>() {
+            @Override
+            public byte[] serialize(Object value) throws SerializationException {
+                if (value == null) return null;
+                try {
+                    return objectMapper.writeValueAsBytes(value);
+                } catch (Exception e) {
+                    throw new SerializationException("Could not serialize: " + e.getMessage(), e);
+                }
+            }
+
+            @Override
+            public Object deserialize(byte[] bytes) throws SerializationException {
+                if (bytes == null || bytes.length == 0) return null;
+                try {
+                    return objectMapper.readValue(bytes, type);
+                } catch (Exception e) {
+                    throw new SerializationException("Could not deserialize: " + e.getMessage(), e);
+                }
+            }
+        };
+    }
+}

--- a/src/main/java/com/cookeep/cookeep/domain/cookeeps/application/CookeepsService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/cookeeps/application/CookeepsService.java
@@ -28,7 +28,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.temporal.TemporalAdjusters;
 import java.util.List;
-import java.util.stream.IntStream;
+
 
 @Service
 @RequiredArgsConstructor
@@ -37,7 +37,7 @@ public class CookeepsService {
 	private final UserReader userReader;
 	private final WateringLogRepository wateringLogRepository;
 	private final DailyRecipeRepository dailyRecipeRepository;
-	private final UserRepository userRepository;
+	private final RankingCacheService rankingCacheService;
 
 	@Transactional(readOnly = true)
 	public RankingResponseDto getRanking(Long userId) {
@@ -49,8 +49,8 @@ public class CookeepsService {
 			.atStartOfDay();
 		LocalDateTime weekEnd = weekStart.plusDays(7);
 
-		List<WateringRankDto> wateringRanking = getWateringRanking(monthStart, monthEnd);
-		List<RecipeRankDto> recipeRanking = getRecipeRanking(weekStart, weekEnd);
+		List<WateringRankDto> wateringRanking = rankingCacheService.getWateringRanking(monthStart, monthEnd);
+		List<RecipeRankDto> recipeRanking = rankingCacheService.getRecipeRanking(weekStart, weekEnd);
 		Long myWateringCount = wateringLogRepository.countByUserAndMonth(userId, monthStart, monthEnd);
 
 		return RankingResponseDto.builder()
@@ -58,55 +58,6 @@ public class CookeepsService {
 			.recipeRanking(recipeRanking)
 			.myWateringCount(myWateringCount)
 			.build();
-	}
-
-	private List<WateringRankDto> getWateringRanking(LocalDateTime monthStart, LocalDateTime monthEnd) {
-		// 1단계: 이번 달 물주기 상위 3명 조회
-		List<Object[]> results = wateringLogRepository.findTopWateringUsers(
-			monthStart, monthEnd, PageRequest.of(0, 3));
-		
-		// 2단계: 인덱스를 포함한 스트림 처리
-		return IntStream.range(0, results.size()) // 0부터 results 크기-1까지
-			.mapToObj(index -> {
-				Object[] row = results.get(index);
-				User user = (User) row[0]; // 유저 객체 추출
-				Long wateringCount = (Long) row[1]; // 물주기 횟수 추출
-
-				// 프로필 이미지 URL 가져오기
-				String profileImageUrl = user.getProfilePlant() != null
-					? user.getProfilePlant().getCurrentImageUrl()
-					: null;
-
-				// DTO로 변환 (rank = 인덱스 + 1 → 1, 2, 3)
-				return WateringRankDto.builder()
-					.rank(index + 1)
-					.nickname(user.getNickname())
-					.profileImageUrl(profileImageUrl)
-					.wateringCount(wateringCount)
-					.build();
-			})
-			.toList();
-	}
-
-	private List<RecipeRankDto> getRecipeRanking(LocalDateTime weekStart, LocalDateTime weekEnd) {
-		// 이번 주 공개 레시피 중 좋아요 상위 3개 조회 (좋아요 내림차순, 동점 시 등록 오래된 순)
-		List<DailyRecipe> results = dailyRecipeRepository.findTopRankedRecipes(
-			weekStart, weekEnd, PageRequest.of(0, 3));
-
-		return IntStream.range(0, results.size())
-			.mapToObj(index -> {
-				DailyRecipe recipe = results.get(index);
-
-				return RecipeRankDto.builder()
-						.dailyRecipeId(recipe.getId())
-						.rank(index + 1)
-						.nickname(recipe.getUser().getNickname())
-						.title(recipe.getTitle())
-						.likeCount(recipe.getLikeCount().longValue())
-						.recipeImageUrl(recipe.getRecipeImageUrl())
-						.build();
-			})
-			.toList();
 	}
 
 	@Transactional(readOnly = true)

--- a/src/main/java/com/cookeep/cookeep/domain/cookeeps/application/RankingCacheEvictScheduler.java
+++ b/src/main/java/com/cookeep/cookeep/domain/cookeeps/application/RankingCacheEvictScheduler.java
@@ -1,0 +1,22 @@
+package com.cookeep.cookeep.domain.cookeeps.application;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class RankingCacheEvictScheduler {
+
+    private final RankingCacheService rankingCacheService;
+
+    @Scheduled(cron = "0 1 0 1 * *", zone = "Asia/Seoul")
+    public void evictOnMonthStart() {
+        rankingCacheService.evictAllRankingCaches();
+    }
+
+    @Scheduled(cron = "0 1 0 * * MON", zone = "Asia/Seoul")
+    public void evictOnWeekStart() {
+        rankingCacheService.evictAllRankingCaches();
+    }
+}

--- a/src/main/java/com/cookeep/cookeep/domain/cookeeps/application/RankingCacheService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/cookeeps/application/RankingCacheService.java
@@ -1,0 +1,76 @@
+package com.cookeep.cookeep.domain.cookeeps.application;
+
+import com.cookeep.cookeep.api.dto.response.RankingResponseDto.RecipeRankDto;
+import com.cookeep.cookeep.api.dto.response.RankingResponseDto.WateringRankDto;
+import com.cookeep.cookeep.domain.dailyrecipe.dao.DailyRecipeRepository;
+import com.cookeep.cookeep.domain.dailyrecipe.entity.DailyRecipe;
+import com.cookeep.cookeep.domain.plant.dao.WateringLogRepository;
+import com.cookeep.cookeep.domain.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+@Service
+@RequiredArgsConstructor
+public class RankingCacheService {
+
+    private final WateringLogRepository wateringLogRepository;
+    private final DailyRecipeRepository dailyRecipeRepository;
+
+    @Cacheable(cacheNames = "wateringRanking", key = "'current'")
+    @Transactional(readOnly = true)
+    public List<WateringRankDto> getWateringRanking(LocalDateTime monthStart, LocalDateTime monthEnd) {
+        List<Object[]> results = wateringLogRepository.findTopWateringUsers(
+            monthStart, monthEnd, PageRequest.of(0, 3));
+
+        return IntStream.range(0, results.size())
+            .mapToObj(index -> {
+                Object[] row = results.get(index);
+                User user = (User) row[0];
+                Long wateringCount = (Long) row[1];
+                String profileImageUrl = user.getProfilePlant() != null
+                    ? user.getProfilePlant().getCurrentImageUrl()
+                    : null;
+                return WateringRankDto.builder()
+                    .rank(index + 1)
+                    .nickname(user.getNickname())
+                    .profileImageUrl(profileImageUrl)
+                    .wateringCount(wateringCount)
+                    .build();
+            })
+            .collect(Collectors.toList());
+    }
+
+    @Cacheable(cacheNames = "recipeRanking", key = "'current'")
+    @Transactional(readOnly = true)
+    public List<RecipeRankDto> getRecipeRanking(LocalDateTime weekStart, LocalDateTime weekEnd) {
+        List<DailyRecipe> results = dailyRecipeRepository.findTopRankedRecipes(
+            weekStart, weekEnd, PageRequest.of(0, 3));
+
+        return IntStream.range(0, results.size())
+            .mapToObj(index -> {
+                DailyRecipe recipe = results.get(index);
+                return RecipeRankDto.builder()
+                    .dailyRecipeId(recipe.getId())
+                    .rank(index + 1)
+                    .nickname(recipe.getUser().getNickname())
+                    .title(recipe.getTitle())
+                    .likeCount(recipe.getLikeCount().longValue())
+                    .recipeImageUrl(recipe.getRecipeImageUrl())
+                    .build();
+            })
+            .collect(Collectors.toList());
+    }
+
+    @CacheEvict(cacheNames = {"wateringRanking", "recipeRanking"}, allEntries = true)
+    public void evictAllRankingCaches() {
+    }
+}

--- a/src/main/java/com/cookeep/cookeep/domain/plant/application/UserPlantService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/plant/application/UserPlantService.java
@@ -18,7 +18,6 @@ import com.cookeep.cookeep.domain.user.application.UserReader;
 import com.cookeep.cookeep.domain.user.dao.UserRepository;
 import com.cookeep.cookeep.domain.user.entity.User;
 import lombok.RequiredArgsConstructor;
-import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -177,7 +176,6 @@ public class UserPlantService {
 
     // 식물에게 물 주기 (무료 물주기 여부 반환)
     @Transactional
-    @CacheEvict(cacheNames = "wateringRanking", allEntries = true)
     public boolean giveWater(Long userId, Long userPlantId) {
         // 1. 식물 조회
         UserPlant userPlant = userPlantRepository.findById(userPlantId)

--- a/src/main/java/com/cookeep/cookeep/domain/plant/application/UserPlantService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/plant/application/UserPlantService.java
@@ -18,13 +18,13 @@ import com.cookeep.cookeep.domain.user.application.UserReader;
 import com.cookeep.cookeep.domain.user.dao.UserRepository;
 import com.cookeep.cookeep.domain.user.entity.User;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
@@ -177,6 +177,7 @@ public class UserPlantService {
 
     // 식물에게 물 주기 (무료 물주기 여부 반환)
     @Transactional
+    @CacheEvict(cacheNames = "wateringRanking", allEntries = true)
     public boolean giveWater(Long userId, Long userPlantId) {
         // 1. 식물 조회
         UserPlant userPlant = userPlantRepository.findById(userPlantId)

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -13,6 +13,15 @@ spring:
   jackson:
     time-zone: Asia/Seoul
 
+  data:
+    redis:
+      host: ${REDIS_HOST:localhost}
+      port: ${REDIS_PORT:6379}
+      password: ${REDIS_PASSWORD:}
+
+  cache:
+    type: redis
+
   datasource:
     url: ${DB_URL}
     username: ${DB_USERNAME:root}


### PR DESCRIPTION
# Related Issue
CLOSE #232 

# Description

랭킹 조회 API(`GET /api/cookeeps/ranking`)에 Redis 캐싱을 도입했습니다.

### [Redis]

Redis는 데이터를 메모리에 저장하는 초고속 저장로, 기존에는 랭킹 API를 호출할 때마다 MySQL에 무거운 집계 쿼리(GROUP BY)를 날렸는데, 
이 결과를 Redis에 저장해두어 이후 요청은 DB를 거치지 않고 메모리에서 바로 꺼내줍니다.

### 도입 이유

랭킹 데이터는 모든 유저가 동일한 결과를 조회합니다. 즉, 100명이 동시에 랭킹을 보더라도 DB 쿼리는 1번만 날아가고, 나머지 99명은 Redis에서 응답합니다.                 
   
### 성능 측정 결과 (더미 데이터 5,400건 기준)                                                                                                                            
                  
| 구분                                | 응답 시간  |
|-------------------------------------|------------|
| 캐시 미스 (첫 요청, DB 조회)        | 289ms      |
| 캐시 히트 (이후 요청, Redis 반환)   | 36ms       |
| 개선율                              | 약 88% 감소 |                                                                                                              
                  
### 캐시 갱신 주기                                                                                                                                                       
   
  - 캐시는 10분 TTL로 자동 만료됩니다. 즉, 랭킹은 최대 10분 간격으로 갱신됩니다.                                                                                       
  - 월초(1일 00:01), 주초(월요일 00:01)에는 기간이 바뀌므로 스케줄러가 캐시를 즉시 삭제합니다.
                                                                                                                                                                       
# Changes                                                                                                                                                              
                  
### 로컬 개발 환경

  - docker-compose.yml 추가 — Redis 컨테이너 설정                                                                                                                      
    - `docker compose up -d `한 번으로 Redis 실행 가능합니다!! (별도 설치 불필요)
                                                                                                                                                                       
### 의존성 / 설정   
                                                                                                                                                                       
  - build.gradle — spring-boot-starter-data-redis, spring-boot-starter-cache 추가                                                                                      
  - application.yaml — Redis 연결 설정 추가 (REDIS_HOST, REDIS_PORT, REDIS_PASSWORD 환경변수)
                                                                                                                                                                       
### 핵심 로직       
                                                                                                                                                                       
  - RedisConfig.java (신규) — 캐시 직렬화 설정 및 TTL 정의 (wateringRanking, recipeRanking 각 10분)                                                                    
  - RankingCacheService.java (신규) — @Cacheable 적용. Spring AOP 특성상 같은 클래스 내 private 메서드에는 캐시가 동작하지 않아 별도 서비스로 분리
  - CookeepsService.java — 랭킹 조회를 RankingCacheService에 위임                                                                                                      
  - RankingResponseDto.java — Redis 역직렬화를 위해 내부 DTO에 @NoArgsConstructor, @AllArgsConstructor 추가                                                            
                                                                                                                                                                       
### 캐시 무효화                                                                                                                                                          
                                                                                                                                                                       
  - RankingCacheEvictScheduler.java (신규) — 월초 / 주초 캐시 자동 삭제 스케줄러                                                                                       
                  
### CI/CD (EC2 배포)                                                                                                                                                     
                  
  - .github/workflows/deploy.yml — 배포 시 Redis 컨테이너 자동 실행 및 Docker 네트워크 연결                                                                            
    - GitHub Secrets에 REDIS_PASSWORD 추가 완료