### PR TITLE
Fix: 신규 기기 로그인 시 구독 등록 갱신

### DIFF
--- a/src/main/java/com/cookeep/cookeep/domain/notification/application/WebPushSubscriptionService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/notification/application/WebPushSubscriptionService.java
@@ -51,7 +51,7 @@ public class WebPushSubscriptionService {
             return WebPushSubscriptionResponseDto.subscribed();
         }
 
-        // 기존 구독 삭제 후 새 구독 등록 (단일 기기 정책 유지하려면)
+        // 기존 구독 삭제 후 새 구독 등록 (유저 당 한 기기만 등록)
         webPushSubscriptionRepository.deleteAllByUser_UserId(userId);
 
         WebPushSubscription subscription = WebPushSubscription.builder()

--- a/src/main/java/com/cookeep/cookeep/domain/notification/application/WebPushSubscriptionService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/notification/application/WebPushSubscriptionService.java
@@ -51,6 +51,9 @@ public class WebPushSubscriptionService {
             return WebPushSubscriptionResponseDto.subscribed();
         }
 
+        // 기존 구독 삭제 후 새 구독 등록 (단일 기기 정책 유지하려면)
+        webPushSubscriptionRepository.deleteAllByUser_UserId(userId);
+
         WebPushSubscription subscription = WebPushSubscription.builder()
                 .user(user)
                 .endpoint(request.getEndpoint())

--- a/src/main/java/com/cookeep/cookeep/domain/user/application/AuthService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/user/application/AuthService.java
@@ -135,7 +135,7 @@ public class AuthService {
 
 	private TokenPair issueTokensAndUpsertSession(User user) {
 		// 기존 구독 삭제 (새 기기로 갱신)
-		webPushSubscriptionRepository.deleteAllByUser_UserId(user.getUserId());
+		//webPushSubscriptionRepository.deleteAllByUser_UserId(user.getUserId());
 
 		boolean isRewarded = issueComebackReward(user);
 		user.updateLastAccessAt(LocalDateTime.now());


### PR DESCRIPTION
# Issue
#259 

# Description
- 기존 로그아웃 시 구독 정보 삭제 로직으로 인해 신규 기기에서 로그인 시 구독 정보가 등록되지 않아 알림이 전송되지 않는 문제 발생
- 기존 자동 로그이웃 시 구독 정보 삭제 로직 제거 후 신규 환경에서 로그인 시 해당 기기 정보로 구독이 갱신되도록 수정

# Changes
- WebPushSubscriptionService.subscribe() 내부 기존 구독 삭제 후 새 구독 등록 로직 추가
- AuthService.issueTokensAndUpsertSession() 내부 구독 삭제 로직 주석 처리
  - 추후 삭제 예정