### PR TITLE
refactor: 로그아웃 시 구독 등록 삭제 로직 추가

### DIFF
--- a/src/main/java/com/cookeep/cookeep/domain/user/application/AuthService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/user/application/AuthService.java
@@ -11,6 +11,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import com.cookeep.cookeep.domain.notification.dao.WebPushSubscriptionRepository;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -63,6 +64,7 @@ public class AuthService {
 	private final NicknameGenerator nicknameGenerator;
 	private final EmailVerificationService emailVerificationService;
 	private final CookieService cookieService;
+	private final WebPushSubscriptionRepository webPushSubscriptionRepository;
 
 	// 액세스 토큰이 만료되었을 경우 리프레쉬 토큰으로 액세스 토큰 갱신
 	@Transactional
@@ -132,6 +134,9 @@ public class AuthService {
 	}
 
 	private TokenPair issueTokensAndUpsertSession(User user) {
+		// 기존 구독 삭제 (새 기기로 갱신)
+		webPushSubscriptionRepository.deleteAllByUser_UserId(user.getUserId());
+
 		boolean isRewarded = issueComebackReward(user);
 		user.updateLastAccessAt(LocalDateTime.now());
 
@@ -437,6 +442,9 @@ public class AuthService {
 	public void logout(Long userId) {
 		// 로그아웃 시 refreshToken 저장된 userSession 폐기
 		userSessionRepository.deleteByUser_UserId(userId);
+
+		// 알림 구독 삭제
+		webPushSubscriptionRepository.deleteAllByUser_UserId(userId);
 	}
 
 	@Transactional
@@ -453,5 +461,7 @@ public class AuthService {
 
 		// 탈퇴 시 refreshToken도 함께 무효화
 		userSessionRepository.deleteByUser_UserId(userId);
+		// 알림 구독 삭제
+		webPushSubscriptionRepository.deleteAllByUser_UserId(userId);
 	}
 }


### PR DESCRIPTION
# Issue
#255 

# Description

로그인 시 기존 기기의 웹 푸시 구독 정보가 삭제되지 않아, 새로운 기기가 아닌 이전 기기로 알림이 전송되는 버그를 수정합니다.


# Changes

## 기존 방식의 문제점

구독 삭제는 프론트엔드가 명시적으로 `DELETE /api/users/me/web/push/subscription`을 호출할 때만 이루어졌습니다.

로그아웃(`logout`) 및 새 기기 로그인(`issueTokensAndUpsertSession`) 시 `UserSession`만 갱신하고 `WebPushSubscription`은 건드리지 않았기 때문에, 이전 기기의 구독 정보가 DB에 그대로 남아 있었습니다.

알림 전송 시 `findAllByUser_UserId`로 해당 유저의 모든 구독을 조회하여 전송하므로, 현재 로그인된 기기가 아닌 이전 기기로 알림이 전송되는 문제가 발생했습니다.

**재현 시나리오**
- 기기 A 로그인 → 구독 등록
- 기기 B 로그인 (기기 A 자동 로그아웃) → 구독 등록
- 알림 전송 조건 충족 → 기기 A, B 모두에 알림 전송됨 (또는 기기 A에만 전송됨)

## 변경 내용

**`AuthService`**
- `issueTokensAndUpsertSession()` : 새 로그인 시 해당 유저의 기존 구독 정보를 전부 삭제하도록 추가
- `logout()` : 로그아웃 시 세션 삭제와 함께 구독 정보도 삭제하도록 추가
- `withdraw()` : 회원 탈퇴 시 구독 정보도 함께 삭제하도록 추가

## 해결된 문제

- 새 기기로 로그인하면 이전 기기의 구독이 초기화되고, 로그인 후 프론트가 구독 등록 API를 호출하면 새 기기의 구독만 유효하게 유지됩니다.
- 수동 로그아웃 시 구독이 함께 삭제되어 로그아웃된 기기로 알림이 전송되지 않습니다.
- 회원 탈퇴 시 구독 정보가 남아 불필요한 알림이 전송되는 케이스가 제거됩니다.