### PR TITLE
refactor: PR #235 Redis 캐시 코드 리뷰 반영

### DIFF
--- a/src/main/java/com/cookeep/cookeep/config/RedisConfig.java
+++ b/src/main/java/com/cookeep/cookeep/config/RedisConfig.java
@@ -25,14 +25,19 @@ import java.util.List;
 public class RedisConfig {
 
     @Bean
-    public RedisCacheManager cacheManager(RedisConnectionFactory connectionFactory) {
-        ObjectMapper objectMapper = new ObjectMapper();
-        objectMapper.registerModule(new JavaTimeModule());
-        objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+    public ObjectMapper redisObjectMapper() {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.registerModule(new JavaTimeModule());
+        mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        return mapper;
+    }
 
-        JavaType wateringType = objectMapper.getTypeFactory()
+    @Bean
+    public RedisCacheManager cacheManager(RedisConnectionFactory connectionFactory,
+                                          ObjectMapper redisObjectMapper) {
+        JavaType wateringType = redisObjectMapper.getTypeFactory()
             .constructCollectionType(List.class, WateringRankDto.class);
-        JavaType recipeType = objectMapper.getTypeFactory()
+        JavaType recipeType = redisObjectMapper.getTypeFactory()
             .constructCollectionType(List.class, RecipeRankDto.class);
 
         StringRedisSerializer keySerializer = new StringRedisSerializer();
@@ -41,14 +46,14 @@ public class RedisConfig {
             .entryTtl(Duration.ofMinutes(10))
             .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(keySerializer))
             .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(
-                typedSerializer(objectMapper, wateringType)))
+                typedSerializer(redisObjectMapper, wateringType)))
             .disableCachingNullValues();
 
         RedisCacheConfiguration recipeConfig = RedisCacheConfiguration.defaultCacheConfig()
             .entryTtl(Duration.ofMinutes(10))
             .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(keySerializer))
             .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(
-                typedSerializer(objectMapper, recipeType)))
+                typedSerializer(redisObjectMapper, recipeType)))
             .disableCachingNullValues();
 
         return RedisCacheManager.builder(connectionFactory)
@@ -57,13 +62,13 @@ public class RedisConfig {
             .build();
     }
 
-    private static RedisSerializer<Object> typedSerializer(ObjectMapper objectMapper, JavaType type) {
+    private static RedisSerializer<Object> typedSerializer(ObjectMapper redisObjectMapper, JavaType type) {
         return new RedisSerializer<>() {
             @Override
             public byte[] serialize(Object value) throws SerializationException {
                 if (value == null) return null;
                 try {
-                    return objectMapper.writeValueAsBytes(value);
+                    return redisObjectMapper.writeValueAsBytes(value);
                 } catch (Exception e) {
                     throw new SerializationException("Could not serialize: " + e.getMessage(), e);
                 }
@@ -73,7 +78,7 @@ public class RedisConfig {
             public Object deserialize(byte[] bytes) throws SerializationException {
                 if (bytes == null || bytes.length == 0) return null;
                 try {
-                    return objectMapper.readValue(bytes, type);
+                    return redisObjectMapper.readValue(bytes, type);
                 } catch (Exception e) {
                     throw new SerializationException("Could not deserialize: " + e.getMessage(), e);
                 }

--- a/src/main/java/com/cookeep/cookeep/domain/cookeeps/application/RankingCacheEvictScheduler.java
+++ b/src/main/java/com/cookeep/cookeep/domain/cookeeps/application/RankingCacheEvictScheduler.java
@@ -11,12 +11,12 @@ public class RankingCacheEvictScheduler {
     private final RankingCacheService rankingCacheService;
 
     @Scheduled(cron = "0 1 0 1 * *", zone = "Asia/Seoul")
-    public void evictOnMonthStart() {
-        rankingCacheService.evictAllRankingCaches();
+    public void evictWateringRankingCache() {
+        rankingCacheService.evictWateringRankingCache();
     }
 
     @Scheduled(cron = "0 1 0 * * MON", zone = "Asia/Seoul")
-    public void evictOnWeekStart() {
-        rankingCacheService.evictAllRankingCaches();
+    public void evictRecipeRankingCache() {
+        rankingCacheService.evictRecipeRankingCache();
     }
 }

--- a/src/main/java/com/cookeep/cookeep/domain/cookeeps/application/RankingCacheService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/cookeeps/application/RankingCacheService.java
@@ -25,7 +25,7 @@ public class RankingCacheService {
     private final WateringLogRepository wateringLogRepository;
     private final DailyRecipeRepository dailyRecipeRepository;
 
-    @Cacheable(cacheNames = "wateringRanking", key = "'current'")
+    @Cacheable(cacheNames = "wateringRanking", key = "#monthStart.toLocalDate().toString()")
     @Transactional(readOnly = true)
     public List<WateringRankDto> getWateringRanking(LocalDateTime monthStart, LocalDateTime monthEnd) {
         List<Object[]> results = wateringLogRepository.findTopWateringUsers(
@@ -49,7 +49,7 @@ public class RankingCacheService {
             .collect(Collectors.toList());
     }
 
-    @Cacheable(cacheNames = "recipeRanking", key = "'current'")
+    @Cacheable(cacheNames = "recipeRanking", key = "#weekStart.toLocalDate().toString()")
     @Transactional(readOnly = true)
     public List<RecipeRankDto> getRecipeRanking(LocalDateTime weekStart, LocalDateTime weekEnd) {
         List<DailyRecipe> results = dailyRecipeRepository.findTopRankedRecipes(
@@ -70,7 +70,11 @@ public class RankingCacheService {
             .collect(Collectors.toList());
     }
 
-    @CacheEvict(cacheNames = {"wateringRanking", "recipeRanking"}, allEntries = true)
-    public void evictAllRankingCaches() {
+    @CacheEvict(cacheNames = "wateringRanking", allEntries = true)
+    public void evictWateringRankingCache() {
+    }
+
+    @CacheEvict(cacheNames = "recipeRanking", allEntries = true)
+    public void evictRecipeRankingCache() {
     }
 }


### PR DESCRIPTION
# Related Issue
CLOSE #239 

# Description
PR #235 (`feat/232-ranking-redis-cache`) 머지 후 형원님 코드 리뷰를 반영한 리팩토링입니다.

# Changes
- 랭킹 캐시 key를 `'current'` 하드코딩에서 파라미터 기반으로 변경
  - `wateringRanking`: `#monthStart.toLocalDate().toString()`
  - `recipeRanking`: `#weekStart.toLocalDate().toString()`
  - 기존 방식은 **캐시 무효화 후에도 항상 동일한 key로 조회되어 갱신된 데이터가 반환되지 않는** 문제가 있었음

- 물주기·레시피 랭킹 캐시 evict 메서드 분리
  - 기존 `evictAllRankingCaches()`가 두 캐시를 동시에 삭제하던 잘못된 구조 개선
  - 매달 1일에는 `wateringRanking`만, 매주 월요일에는 `recipeRanking`만 evict하도록 수정

- `RedisConfig`의 ObjectMapper를 `redisObjectMapper` Bean으로 분리
  - `cacheManager` 내부 로컬 변수에서 독립 Bean으로 추출하여 재사용성 향상