### PR TITLE
Feat: ai redis 적용

### DIFF
--- a/src/main/java/com/cookeep/cookeep/common/exception/ErrorCode.java
+++ b/src/main/java/com/cookeep/cookeep/common/exception/ErrorCode.java
@@ -222,6 +222,9 @@ public enum ErrorCode {
 
 	// NICKNAME
 	NICKNAME_GENERATION_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE,"닉네임을 생성할 수 없습니다. 잠시 후 다시 시도해주세요.", "NICKNAME-001"),
+
+	// RECIPE
+	AI_SERVER_FAILED(HttpStatus.SERVICE_UNAVAILABLE, "AI 서비스가 일시적으로 불안정합니다. 잠시 후 다시 시도해주세요.", "RECIPE-028"),
 	;
 
 	private final HttpStatus httpStatus;

--- a/src/main/java/com/cookeep/cookeep/domain/recipe/application/AiRateLimitService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/recipe/application/AiRateLimitService.java
@@ -2,38 +2,51 @@ package com.cookeep.cookeep.domain.recipe.application;
 
 import com.cookeep.cookeep.common.exception.AppException;
 import com.cookeep.cookeep.common.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
+@Slf4j
 @Service
+@RequiredArgsConstructor
 public class AiRateLimitService {
+
+    private final StringRedisTemplate redisTemplate;
 
     // 유저 요청 기록 (아이디로 구분)
     private final Map<Long, List<Long>> requestLogs = new ConcurrentHashMap<>();
 
     // 제한 설정
     private static final int LIMIT = 3;         // 3회/m
-    private static final long WINDOW = 60_000;  // 1분
+    private static final Duration WINDOW = Duration.ofMinutes(1); // 1분
+    private static final String KEY_PREFIX = "rate:limit:ai:";
+
 
     public void validate(Long userId) {
-        long now = System.currentTimeMillis();
+        String key = KEY_PREFIX + userId;
 
-        requestLogs.putIfAbsent(userId, new ArrayList<>());
-        List<Long> logs = requestLogs.get(userId);
+        // INCR는 원자적으로 값을 증가시키고, 키가 없으면 1로 초기화
+        Long count = redisTemplate.opsForValue().increment(key);
 
-        // 오래된 요청 제거 (1분 이전)
-        logs.removeIf(time -> now - time > WINDOW);
-
-        // 제한 초과
-        if (logs.size() >= LIMIT) {
-            throw new AppException(ErrorCode.USER_RATE_LIMIT_EXCEEDED);
+        if (count == null) {
+            throw new AppException(ErrorCode.INTERNAL_SERVER_ERROR);
         }
 
-        // 현재 요청 기록
-        logs.add(now);
+        // 최초 요청(count == 1)일 때만 TTL 설정
+        if (count == 1L) {
+            redisTemplate.expire(key, WINDOW);
+        }
+
+        if (count > LIMIT) {
+            log.warn("AI Rate Limit 초과. userId={}, count={}", userId, count);
+            throw new AppException(ErrorCode.USER_RATE_LIMIT_EXCEEDED);
+        }
     }
 }

--- a/src/main/java/com/cookeep/cookeep/domain/recipe/application/AiRecipeCacheService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/recipe/application/AiRecipeCacheService.java
@@ -1,0 +1,54 @@
+package com.cookeep.cookeep.domain.recipe.application;
+
+import com.cookeep.cookeep.domain.recipe.dto.GeminiRecipeResponseDto;
+import com.cookeep.cookeep.domain.recipe.entity.Difficulty;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+import tools.jackson.databind.ObjectMapper;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AiRecipeCacheService {
+
+    private final StringRedisTemplate redisTemplate;
+    private final ObjectMapper objectMapper;
+
+    private static final Duration TTL = Duration.ofHours(24);
+    private static final String KEY_PREFIX = "recipe:cache:";
+
+    public String buildCacheKey(List<Long> ingredientIds, Difficulty difficulty) {
+        String sortedIds = ingredientIds.stream()
+                .sorted()
+                .map(String::valueOf)
+                .collect(Collectors.joining("_"));
+        return KEY_PREFIX + sortedIds + ":" + difficulty.name();
+    }
+
+    public GeminiRecipeResponseDto get(String cacheKey) {
+        String json = redisTemplate.opsForValue().get(cacheKey);
+        if (json == null) return null;
+        try {
+            return objectMapper.readValue(json, GeminiRecipeResponseDto.class);
+        } catch (Exception e) {
+            log.warn("AI 레시피 캐시 역직렬화 실패. key={}", cacheKey, e);
+            return null;
+        }
+    }
+
+    public void put(String cacheKey, GeminiRecipeResponseDto dto) {
+        try {
+            String json = objectMapper.writeValueAsString(dto);
+            redisTemplate.opsForValue().set(cacheKey, json, TTL);
+            log.info("AI 레시피 캐시 저장. key={}", cacheKey);
+        } catch (Exception e) {
+            log.warn("AI 레시피 캐시 저장 실패. key={}", cacheKey, e);
+        }
+    }
+}

--- a/src/main/java/com/cookeep/cookeep/domain/recipe/application/AiRecipeCacheService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/recipe/application/AiRecipeCacheService.java
@@ -23,11 +23,19 @@ public class AiRecipeCacheService {
     private static final Duration TTL = Duration.ofHours(24);
     private static final String KEY_PREFIX = "recipe:cache:";
 
-    public String buildCacheKey(List<Long> ingredientIds, Difficulty difficulty) {
+    public String buildCacheKey(List<Long> ingredientIds, Difficulty difficulty, List<String> dislikedIngredients) {
         String sortedIds = ingredientIds.stream()
                 .sorted()
                 .map(String::valueOf)
                 .collect(Collectors.joining("_"));
+
+        String dislikedPart = (dislikedIngredients == null || dislikedIngredients.isEmpty())
+                ? "none"
+                : dislikedIngredients.stream()
+                .map(String::toLowerCase)
+                .sorted()
+                .collect(Collectors.joining("_"));
+
         return KEY_PREFIX + sortedIds + ":" + difficulty.name();
     }
 

--- a/src/main/java/com/cookeep/cookeep/domain/recipe/application/AiRecipeService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/recipe/application/AiRecipeService.java
@@ -67,6 +67,7 @@ public class AiRecipeService {
     private final AiRateLimitService rateLimitService;
     private final UserReader userReader;
     private final AiRecipeCacheService aiRecipeCacheService;
+    private final GeminiQueueService geminiQueueService;
 
     // sessionId 유무에 따라 신규/재요청 로직 분기
     public AiRecipeResponseDto generateRecipe(Long userId, AiRecipeRequestDto request) {
@@ -128,7 +129,7 @@ public class AiRecipeService {
             // 신규 세션이므로 기존 제목 목록은 빈 리스트 → 캐시 제목 중복 없음
             log.info("AI 레시피 캐시 히트. key={}", cacheKey);
         } else {
-            aiResponse = geminiService.generateRecipe(
+            aiResponse = geminiQueueService.generateRecipe(
                     enrichedIngredients, request.getDifficulty(), dislikedIngredients);
             aiRecipeCacheService.put(cacheKey, aiResponse);
         }
@@ -207,7 +208,7 @@ public class AiRecipeService {
         List<String> dislikedIngredients = getDislikedIngredients(userId);
 
         // 5. AI 호출 (제외 리스트 포함)
-        GeminiRecipeResponseDto aiResponse = geminiService.generateRecipeWithExclusion(
+        GeminiRecipeResponseDto aiResponse = geminiQueueService.generateRecipeWithExclusion(
                 ingredients,
                 session.getDifficulty(),
                 excludedTitles,

--- a/src/main/java/com/cookeep/cookeep/domain/recipe/application/AiRecipeService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/recipe/application/AiRecipeService.java
@@ -121,7 +121,8 @@ public class AiRecipeService {
 
         // ── AI 호출을 세션 저장보다 먼저 ──
         // 캐시 조회
-        String cacheKey = aiRecipeCacheService.buildCacheKey(request.getIngredientIds(), request.getDifficulty());
+        String cacheKey = aiRecipeCacheService.buildCacheKey(
+                request.getIngredientIds(), request.getDifficulty(), dislikedIngredients);
         GeminiRecipeResponseDto aiResponse = aiRecipeCacheService.get(cacheKey);
 
         // 4. AI 레시피 생성 (이름 + 단위만 전달, AI가 quantity 생성)
@@ -214,17 +215,6 @@ public class AiRecipeService {
                 excludedTitles,
                 dislikedIngredients
         );
-
-        // 재요청 결과도 캐시에 저장 (다른 세션에서 재사용 가능하도록)
-        // 세션의 원본 재료 ID 목록이 필요하므로 ingredientIdsJson에서 파싱
-        try {
-            List<Long> originalIds = objectMapper.readValue(
-                    session.getIngredientIdsJson(), new TypeReference<List<Long>>() {});
-            String retryKey = aiRecipeCacheService.buildCacheKey(originalIds, session.getDifficulty());
-            aiRecipeCacheService.put(retryKey, aiResponse);
-        } catch (Exception e) {
-            log.warn("retry 결과 캐시 저장 실패", e);
-        }
 
         // 6. 시도 횟수 증가 및 저장
         session.increaseAttempt();

--- a/src/main/java/com/cookeep/cookeep/domain/recipe/application/AiRecipeService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/recipe/application/AiRecipeService.java
@@ -66,6 +66,7 @@ public class AiRecipeService {
     private final UserRepository userRepository;
     private final AiRateLimitService rateLimitService;
     private final UserReader userReader;
+    private final AiRecipeCacheService aiRecipeCacheService;
 
     // sessionId 유무에 따라 신규/재요청 로직 분기
     public AiRecipeResponseDto generateRecipe(Long userId, AiRecipeRequestDto request) {
@@ -115,6 +116,8 @@ public class AiRecipeService {
         boolean hasUrgent = userIngredients.stream()
                 .anyMatch(ui -> ui.getLeftDays() == 0);
 
+        List<String> dislikedIngredients = getDislikedIngredients(userId);
+
         // 4. 세션 생성
         AiSession session = AiSession.builder()
                 .userId(userId)
@@ -131,14 +134,26 @@ public class AiRecipeService {
         // 메시지 db에 저장
         saveInitialUserMessage(session, request);
 
-        List<String> dislikedIngredients = getDislikedIngredients(userId);
+        // 캐시 조회
+        String cacheKey = aiRecipeCacheService.buildCacheKey(request.getIngredientIds(), request.getDifficulty());
+        GeminiRecipeResponseDto aiResponse = aiRecipeCacheService.get(cacheKey);
 
         // 3. AI 레시피 생성 (이름 + 단위만 전달, AI가 quantity 생성)
-        GeminiRecipeResponseDto aiResponse = geminiService.generateRecipe(
-                enrichedIngredients,
-                request.getDifficulty(),
-                dislikedIngredients
-        );
+
+        if (aiResponse != null) {
+            List<String> existingTitles = extractRecipeTitlesFromMessages(session.getId());
+            if (existingTitles.contains(aiResponse.getTitle())) {
+                log.info("캐시 제목 중복 → Gemini 신규 호출. title={}", aiResponse.getTitle());
+                aiResponse = null;
+            } else {
+                log.info("AI 레시피 캐시 히트. key={}", cacheKey);
+            }
+        }
+
+        if (aiResponse == null) {
+            aiResponse = geminiService.generateRecipe(enrichedIngredients, request.getDifficulty(), dislikedIngredients);
+            aiRecipeCacheService.put(cacheKey, aiResponse);
+        }
 
         // 4. 세션 제목 업데이트
         updateSessionTitle(session, aiResponse);
@@ -206,6 +221,17 @@ public class AiRecipeService {
                 excludedTitles,
                 dislikedIngredients
         );
+
+        // 재요청 결과도 캐시에 저장 (다른 세션에서 재사용 가능하도록)
+        // 세션의 원본 재료 ID 목록이 필요하므로 ingredientIdsJson에서 파싱
+        try {
+            List<Long> originalIds = objectMapper.readValue(
+                    session.getIngredientIdsJson(), new TypeReference<List<Long>>() {});
+            String retryKey = aiRecipeCacheService.buildCacheKey(originalIds, session.getDifficulty());
+            aiRecipeCacheService.put(retryKey, aiResponse);
+        } catch (Exception e) {
+            log.warn("retry 결과 캐시 저장 실패", e);
+        }
 
         // 6. 시도 횟수 증가 및 저장
         session.increaseAttempt();

--- a/src/main/java/com/cookeep/cookeep/domain/recipe/application/AiRecipeService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/recipe/application/AiRecipeService.java
@@ -118,7 +118,22 @@ public class AiRecipeService {
 
         List<String> dislikedIngredients = getDislikedIngredients(userId);
 
-        // 4. 세션 생성
+        // ── AI 호출을 세션 저장보다 먼저 ──
+        // 캐시 조회
+        String cacheKey = aiRecipeCacheService.buildCacheKey(request.getIngredientIds(), request.getDifficulty());
+        GeminiRecipeResponseDto aiResponse = aiRecipeCacheService.get(cacheKey);
+
+        // 4. AI 레시피 생성 (이름 + 단위만 전달, AI가 quantity 생성)
+        if (aiResponse != null) {
+            // 신규 세션이므로 기존 제목 목록은 빈 리스트 → 캐시 제목 중복 없음
+            log.info("AI 레시피 캐시 히트. key={}", cacheKey);
+        } else {
+            aiResponse = geminiService.generateRecipe(
+                    enrichedIngredients, request.getDifficulty(), dislikedIngredients);
+            aiRecipeCacheService.put(cacheKey, aiResponse);
+        }
+
+        // 5. 세션 생성
         AiSession session = AiSession.builder()
                 .userId(userId)
                 .difficulty(request.getDifficulty())
@@ -133,40 +148,17 @@ public class AiRecipeService {
 
         // 메시지 db에 저장
         saveInitialUserMessage(session, request);
-
-        // 캐시 조회
-        String cacheKey = aiRecipeCacheService.buildCacheKey(request.getIngredientIds(), request.getDifficulty());
-        GeminiRecipeResponseDto aiResponse = aiRecipeCacheService.get(cacheKey);
-
-        // 3. AI 레시피 생성 (이름 + 단위만 전달, AI가 quantity 생성)
-
-        if (aiResponse != null) {
-            List<String> existingTitles = extractRecipeTitlesFromMessages(session.getId());
-            if (existingTitles.contains(aiResponse.getTitle())) {
-                log.info("캐시 제목 중복 → Gemini 신규 호출. title={}", aiResponse.getTitle());
-                aiResponse = null;
-            } else {
-                log.info("AI 레시피 캐시 히트. key={}", cacheKey);
-            }
-        }
-
-        if (aiResponse == null) {
-            aiResponse = geminiService.generateRecipe(enrichedIngredients, request.getDifficulty(), dislikedIngredients);
-            aiRecipeCacheService.put(cacheKey, aiResponse);
-        }
-
-        // 4. 세션 제목 업데이트
+        // 세션 제목 업데이트
         updateSessionTitle(session, aiResponse);
 
-        // 5. 유튜브 검색어로 실제 영상 조회
+        // 6. 유튜브 검색어로 실제 영상 조회
         List<YoutubeReferenceDto> youtubeReferences =
                 youtubeSearchService.searchVideos(aiResponse.getYoutubeSearchQueries());
 
-        // 6. 레시피 저장
+        // 7. 레시피 저장
         saveAiMessageWithYoutubeReferences(session, aiResponse, youtubeReferences, MessageType.INITIAL_REQUEST, dislikedIngredients);
 
-
-        // 7. 응답 반환
+        // 8. 응답 반환
         return AiRecipeResponseDto.builder()
                 .sessionId(session.getId())
                 .changeCount(session.getAttemptNumber())

--- a/src/main/java/com/cookeep/cookeep/domain/recipe/application/GeminiQueueService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/recipe/application/GeminiQueueService.java
@@ -1,0 +1,82 @@
+package com.cookeep.cookeep.domain.recipe.application;
+
+import com.cookeep.cookeep.common.exception.AppException;
+import com.cookeep.cookeep.common.exception.ErrorCode;
+import com.cookeep.cookeep.domain.recipe.dto.GeminiRecipeResponseDto;
+import com.cookeep.cookeep.domain.recipe.dto.IngredientDetailDto;
+import com.cookeep.cookeep.domain.recipe.entity.Difficulty;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class GeminiQueueService {
+
+    private final GeminiService geminiService;
+
+    // 동시 Gemini 호출 최대 3개로 제한
+    private static final int MAX_CONCURRENT = 3;
+    private static final int QUEUE_TIMEOUT_SECONDS = 90;
+
+    private final Semaphore semaphore = new Semaphore(MAX_CONCURRENT, true);
+
+    /**
+     * Semaphore로 동시 호출 수를 제어합니다.
+     * 슬롯이 없으면 최대 90초 대기 후 타임아웃 에러를 반환합니다.
+     */
+    public GeminiRecipeResponseDto generateRecipe(
+            List<IngredientDetailDto> ingredients,
+            Difficulty difficulty,
+            List<String> dislikedIngredients) {
+
+        boolean acquired = false;
+        try {
+            acquired = semaphore.tryAcquire(QUEUE_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            if (!acquired) {
+                log.warn("Gemini 큐 대기 타임아웃. 현재 대기 수={}", semaphore.getQueueLength());
+                throw new AppException(ErrorCode.AI_SEARCH_FAILED);
+            }
+            log.info("Gemini 슬롯 획득. 남은 슬롯={}", semaphore.availablePermits());
+            return geminiService.generateRecipe(ingredients, difficulty, dislikedIngredients);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new AppException(ErrorCode.AI_SEARCH_FAILED);
+        } finally {
+            if (acquired) {
+                semaphore.release();
+                log.info("Gemini 슬롯 반환. 남은 슬롯={}", semaphore.availablePermits());
+            }
+        }
+    }
+
+    public GeminiRecipeResponseDto generateRecipeWithExclusion(
+            List<IngredientDetailDto> ingredients,
+            Difficulty difficulty,
+            List<String> excludedTitles,
+            List<String> dislikedIngredients) {
+
+        boolean acquired = false;
+        try {
+            acquired = semaphore.tryAcquire(QUEUE_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            if (!acquired) {
+                log.warn("Gemini 큐 대기 타임아웃. 현재 대기 수={}", semaphore.getQueueLength());
+                throw new AppException(ErrorCode.AI_SEARCH_FAILED);
+            }
+            return geminiService.generateRecipeWithExclusion(
+                    ingredients, difficulty, excludedTitles, dislikedIngredients);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new AppException(ErrorCode.AI_SEARCH_FAILED);
+        } finally {
+            if (acquired) {
+                semaphore.release();
+            }
+        }
+    }
+}

--- a/src/main/java/com/cookeep/cookeep/domain/recipe/application/GeminiService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/recipe/application/GeminiService.java
@@ -120,11 +120,11 @@ public class GeminiService {
             }
 
             log.error("Gemini API 호출 실패 - status={}", e.getStatusCode(), e);
-            throw new AppException(ErrorCode.AI_SEARCH_FAILED);
+            throw new AppException(ErrorCode.AI_SERVER_FAILED);
 
         } catch (Exception e) {
             log.error("Gemini API 호출 실패", e);
-            throw new AppException(ErrorCode.AI_SEARCH_FAILED);
+            throw new AppException(ErrorCode.AI_SERVER_FAILED);
         }
     }
 

--- a/src/main/java/com/cookeep/cookeep/domain/recipe/application/GeminiService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/recipe/application/GeminiService.java
@@ -97,7 +97,7 @@ public class GeminiService {
                     .timeout(Duration.ofSeconds(120))
                     .retryWhen(
                             Retry.backoff(3, Duration.ofSeconds(2))
-                                    .maxBackoff(Duration.ofSeconds(10))
+                                    .maxBackoff(Duration.ofSeconds(5))
                                     .filter(this::isRetryableError)
                                     .doBeforeRetry(retrySignal ->
                                             log.warn("Gemini 재시도 중... attempt={}, cause={}",

--- a/src/main/resources/seed_ingredient.sql
+++ b/src/main/resources/seed_ingredient.sql
@@ -73,6 +73,10 @@ VALUES
     ('VEGETABLE','돌나물','PIECE','FRIDGE',7,'물기 제거 후 밀봉이 좋아요.','https://cookeep-images.s3.ap-northeast-2.amazonaws.com/ingredients/6cad2799-8e85-42f3-91f6-5bf73246a2f1.png'),
     ('VEGETABLE','명이나물','PIECE','FRIDGE',7,'공기 접촉을 줄여 보관하세요.','https://cookeep-images.s3.ap-northeast-2.amazonaws.com/ingredients/dd75dab7-78de-4df5-9519-b65c5d63d647.png'),
     ('VEGETABLE','호박잎','PIECE','FRIDGE',7,'키친타월로 감싸 보관하세요.','https://cookeep-images.s3.ap-northeast-2.amazonaws.com/ingredients/19e87dc9-305a-4677-86d4-640bd6664b07.png'),
+    ('VEGETABLE', '샐러드채소', 'PIECE', 'FRIDGE', 5, '세척 후 물기를 완전히 제거하고 키친타월과 함께 밀봉 보관하세요.', 'https://cookeep-images.s3.ap-northeast-2.amazonaws.com/ingredients/87e63acb-9198-498b-948a-06347b859420.png'),
+    ('VEGETABLE', '연잎', 'PIECE', 'FRIDGE', 5, '마르지 않도록 약간의 물기를 유지하며 밀봉 보관하세요.', 'https://cookeep-images.s3.ap-northeast-2.amazonaws.com/ingredients/01ed7517-39cc-467b-a519-710f3c0fc9c2.png'),
+    ('VEGETABLE', '알배기배추', 'PIECE', 'FRIDGE', 7, '겉잎을 제거하지 말고 통째로 밀봉 보관하세요.', 'https://cookeep-images.s3.ap-northeast-2.amazonaws.com/ingredients/7b1a88e8-8f1c-465b-afc6-e18a8ab75a61.png'),
+    ('VEGETABLE', '봄동', 'PIECE', 'FRIDGE', 7, '키친타월로 감싸 밀봉 보관하면 수분이 유지돼요.', 'https://cookeep-images.s3.ap-northeast-2.amazonaws.com/ingredients/3f635b86-e11f-45d0-9aed-849b9eb76a84.png'),
 
     -- 과일 (FRUIT)
     ('FRUIT', '사과', 'PIECE', 'FRIDGE', 7, '다른 과일과 함께 두면 빨리 무를 수 있어 따로 보관하세요.','https://cookeep-images.s3.ap-northeast-2.amazonaws.com/ingredients/사과.png'),
@@ -104,7 +108,6 @@ VALUES
     ('FRUIT', '대추', 'PIECE', 'FRIDGE', 7, '밀봉 보관하면 수분이 유지돼요.','https://cookeep-images.s3.ap-northeast-2.amazonaws.com/ingredients/c7d95c70-1052-4fef-a96d-b69bc12b2aaa.png'),
     ('FRUIT', '건대추', 'PIECE', 'FRIDGE', 7, '습기를 피해서 밀봉 보관하세요.','https://cookeep-images.s3.ap-northeast-2.amazonaws.com/ingredients/6c34c71c-bce5-4f1a-b8db-ec7edbf39d5b.png'),
     ('FRUIT', '밤', 'PIECE', 'FRIDGE', 7, '수분이 마르지 않게 밀봉 보관하면 좋아요.','https://cookeep-images.s3.ap-northeast-2.amazonaws.com/ingredients/1a190ca7-5a80-49e2-be76-c114de1862d9.png'),
-    ('FRUIT', '은행', 'PIECE', 'FRIDGE', 7, '습기를 피해 밀봉 보관하세요.','https://cookeep-images.s3.ap-northeast-2.amazonaws.com/ingredients/39f036bb-8cd6-4161-ac49-8d03709f520d.png'),
     ('FRUIT', '건포도', 'PIECE', 'FRIDGE', 7, '습기 차단을 위해 밀봉 보관이 좋아요.','https://cookeep-images.s3.ap-northeast-2.amazonaws.com/ingredients/1e5537d7-6226-49c1-a7ef-02b8251aa7ee.png'),
     ('FRUIT', '건망고', 'PIECE', 'FRIDGE', 7, '개봉 후엔 밀봉해 냉장 보관하세요.','https://cookeep-images.s3.ap-northeast-2.amazonaws.com/ingredients/a7556ecc-5a48-4fb3-b520-0bc2130e8f48.png'),
     ('FRUIT', '건바나나', 'PIECE', 'FRIDGE', 7, '습기를 피하고 밀봉 보관하세요.','https://cookeep-images.s3.ap-northeast-2.amazonaws.com/ingredients/바나나.png'),
@@ -120,6 +123,8 @@ VALUES
     ('FRUIT', '레몬청', 'PIECE', 'FRIDGE', 14, '수분/이물 혼입을 막고 냉장 보관하세요.','https://cookeep-images.s3.ap-northeast-2.amazonaws.com/ingredients/98ac383d-c078-48d0-991e-e7b6f71efd34.png'),
     ('FRUIT', '유자', 'PIECE', 'FRIDGE', 7, '밀봉 보관하면 향이 오래 유지돼요.','https://cookeep-images.s3.ap-northeast-2.amazonaws.com/ingredients/2a5ee0e9-12f6-4a23-a8e3-1feaa642f67b.png'),
     ('FRUIT', '유자청', 'PIECE', 'FRIDGE', 14, '깨끗한 도구로 덜어 사용하면 오래가요.','https://cookeep-images.s3.ap-northeast-2.amazonaws.com/ingredients/d3e6ddc7-4278-4402-9b92-0c0414c8ee43.png'),
+    ('FRUIT', '바나나칩', 'BAG', 'PANTRY', 180, '습기를 피해 밀봉 보관하면 바삭함이 유지돼요.', 'https://cookeep-images.s3.ap-northeast-2.amazonaws.com/ingredients/바나나.png'),
+    ('FRUIT', '과일퓨레', 'PACK', 'FRIDGE', 7, '개봉 후엔 밀봉해 냉장 보관하고 빠르게 소비하세요.', 'https://cookeep-images.s3.ap-northeast-2.amazonaws.com/ingredients/37fc5978-9050-4225-b875-2e33d6855564.png'),
 
     -- 육류 (MEAT)
     ('MEAT', '삼겹살', 'PACK', 'FREEZER', 90, '1회분씩 소분해 냉동하면 해동이 편해요.','https://cookeep-images.s3.ap-northeast-2.amazonaws.com/ingredients/2faf5ece-076b-421a-8996-2a3dbb5e6448.png'),
@@ -156,12 +161,8 @@ VALUES
     ('MEAT', '비엔나소시지', 'PACK', 'FREEZER', 90, '한 번에 쓸 양으로 소분해 보관하세요.','https://cookeep-images.s3.ap-northeast-2.amazonaws.com/ingredients/a1228a68-8135-4a7a-a0c2-669c55c73a88.png'),
     ('MEAT', '스팸', 'PACK', 'FREEZER', 90, '개봉 후엔 밀봉해 냉장/냉동 보관하세요.','https://cookeep-images.s3.ap-northeast-2.amazonaws.com/ingredients/9029997b-a9be-400f-9529-dd35917304df.png'),
     ('MEAT', '미트볼', 'PACK', 'FREEZER', 90, '서로 붙지 않게 펼쳐 냉동하면 좋아요.','https://cookeep-images.s3.ap-northeast-2.amazonaws.com/ingredients/6677db52-5bf0-4d05-8822-6876c72ed9ed.png'),
-    ('MEAT', '함박스테이크', 'PACK', 'FREEZER', 90, '냉동 보관 시 공기 접촉을 줄여주세요.','https://cookeep-images.s3.ap-northeast-2.amazonaws.com/ingredients/5f595775-db01-439c-918c-75f1781c0a24.png'),
-    ('MEAT', '떡갈비', 'PACK', 'FREEZER', 90, '포장 상태를 유지하거나 밀봉해 보관하세요.','https://cookeep-images.s3.ap-northeast-2.amazonaws.com/ingredients/159f7785-5779-401e-8aae-3ca794000690.png'),
     ('MEAT', '족발', 'PACK', 'FREEZER', 90, '소분 후 냉동하면 먹을 만큼만 해동할 수 있어요.','https://cookeep-images.s3.ap-northeast-2.amazonaws.com/ingredients/28032ff4-5f4c-4d92-8432-02ad3457ca07.png'),
     ('MEAT', '보쌈', 'PACK', 'FREEZER', 90, '기름기 있는 부위는 이중 포장이 좋아요.','https://cookeep-images.s3.ap-northeast-2.amazonaws.com/ingredients/1d724150-fd4c-4d44-822a-bd75ed286dc4.png'),
-    ('MEAT', '치킨너겟', 'PACK', 'FREEZER', 90, '개봉 후엔 지퍼백 밀봉으로 성에를 줄이세요.','https://cookeep-images.s3.ap-northeast-2.amazonaws.com/ingredients/e20dc190-e0cf-4efa-bb89-73b20572f6b6.png'),
-    ('MEAT', '치킨스테이크', 'PACK', 'FREEZER', 90, '낱개 포장해 냉동하면 조리가 편해요.','https://cookeep-images.s3.ap-northeast-2.amazonaws.com/ingredients/1379afdb-8a42-4b80-8b15-01c423671691.png'),
     ('MEAT', '돈까스', 'PACK', 'FREEZER', 90, '튀김류는 공기 접촉을 줄이면 눅눅함이 덜해요.','https://cookeep-images.s3.ap-northeast-2.amazonaws.com/ingredients/aca22284-55cf-44db-8012-1f4dcd814436.png'),
     ('MEAT', '불닭', 'PACK', 'FREEZER', 90, '냉동 보관 시 라벨로 날짜를 관리하세요.','https://cookeep-images.s3.ap-northeast-2.amazonaws.com/ingredients/55ee8868-19a8-49e3-9ece-b7d9f0690239.png'),
     ('MEAT', '양념닭', 'PACK', 'FREEZER', 90, '양념 육류는 소분 후 냉동하면 활용이 좋아요.','https://cookeep-images.s3.ap-northeast-2.amazonaws.com/ingredients/88283010-94e4-4f7d-989f-763475c75bed.png'),
@@ -183,6 +184,9 @@ VALUES
     ('MEAT', '핫도그', 'PACK', 'FREEZER', 90, '개봉 후 지퍼백 밀봉이 좋아요.','https://cookeep-images.s3.ap-northeast-2.amazonaws.com/ingredients/d01fdb62-b633-4261-8a7b-b65223c37764.png'),
     ('MEAT', '콘비프', 'PACK', 'PANTRY', 365, '개봉 후엔 냉장 보관하고 빨리 소비하세요.','https://cookeep-images.s3.ap-northeast-2.amazonaws.com/ingredients/d8ec2c90-f815-4cb1-880d-e934a007530b.png'),
     ('MEAT', '양념갈비', 'PACK', 'FREEZER', 90, '양념 고기는 소분 냉동하면 해동이 쉬워요.','https://cookeep-images.s3.ap-northeast-2.amazonaws.com/ingredients/0bf70b03-cec9-4c7c-ab2b-10bfe3201930.png'),
+    ('MEAT', '카레용고기', 'PACK', 'FREEZER', 90, '먹기 좋은 크기로 썰어 소분 냉동하면 해동이 편해요.', 'https://cookeep-images.s3.ap-northeast-2.amazonaws.com/ingredients/03ce39ff-a604-4c42-ae1e-d2766eabb61f.png'),
+    ('MEAT', '볶음용고기', 'PACK', 'FREEZER', 90, '얇게 펼쳐 소분 냉동하면 빠르게 해동돼요.', 'https://cookeep-images.s3.ap-northeast-2.amazonaws.com/ingredients/c74d585d-c613-4210-864a-4331cd8da273.png'),
+    ('MEAT', '샤브샤브용고기', 'PACK', 'FREEZER', 90, '겹치지 않게 펼쳐 냉동하면 꺼내 쓰기 편해요.', 'https://cookeep-images.s3.ap-northeast-2.amazonaws.com/ingredients/1bfafa93-2c42-4825-af72-9eb312f962c9.png'),
 
     -- 해산물 (SEAFOOD)
     ('SEAFOOD', '고등어', 'PACK', 'FREEZER', 90, '구입 후 바로 소분 냉동하면 비린내가 줄어요.','https://cookeep-images.s3.ap-northeast-2.amazonaws.com/ingredients/d84f6e6c-e92d-49f7-afba-c673a8b44522.png'),
@@ -241,7 +245,6 @@ VALUES
     -- 유제품·계란 (DAIRY_EGG)
     ('DAIRY_EGG', '계란', 'PACK', 'FRIDGE', 14, '문 쪽보다 안쪽 칸에 보관하면 온도 변화가 적어요.','https://cookeep-images.s3.ap-northeast-2.amazonaws.com/ingredients/7700b81c-e330-4743-936a-84966ee5c2ed.png'),
     ('DAIRY_EGG', '우유', 'PACK', 'FRIDGE', 14, '개봉 후엔 뚜껑을 꼭 닫고 빨리 소비하세요.','https://cookeep-images.s3.ap-northeast-2.amazonaws.com/ingredients/0551d6e6-c434-42bd-ab06-c47b68223ade.png'),
-    ('DAIRY_EGG', '두유', 'PACK', 'FRIDGE', 14, '개봉 후엔 냉장 보관하고 빠르게 마셔주세요.','https://cookeep-images.s3.ap-northeast-2.amazonaws.com/ingredients/b4730755-254a-4997-866a-0d241d53d416.png'),
     ('DAIRY_EGG', '요거트', 'PACK', 'FRIDGE', 14, '개봉 후 깨끗한 스푼을 사용하면 오래가요.','https://cookeep-images.s3.ap-northeast-2.amazonaws.com/ingredients/d0a52c4a-07ef-4287-b0b7-fffd03e08e44.png'),
     ('DAIRY_EGG', '플레인요거트', 'PACK', 'FRIDGE', 14, '수분/이물 혼입을 피하면 품질이 오래가요.','https://cookeep-images.s3.ap-northeast-2.amazonaws.com/ingredients/f100d389-ab1f-472e-ba44-52c067eefbf3.png'),
     ('DAIRY_EGG', '딸기요거트', 'PACK', 'FRIDGE', 14, '개봉 후엔 가능한 빨리 섭취하세요.','https://cookeep-images.s3.ap-northeast-2.amazonaws.com/ingredients/546a5cde-1c92-4129-9b41-859d6ed865c8.png'),
@@ -275,6 +278,7 @@ VALUES
     ('GRAIN_RICE_NOODLE', '가래떡', 'BAG', 'FREEZER', 180, '1회분씩 잘라 소분 냉동하면 편해요.','https://cookeep-images.s3.ap-northeast-2.amazonaws.com/ingredients/ae8d19c8-06c7-4a48-9e50-159d1c8723fc.png'),
     ('GRAIN_RICE_NOODLE', '어묵떡', 'BAG', 'FREEZER', 180, '개봉 후 지퍼백 밀봉 보관이 좋아요.','https://cookeep-images.s3.ap-northeast-2.amazonaws.com/ingredients/881959d3-002f-4b0c-8669-464909e53a60.png'),
     ('GRAIN_RICE_NOODLE', '파스타면', 'BAG', 'PANTRY', 365, '직사광선을 피해 건조하고 서늘한 곳에 보관하세요.', 'https://cookeep-images.s3.ap-northeast-2.amazonaws.com/ingredients/3252f4c9-05a0-40cd-bb31-a8352e7737d6.png'),
+    ('GRAIN_RICE_NOODLE', '밀가루', 'BAG', 'PANTRY', 365, '습기와 벌레를 막기 위해 밀폐 용기에 보관하세요.', 'https://cookeep-images.s3.ap-northeast-2.amazonaws.com/ingredients/6fe58141-27a7-438e-81bd-bed97a1192a3.png'),
 
     -- 빵·베이커리 (BAKERY)
     ('BAKERY', '식빵', 'BAG', 'PANTRY', 5, '빵은 냉동 보관하면 곰팡이를 줄일 수 있어요.','https://cookeep-images.s3.ap-northeast-2.amazonaws.com/ingredients/9e2f9294-106f-4bb5-b6f3-e0f5d0ad19a5.png'),
@@ -326,6 +330,7 @@ VALUES
     ('SNACK_DESSERT', '파이', 'BAG', 'PANTRY', 180, '개봉 후엔 밀봉 보관이 좋아요.','https://cookeep-images.s3.ap-northeast-2.amazonaws.com/ingredients/c81d7b30-da77-4fb9-8d2d-c2a68f438c15.png'),
     ('SNACK_DESSERT', '웨하스', 'BAG', 'PANTRY', 180, '습기 차단을 위해 밀봉하세요.','https://cookeep-images.s3.ap-northeast-2.amazonaws.com/ingredients/4db88796-4843-4b52-a254-a03f8c5c8a2c.png'),
     ('SNACK_DESSERT', '초코바', 'BAG', 'PANTRY', 180, '더운 곳을 피하면 녹는 걸 막을 수 있어요.','https://cookeep-images.s3.ap-northeast-2.amazonaws.com/ingredients/0710add4-a6e4-4d68-854e-7de9cfa0d1c2.png'),
+    ('SNACK_DESSERT', '군밤', 'BAG', 'PANTRY', 3, '구입 후 빠르게 소비하고 남은 건 냉장 보관하세요.', 'https://cookeep-images.s3.ap-northeast-2.amazonaws.com/ingredients/207c2614-db28-40a6-bf6a-6bbd5aeaef68.png'),
 
     -- 음료 (BEVERAGE)
     ('BEVERAGE', '생수', 'BOTTLE', 'PANTRY', 180, '직사광선을 피하고 서늘한 곳에 보관하세요.','https://cookeep-images.s3.ap-northeast-2.amazonaws.com/ingredients/444dd13f-38bb-4411-9fdf-6f4a90ab91b4.png'),
@@ -336,6 +341,10 @@ VALUES
     ('BEVERAGE', '캔커피', 'BOTTLE', 'PANTRY', 180, '고온 보관은 피하는 게 좋아요.','https://cookeep-images.s3.ap-northeast-2.amazonaws.com/ingredients/10b2664b-8dc9-4a8f-be38-c5dfc43fa2a1.png'),
     ('BEVERAGE', '차음료', 'BOTTLE', 'PANTRY', 180, '개봉 후엔 냉장 보관이 좋아요.','https://cookeep-images.s3.ap-northeast-2.amazonaws.com/ingredients/b50d5db4-2b9c-4014-a729-d8bebcd713fb.png'),
     ('BEVERAGE', '밀크티', 'BOTTLE', 'PANTRY', 180, '개봉 후엔 냉장 보관하고 빠르게 소비하세요.','https://cookeep-images.s3.ap-northeast-2.amazonaws.com/ingredients/620e402f-9665-4be0-8f9c-e4f3570957ae.png'),
+    ('BEVERAGE', '토마토주스', 'BOTTLE', 'PANTRY', 180, '개봉 후엔 반드시 냉장 보관하고 빠르게 소비하세요.', 'https://cookeep-images.s3.ap-northeast-2.amazonaws.com/ingredients/611fd507-c689-4406-9d2e-8cef420a6fc6.png'),
+    ('BEVERAGE', '오렌지주스', 'BOTTLE', 'PANTRY', 180, '개봉 후엔 반드시 냉장 보관하고 빠르게 소비하세요.', 'https://cookeep-images.s3.ap-northeast-2.amazonaws.com/ingredients/c61c9b14-cc63-4d2b-9d3d-78f1702c62a6.png'),
+    ('BEVERAGE', '포도주스', 'BOTTLE', 'PANTRY', 180, '개봉 후엔 냉장 보관하고 빠르게 소비하세요.', 'https://cookeep-images.s3.ap-northeast-2.amazonaws.com/ingredients/ae67d31f-8d68-4eed-94db-89dc36e1db24.png'),
+    ('BEVERAGE', '사과주스', 'BOTTLE', 'PANTRY', 180, '개봉 후엔 냉장 보관하고 빠르게 소비하세요.', 'https://cookeep-images.s3.ap-northeast-2.amazonaws.com/ingredients/67ad1164-fe20-45e4-9daa-d376ae4b1517.png'),
 
     -- 절임·발효 (FERMENTED)
     ('FERMENTED', '김치', 'PACK', 'FRIDGE', 90, '김치는 보관 방법을 잘 지키면 더 오래 신선해요!','https://cookeep-images.s3.ap-northeast-2.amazonaws.com/ingredients/fdbb2831-f589-4a0f-bad5-7bc04308e1a8.png'),
@@ -353,5 +362,7 @@ VALUES
     ('BEAN', '두부면', 'PACK', 'FRIDGE', 5, '개봉 후 냉장 보관하며 물기를 제거하고 밀폐 용기에 보관하세요.', 'https://cookeep-images.s3.ap-northeast-2.amazonaws.com/ingredients/3d47bc7e-8b1f-4001-b127-49dc1e65e1f3.png'),
     ('BEAN', '병아리콩', 'PACK', 'FRIDGE', 30,'삶은 경우 냉장 보관하며 밀폐 용기에 넣어 보관하세요.', 'https://cookeep-images.s3.ap-northeast-2.amazonaws.com/ingredients/27c45ec1-095d-40ec-9013-b88428f91fd2.png'),
     ('BEAN', '렌틸콩', 'PACK', 'FRIDGE', 30, '삶은 경우 냉장 보관하며 밀폐 용기에 넣어 보관하세요.', 'https://cookeep-images.s3.ap-northeast-2.amazonaws.com/ingredients/ab6417aa-3107-4ce5-9b84-fab299129841.png'),
-    ('BEAN', '강낭콩', 'PACK', 'FRIDGE', 30, '삶은 경우 냉장 보관하며 밀폐 용기에 넣어 보관하세요.', 'https://cookeep-images.s3.ap-northeast-2.amazonaws.com/ingredients/a62b92c5-1d49-4813-8ea1-a6ded46b549a.png')
+    ('BEAN', '강낭콩', 'PACK', 'FRIDGE', 30, '삶은 경우 냉장 보관하며 밀폐 용기에 넣어 보관하세요.', 'https://cookeep-images.s3.ap-northeast-2.amazonaws.com/ingredients/a62b92c5-1d49-4813-8ea1-a6ded46b549a.png'),
+    ('BEAN', '두유', 'PACK', 'FRIDGE', 14, '개봉 후엔 냉장 보관하고 빠르게 마셔주세요.','https://cookeep-images.s3.ap-northeast-2.amazonaws.com/ingredients/b4730755-254a-4997-866a-0d241d53d416.png'),
+    ('BEAN', '은행', 'PIECE', 'FRIDGE', 7, '습기를 피해 밀봉 보관하세요.','https://cookeep-images.s3.ap-northeast-2.amazonaws.com/ingredients/39f036bb-8cd6-4161-ac49-8d03709f520d.png')
 ;


### PR DESCRIPTION
# Issue
#237 

# Description
Gemini API 호출의 안정성과 효율성을 개선합니다. 동일 재료 조합에 대한 Redis 캐싱으로 불필요한 API 호출을 줄이고, Rate Limit을 Redis 기반으로 전환해 다중 서버 환경에서도 정확한 제한이 적용되도록 합니다. 또한 Semaphore 기반 큐 처리로 동시 호출 수를 제어하고, Gemini 503 에러로 인한 클라이언트 타임아웃 문제를 구조적으로 개선합니다.

# Changes
### 1. AI 레시피 캐싱 (Redis)
AiRecipeCacheService 추가 — 재료 ID 조합 + 난이도를 키로 Gemini 응답을 Redis에 TTL 24시간으로 저장/조회
신규 요청 시 캐시 히트면 Gemini 호출 생략, 재요청(retry) 결과도 캐시에 저장해 다른 세션에서 재사용 가능

### 2. Redis 기반 Rate Limit
AiRateLimitService 전체 교체 — ConcurrentHashMap 제거, Redis INCR + TTL 60초 방식으로 변경
다중 서버 환경에서도 유저별 분당 3회 제한이 정확히 적용됨

### 3. Gemini 동시 호출 큐 처리
GeminiQueueService 추가 — JVM Semaphore로 동시 Gemini 호출 수를 최대 3개로 제한
슬롯 초과 시 최대 90초 대기 후 타임아웃, AiRecipeService에서 GeminiService 직접 호출을 GeminiQueueService로 대체

### 4. 프론트 로딩 문제 개선
GeminiService retry 설정 변경 — 재시도 3회/최대 10초 → 3회/최대 5초로 단축해 클라이언트 타임아웃 방지
AiRecipeService.generateInitialRecipe 흐름 변경 — 세션/메시지 저장을 AI 호출 성공 후로 이동해 실패 시 오염된 세션 생성 방지
ErrorCode.AI_SERVER_FAILED 503 추가, 메시지를 재시도 안내 문구로 수정

# Test Checklist
- [x] ai 서버 호출 실패 시 재시도 로그 확인 완료
- [x] 캐시 적용 확인 완료
- [x] 동일 제목 레시피 호출 시 캐시 내 레시피 호출 정상 동작 확인