### PR TITLE
feat: CORS 허용 도메인에 vercel 서브 도메인 추가

### DIFF
--- a/src/main/java/com/cookeep/cookeep/config/SecurityConfig.java
+++ b/src/main/java/com/cookeep/cookeep/config/SecurityConfig.java
@@ -32,10 +32,11 @@ public class SecurityConfig {
 	public CorsConfigurationSource corsConfigurationSource() {
 		CorsConfiguration config = new CorsConfiguration();
 		config.setAllowedOrigins(List.of(
-			"http://localhost:5173",
-			"https://12th-coo-keep-fe.vercel.app",
-			"https://cookeep.kr",
-			"https://api.cookeep.kr"
+				"http://localhost:5173",
+				"https://12th-coo-keep-fe.vercel.app",
+				"https://cookeep.kr",
+				"https://api.cookeep.kr",
+				"https://cookeep.vercel.app"
 		));
 		config.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
 		config.setAllowedHeaders(List.of("*"));


### PR DESCRIPTION
# Related Issue
CLOSE #249 

# Description
`SecurityConfig`의 setAllowedOrigins 허용 출처에 `https://cookeep.vercel.app` 도메인을 추가했습니다.

# 참고사항
변동사항은 크게 없어서 바로 머지하겠습니다 코드 살펴보시면 될 것 같습니다!