### PR TITLE
hotfix: Gemini thinking budget 사용 차단

### DIFF
--- a/src/main/java/com/cookeep/cookeep/domain/recipe/dto/GeminiRecipeRequestDto.java
+++ b/src/main/java/com/cookeep/cookeep/domain/recipe/dto/GeminiRecipeRequestDto.java
@@ -99,7 +99,11 @@ public class GeminiRecipeRequestDto {
                 "required", List.of("title", "ingredients", "steps", "youtube_search_queries")
         );
 
-        return new GenerationConfig("application/json", schema);
+        return new GenerationConfig(
+                "application/json",
+                schema,
+                Map.of("thinkingBudget", 0)  // Thinking 비활성화
+        );
     }
 
     // 내부 메서드
@@ -128,6 +132,7 @@ public class GeminiRecipeRequestDto {
     static class GenerationConfig {
         private String responseMimeType;
         private Map<String, Object> responseSchema;
+        private Map<String, Object> thinkingConfig;
     }
 
 }


### PR DESCRIPTION
# Issue
#264 

# Description
- Gemini thinking budget 사용 차단

# Changes
- GenerationConfig에 thinkingConfig 차단
- buildGenerationConfig에 thinking budget 0으로 제한