### PR TITLE
fix: 최근 추가 재료 계산 로직 수정

### DIFF
--- a/src/main/java/com/cookeep/cookeep/domain/ingredient/useringredient/application/RecentIngredientService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/ingredient/useringredient/application/RecentIngredientService.java
@@ -17,6 +17,7 @@ import com.cookeep.cookeep.domain.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import tools.jackson.databind.ObjectMapper;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -34,9 +35,7 @@ public class RecentIngredientService {
     private final DefaultIngredientRepository defaultIngredientRepository;
     private final CustomIngredientRepository customIngredientRepository;
     private final UserRepository userRepository;
-
-    private final com.fasterxml.jackson.databind.ObjectMapper objectMapper =
-            new com.fasterxml.jackson.databind.ObjectMapper();
+    private final ObjectMapper objectMapper;
 
     // 최근 추가한 순으로 최대 6개 재료 목록 반환 (첫 등록은 빈 리스트)
     public RecentIngredientsResponseDto getRecentIngredients(Long userId) {
@@ -85,12 +84,14 @@ public class RecentIngredientService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new AppException(ErrorCode.USER_NOT_FOUND));
 
+        Optional<RecentIngredientBatch> existingBatch = batchRepository.findByUser_UserId(userId);
+
         // 이번에 등록된 UserIngredient 조회
         List<UserIngredient> newIngredients =
                 userIngredientRepository.findAllByIngredientIdInAndUser_UserId(newIngredientIds, userId);
 
         // 기존 배치의 ingredientId 목록 로드
-        List<Long> existingIds = batchRepository.findByUser_UserId(userId)
+        List<Long> existingIds = existingBatch
                 .map(b -> parseIngredientIds(b.getIngredientIdsJson()))
                 .orElse(List.of());
 
@@ -101,16 +102,16 @@ public class RecentIngredientService {
         // ingredientId 내림차순 정렬 후 referenceId 중복 제거
         Map<String, UserIngredient> deduped = new LinkedHashMap<>();
 
+        // ingredientId DESC 정렬 후 LinkedHashMap에 삽입 → 삽입 순서가 곧 최종 순서
         Stream.concat(newIngredients.stream(), existingIngredients.stream())
                 .sorted(Comparator.comparingLong(UserIngredient::getIngredientId).reversed())
                 .forEach(ui -> {
                     String key = ui.getType().name() + "_" + ui.getReferenceId();
-                    deduped.putIfAbsent(key, ui); // 먼저 들어온(ingredientId 큰) 것 유지
+                    deduped.putIfAbsent(key, ui);
                 });
 
         // ingredientId 내림차순으로 최대 6개
         List<Long> finalIds = deduped.values().stream()
-                .sorted(Comparator.comparingLong(UserIngredient::getIngredientId).reversed())
                 .limit(MAX_RECENT_COUNT)
                 .map(UserIngredient::getIngredientId)
                 .toList();
@@ -118,11 +119,7 @@ public class RecentIngredientService {
         String idsJson = toJson(finalIds);
         String batchId = generateBatchId();
 
-        // upsert: 유저당 1행
-        RecentIngredientBatch batch = batchRepository.findByUser_UserId(userId)
-                .orElse(null);
-
-        if (batch == null) {
+        if (existingBatch.isEmpty()) {
             batchRepository.save(
                     RecentIngredientBatch.builder()
                             .user(user)
@@ -131,7 +128,7 @@ public class RecentIngredientService {
                             .build()
             );
         } else {
-            batch.update(batchId, idsJson);
+            existingBatch.get().update(batchId, idsJson);
         }
     }
 
@@ -144,7 +141,7 @@ public class RecentIngredientService {
         if (json == null || json.isBlank()) return List.of();
         try {
             return objectMapper.readValue(json,
-                    new com.fasterxml.jackson.core.type.TypeReference<List<Long>>() {});
+                    objectMapper.getTypeFactory().constructCollectionType(List.class, Long.class));
         } catch (Exception e) {
             return List.of();
         }
@@ -164,20 +161,17 @@ public class RecentIngredientService {
         List<Long> defaultIds = ingredients.stream()
                 .filter(ui -> ui.getType() == Type.DEFAULT)
                 .map(UserIngredient::getReferenceId)
-                .distinct()
                 .toList();
 
         List<Long> customIds = ingredients.stream()
                 .filter(ui -> ui.getType() == Type.CUSTOM)
                 .map(UserIngredient::getReferenceId)
-                .distinct()
                 .toList();
 
         // 타입별 1번씩만 조회 후 Map으로 변환
         Map<Long, DefaultIngredient> defaultMap = defaultIngredientRepository
                 .findAllById(defaultIds).stream()
                 .collect(Collectors.toMap(DefaultIngredient::getId, d -> d));
-
         Map<Long, CustomIngredient> customMap = customIngredientRepository
                 .findAllById(customIds).stream()
                 .collect(Collectors.toMap(CustomIngredient::getId, c -> c));
@@ -186,25 +180,22 @@ public class RecentIngredientService {
         return ingredients.stream().map(ui -> {
             String name;
             String imageUrl;
-
             if (ui.getType() == Type.DEFAULT) {
                 DefaultIngredient ref = defaultMap.get(ui.getReferenceId());
-                imageUrl = ref.getImageUrl();
-                name = ref.getIngredient();
+                name = ref != null ? ref.getIngredient() : "Unknown";
+                imageUrl = ref != null ? ref.getImageUrl() : "";
             } else {
                 CustomIngredient ref = customMap.get(ui.getReferenceId());
-                name = ref.getName();
-                imageUrl = ref.getImageUrl();
+                name = ref != null ? ref.getName() : "Unknown";
+                imageUrl = ref != null ? ref.getImageUrl() : "";
             }
-
             return RecentIngredientsResponseDto.RecentIngredientItem.builder()
                     .ingredientId(ui.getIngredientId())
                     .type(ui.getType().name())
                     .name(name)
                     .imageUrl(imageUrl)
                     .build();
-        })
-        .toList();
+        }).toList();
     }
 
 }

--- a/src/main/java/com/cookeep/cookeep/domain/ingredient/useringredient/application/RecentIngredientService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/ingredient/useringredient/application/RecentIngredientService.java
@@ -20,6 +20,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.*;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 @Service
 @RequiredArgsConstructor
@@ -34,74 +35,127 @@ public class RecentIngredientService {
     private final CustomIngredientRepository customIngredientRepository;
     private final UserRepository userRepository;
 
+    private final com.fasterxml.jackson.databind.ObjectMapper objectMapper =
+            new com.fasterxml.jackson.databind.ObjectMapper();
+
     // 최근 추가한 순으로 최대 6개 재료 목록 반환 (첫 등록은 빈 리스트)
     public RecentIngredientsResponseDto getRecentIngredients(Long userId) {
         if (userId == null) {
             throw new AppException(ErrorCode.UNAUTHORIZED);
         }
 
-        List<RecentIngredientBatch> batches =
-                batchRepository.findByUser_UserIdOrderByCreatedAtDesc(userId);
+        Optional<RecentIngredientBatch> batchOpt = batchRepository.findByUser_UserId(userId);
 
-        if (batches.isEmpty()) {
+        if (batchOpt.isEmpty() || batchOpt.get().getIngredientIdsJson() == null) {
             return RecentIngredientsResponseDto.builder()
                     .ingredients(List.of())
                     .build();
         }
 
-        // 1단계: 최신 배치부터 역순으로 총 6개 행 수집 (중복 포함)
-        List<UserIngredient> collectedRaw = new ArrayList<>();
-
-        for (RecentIngredientBatch batch : batches) {
-            if (collectedRaw.size() >= MAX_RECENT_COUNT) break;
-
-            List<UserIngredient> batchIngredients =
-                    userIngredientRepository.findByUserIdAndBatchId(userId, batch.getBatchId());
-
-            for (UserIngredient ui : batchIngredients) {
-                collectedRaw.add(ui);
-                if (collectedRaw.size() >= MAX_RECENT_COUNT) break;
-            }
+        List<Long> ingredientIds = parseIngredientIds(batchOpt.get().getIngredientIdsJson());
+        if (ingredientIds.isEmpty()) {
+            return RecentIngredientsResponseDto.builder()
+                    .ingredients(List.of())
+                    .build();
         }
 
-        // 2단계: type + referenceId 기준 중복 제거 (순서 유지)
-        Set<String> seenKeys = new LinkedHashSet<>();
-        List<UserIngredient> deduplicated = new ArrayList<>();
+        // ingredientId로 UserIngredient 조회
+        List<UserIngredient> ingredients =
+                userIngredientRepository.findAllByIngredientIdInAndUser_UserId(ingredientIds, userId);
 
-        for (UserIngredient ui : collectedRaw) {
-            String key = ui.getType().name() + "_" + ui.getReferenceId();
-            if (seenKeys.add(key)) { // add()는 중복이면 false 반환
-                deduplicated.add(ui);
-            }
-        }
+        // batch에 저장된 순서(ingredientId 내림차순) 그대로 정렬
+        Map<Long, UserIngredient> ingredientMap = ingredients.stream()
+                .collect(Collectors.toMap(UserIngredient::getIngredientId, ui -> ui));
 
-        // 3단계: DTO 변환
-        List<RecentIngredientsResponseDto.RecentIngredientItem> items = toItems(deduplicated);
+        List<UserIngredient> ordered = ingredientIds.stream()
+                .map(ingredientMap::get)
+                .filter(Objects::nonNull) // 삭제된 재료는 제외
+                .toList();
 
         return RecentIngredientsResponseDto.builder()
-                .ingredients(items)
+                .ingredients(toItems(ordered))
                 .build();
     }
 
     // 배치 저장: 재료 등록 완료 후 호출하여 최신 batchId를 업데이트
     @Transactional
-    public void saveBatch(Long userId, String batchId) {
+    public void saveBatch(Long userId, List<Long> newIngredientIds) {
+        if (newIngredientIds == null || newIngredientIds.isEmpty()) return;
 
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new AppException(ErrorCode.USER_NOT_FOUND));
 
-        // 기존 upsert 방식에서 항상 새 행 INSERT로 변경
-        batchRepository.save(
-                RecentIngredientBatch.builder()
-                        .user(user)
-                        .batchId(batchId)
-                        .build()
-        );
+        // 이번에 등록된 UserIngredient 조회
+        List<UserIngredient> newIngredients =
+                userIngredientRepository.findAllByIngredientIdInAndUser_UserId(newIngredientIds, userId);
+
+        // 기존 배치의 ingredientId 목록 로드
+        List<Long> existingIds = batchRepository.findByUser_UserId(userId)
+                .map(b -> parseIngredientIds(b.getIngredientIdsJson()))
+                .orElse(List.of());
+
+        List<UserIngredient> existingIngredients =
+                userIngredientRepository.findAllByIngredientIdInAndUser_UserId(existingIds, userId);
+
+        // 전체 후보 목록: 새것 + 기존것 (새것이 앞에 와야 중복 제거 시 최신이 살아남음)
+        // ingredientId 내림차순 정렬 후 referenceId 중복 제거
+        Map<String, UserIngredient> deduped = new LinkedHashMap<>();
+
+        Stream.concat(newIngredients.stream(), existingIngredients.stream())
+                .sorted(Comparator.comparingLong(UserIngredient::getIngredientId).reversed())
+                .forEach(ui -> {
+                    String key = ui.getType().name() + "_" + ui.getReferenceId();
+                    deduped.putIfAbsent(key, ui); // 먼저 들어온(ingredientId 큰) 것 유지
+                });
+
+        // ingredientId 내림차순으로 최대 6개
+        List<Long> finalIds = deduped.values().stream()
+                .sorted(Comparator.comparingLong(UserIngredient::getIngredientId).reversed())
+                .limit(MAX_RECENT_COUNT)
+                .map(UserIngredient::getIngredientId)
+                .toList();
+
+        String idsJson = toJson(finalIds);
+        String batchId = generateBatchId();
+
+        // upsert: 유저당 1행
+        RecentIngredientBatch batch = batchRepository.findByUser_UserId(userId)
+                .orElse(null);
+
+        if (batch == null) {
+            batchRepository.save(
+                    RecentIngredientBatch.builder()
+                            .user(user)
+                            .batchId(batchId)
+                            .ingredientIdsJson(idsJson)
+                            .build()
+            );
+        } else {
+            batch.update(batchId, idsJson);
+        }
     }
 
     // UUID 생성하여 반환. createAll() 에서 배치 시작 시 호출
     public static String generateBatchId() {
         return UUID.randomUUID().toString();
+    }
+
+    private List<Long> parseIngredientIds(String json) {
+        if (json == null || json.isBlank()) return List.of();
+        try {
+            return objectMapper.readValue(json,
+                    new com.fasterxml.jackson.core.type.TypeReference<List<Long>>() {});
+        } catch (Exception e) {
+            return List.of();
+        }
+    }
+
+    private String toJson(List<Long> ids) {
+        try {
+            return objectMapper.writeValueAsString(ids);
+        } catch (Exception e) {
+            return "[]";
+        }
     }
 
     private List<RecentIngredientsResponseDto.RecentIngredientItem> toItems(List<UserIngredient> ingredients) {
@@ -129,29 +183,28 @@ public class RecentIngredientService {
                 .collect(Collectors.toMap(CustomIngredient::getId, c -> c));
 
         // 매핑
-        return ingredients.stream()
-                .map(ui -> {
-                    String name;
-                    String imageUrl;
+        return ingredients.stream().map(ui -> {
+            String name;
+            String imageUrl;
 
-                    if (ui.getType() == Type.DEFAULT) {
-                        DefaultIngredient ref = defaultMap.get(ui.getReferenceId());
-                        imageUrl = ref.getImageUrl();
-                        name = ref.getIngredient();
-                    } else {
-                        CustomIngredient ref = customMap.get(ui.getReferenceId());
-                        name = ref.getName();
-                        imageUrl = ref.getImageUrl();
-                    }
+            if (ui.getType() == Type.DEFAULT) {
+                DefaultIngredient ref = defaultMap.get(ui.getReferenceId());
+                imageUrl = ref.getImageUrl();
+                name = ref.getIngredient();
+            } else {
+                CustomIngredient ref = customMap.get(ui.getReferenceId());
+                name = ref.getName();
+                imageUrl = ref.getImageUrl();
+            }
 
-                    return RecentIngredientsResponseDto.RecentIngredientItem.builder()
-                            .ingredientId(ui.getIngredientId())
-                            .type(ui.getType().name())
-                            .name(name)
-                            .imageUrl(imageUrl)
-                            .build();
-                })
-                .toList();
+            return RecentIngredientsResponseDto.RecentIngredientItem.builder()
+                    .ingredientId(ui.getIngredientId())
+                    .type(ui.getType().name())
+                    .name(name)
+                    .imageUrl(imageUrl)
+                    .build();
+        })
+        .toList();
     }
 
 }

--- a/src/main/java/com/cookeep/cookeep/domain/ingredient/useringredient/application/UserIngredientServiceImpl.java
+++ b/src/main/java/com/cookeep/cookeep/domain/ingredient/useringredient/application/UserIngredientServiceImpl.java
@@ -87,8 +87,13 @@ public class UserIngredientServiceImpl implements UserIngredientService {
                 .map(req -> createOne(user, req, batchId))
                 .toList();
 
-        // 최신 배치 ID 저장 (upsert)
-        recentIngredientService.saveBatch(userId, batchId);
+        // 이번 등록된 ingredientId 목록 수집
+        List<Long> newIngredientIds = results.stream()
+                .map(UserIngredientCreateResponseDto::getIngredientId)
+                .toList();
+
+        // 변경된 saveBatch 호출
+        recentIngredientService.saveBatch(userId, newIngredientIds);
 
         // 최초 재료 등록 온보딩 쿠키 지급 (일회성)
         boolean rewardGranted = grantFirstIngredientRewardIfEligible(user);

--- a/src/main/java/com/cookeep/cookeep/domain/ingredient/useringredient/entity/RecentIngredientBatch.java
+++ b/src/main/java/com/cookeep/cookeep/domain/ingredient/useringredient/entity/RecentIngredientBatch.java
@@ -19,21 +19,26 @@ public class RecentIngredientBatch extends BaseEntity {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id", nullable = false)
+    @JoinColumn(name = "user_id", nullable = false, unique = true)
     private User user;
 
     // 마지막 등록 배치의 UUID
     @Column(name = "batch_id", nullable = false, length = 36)
     private String batchId;
 
+    @Column(name = "ingredient_ids", columnDefinition = "JSON")
+    private String ingredientIdsJson;
+
     @Builder
-    public RecentIngredientBatch(User user, String batchId) {
+    public RecentIngredientBatch(User user, String batchId, String ingredientIdsJson) {
         this.user = user;
         this.batchId = batchId;
+        this.ingredientIdsJson = ingredientIdsJson;
     }
 
-    public void updateBatchId(String batchId) {
+    public void update(String batchId, String ingredientIdsJson) {
         this.batchId = batchId;
+        this.ingredientIdsJson = ingredientIdsJson;
     }
 
 }


### PR DESCRIPTION
# Issue
#230 

# Description

최근 추가한 재료 목록(`/api/users/me/ingredients/recent`) 조회 시 정렬 순서와 중복 제거 로직이 의도와 다르게 동작하는 버그를 수정합니다.

**기존 문제**
- 배치 단위로 최대 6개를 먼저 자른 뒤 중복 제거를 수행해, 실제로는 6개보다 적게 노출되거나 오래된 재료가 남는 문제가 있었습니다.
- 동일 재료(`referenceId` 기준)를 재등록할 경우, 기존 항목이 제거되지 않고 중복으로 남았습니다.
- 화면 노출 순서가 `ingredientId` 내림차순이 아닌 배치 등록 순서 기준으로 정렬되었습니다.

**수정 후 동작**
- `ingredientId` 내림차순(최근 등록 순) 정렬 후 `referenceId` 기준 중복 제거 → 최대 6개 선별 순서로 처리합니다.
- `recent_ingredient_batch` 테이블을 유저당 1행으로 관리하고, `ingredient_ids` JSON 컬럼에 최종 선별된 `ingredientId` 목록을 직접 저장합니다.

# Changes

- **`RecentIngredientBatch`** — `ingredientIdsJson` 컬럼 추가, `update()` 메서드 추가, `user_id` unique 제약 적용
- **`RecentIngredientService`**
  - `saveBatch()` 시그니처 변경: `batchId(String)` → `newIngredientIds(List<Long>)`
  - 저장 로직: 새 등록 목록 + 기존 배치 목록 병합 → `ingredientId` 내림차순 정렬 → `referenceId` 중복 제거 → 상위 6개 → upsert
  - `getRecentIngredients()`: 배치에 저장된 `ingredientId` 목록을 직접 읽어 순서 그대로 반환하도록 단순화
- **`UserIngredientServiceImpl`** — `saveBatch()` 호출 시 이번 등록된 `ingredientId` 목록을 전달하도록 변경
- **DB migration** — `recent_ingredient_batch` 테이블에 `ingredient_ids JSON` 컬럼 추가 및 `user_id` unique 제약 추가

# Test Checklist

- [x] 1-2 등록 → 3-4-5 등록 → 6 등록 → 7 등록 → 최근 목록: `7-6-5-4-3-2`
- [x] referenceId 1-2-3-4-5-6-7 순차 등록 → 최근 목록: `7-6-5-4-3-2` (1번 제외 6개)
- [x] 1-2-3-4 등록 → 3-4-5-6 등록 → 3-4-5-6 재등록 → 최근 목록: `6-5-4-3-2-1`
- [x] 1-2-3-4-5-6 등록 → 7-8 등록 → 7-8 재등록 → 최근 목록: `8-7-6-5-4-3`
- [x] 1-2-3-4-5-6 등록 → 7-8-9 등록 → 7-8-9 재등록 → 최근 목록: `9-8-7-6-5-4`

# 전달사항 (DB 수정)
```
-- 1. 데이터 초기화
TRUNCATE TABLE recent_ingredient_batch;

-- 2. recent_ingredient_batch 테이블에 ingredient_ids 컬럼 추가
ALTER TABLE recent_ingredient_batch
    ADD COLUMN ingredient_ids JSON NULL;

-- 3. 유저당 1행 보장을 위해 unique 제약 추가 (기존 중복 행이 있다면 정리 후 실행)
ALTER TABLE recent_ingredient_batch
    ADD CONSTRAINT uq_recent_batch_user UNIQUE (user_id);
```