### PR TITLE
Feat: AI 레시피 요청 조건 difficulty → feature 변경

### DIFF
--- a/src/main/java/com/cookeep/cookeep/api/dto/request/AiRecipeRequestDto.java
+++ b/src/main/java/com/cookeep/cookeep/api/dto/request/AiRecipeRequestDto.java
@@ -1,6 +1,7 @@
 package com.cookeep.cookeep.api.dto.request;
 
 import com.cookeep.cookeep.domain.recipe.entity.Difficulty;
+import com.cookeep.cookeep.domain.recipe.entity.Feature;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -22,13 +23,19 @@ public class AiRecipeRequestDto {
     )
     private Long sessionId;
 
+//    @Schema(
+//            description = "레시피 난이도 (신규 요청 시 필수)",
+//            example = "EASY",
+//            allowableValues = {"EASY", "NORMAL", "HARD"},
+//            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+//    )
+//    private Difficulty difficulty;
+
     @Schema(
-            description = "레시피 난이도 (신규 요청 시 필수)",
-            example = "EASY",
-            allowableValues = {"EASY", "NORMAL", "HARD"},
-            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+            description = "요리 종류 (신규 요청 시 필수)",
+            example = "RICE_BOWL"
     )
-    private Difficulty difficulty;
+    private Feature feature;
 
     @Schema(
             description = "레시피 생성을 위한 유저 식재료 ID 목록 (신규 요청 시 필수)",

--- a/src/main/java/com/cookeep/cookeep/api/dto/request/AiRecipeRequestDto.java
+++ b/src/main/java/com/cookeep/cookeep/api/dto/request/AiRecipeRequestDto.java
@@ -1,6 +1,5 @@
 package com.cookeep.cookeep.api.dto.request;
 
-import com.cookeep.cookeep.domain.recipe.entity.Difficulty;
 import com.cookeep.cookeep.domain.recipe.entity.Feature;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;

--- a/src/main/java/com/cookeep/cookeep/api/dto/request/AiRecipeRequestDto.java
+++ b/src/main/java/com/cookeep/cookeep/api/dto/request/AiRecipeRequestDto.java
@@ -33,6 +33,8 @@ public class AiRecipeRequestDto {
     @Schema(
             description = "요리 종류 (신규 요청 시 필수)",
             example = "RICE_BOWL"
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED,
+            allowableValues = {"SOUP_STEW", "RICE_BOWL", "NOODLE", "STIR_FRY_GRILL", "SALAD_HEALTHY", "SNACK_DESSERT", "ANY"}
     )
     private Feature feature;
 

--- a/src/main/java/com/cookeep/cookeep/api/dto/request/AiRecipeRequestDto.java
+++ b/src/main/java/com/cookeep/cookeep/api/dto/request/AiRecipeRequestDto.java
@@ -22,14 +22,6 @@ public class AiRecipeRequestDto {
     )
     private Long sessionId;
 
-//    @Schema(
-//            description = "레시피 난이도 (신규 요청 시 필수)",
-//            example = "EASY",
-//            allowableValues = {"EASY", "NORMAL", "HARD"},
-//            requiredMode = Schema.RequiredMode.NOT_REQUIRED
-//    )
-//    private Difficulty difficulty;
-
     @Schema(
             description = "요리 종류 (신규 요청 시 필수)",
             example = "RICE_BOWL"

--- a/src/main/java/com/cookeep/cookeep/api/dto/response/AiRecipeResponseDto.java
+++ b/src/main/java/com/cookeep/cookeep/api/dto/response/AiRecipeResponseDto.java
@@ -2,6 +2,7 @@ package com.cookeep.cookeep.api.dto.response;
 
 import com.cookeep.cookeep.domain.recipe.dto.GeminiRecipeResponseDto;
 import com.cookeep.cookeep.domain.recipe.dto.YoutubeReferenceDto;
+import com.cookeep.cookeep.domain.recipe.entity.Feature;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
@@ -42,4 +43,7 @@ public class AiRecipeResponseDto {
             requiredMode = Schema.RequiredMode.NOT_REQUIRED
     )
     private List<YoutubeReferenceDto> youtubeReferences;
+
+    @Schema(description = "요리 종류", example = "RICE_BOWL")
+    private Feature feature;
 }

--- a/src/main/java/com/cookeep/cookeep/common/exception/ErrorCode.java
+++ b/src/main/java/com/cookeep/cookeep/common/exception/ErrorCode.java
@@ -54,6 +54,7 @@ public enum ErrorCode {
 	TITLE_TOO_LONG(HttpStatus.BAD_REQUEST, "레시피 제목은 최대 100글자입니다.", "RECIPE-023"),
 	RECIPE_DELETE_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "데일리레시피에 기록된 레시피는 삭제할 수 없습니다.", "RECIPE-024"),
 	DISLIKED_INGREDIENT_INCLUDED(HttpStatus.BAD_REQUEST, "제외 재료가 포함된 레시피입니다.", "RECIPE-025"),
+	INVALID_FEATURE(HttpStatus.BAD_REQUEST, "유효하지 않은 요리 종류입니다.", "RECIPE-029"),
 
 	// ONBOARDING
 	INVALID_FOOD_TYPE_COUNT(HttpStatus.BAD_REQUEST, "선호하는 음식 종류는 3개까지만 선택 가능합니다.", "ONBOARDING-001"),

--- a/src/main/java/com/cookeep/cookeep/common/exception/ErrorCode.java
+++ b/src/main/java/com/cookeep/cookeep/common/exception/ErrorCode.java
@@ -55,6 +55,7 @@ public enum ErrorCode {
 	RECIPE_DELETE_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "데일리레시피에 기록된 레시피는 삭제할 수 없습니다.", "RECIPE-024"),
 	DISLIKED_INGREDIENT_INCLUDED(HttpStatus.BAD_REQUEST, "제외 재료가 포함된 레시피입니다.", "RECIPE-025"),
 	INVALID_FEATURE(HttpStatus.BAD_REQUEST, "유효하지 않은 요리 종류입니다.", "RECIPE-029"),
+	SESSION_FEATURE_NOT_FOUND(HttpStatus.BAD_REQUEST, "세션의 요리 종류 정보를 찾을 수 없습니다.", "RECIPE-030"),
 
 	// ONBOARDING
 	INVALID_FOOD_TYPE_COUNT(HttpStatus.BAD_REQUEST, "선호하는 음식 종류는 3개까지만 선택 가능합니다.", "ONBOARDING-001"),

--- a/src/main/java/com/cookeep/cookeep/common/util/FlywayDependencyPostProcessor.java
+++ b/src/main/java/com/cookeep/cookeep/common/util/FlywayDependencyPostProcessor.java
@@ -1,0 +1,21 @@
+package com.cookeep.cookeep.common.util;
+
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.beans.factory.support.BeanDefinitionRegistry;
+import org.springframework.beans.factory.support.BeanDefinitionRegistryPostProcessor;
+import org.springframework.stereotype.Component;
+
+@Component
+public class FlywayDependencyPostProcessor implements BeanDefinitionRegistryPostProcessor {
+
+    @Override
+    public void postProcessBeanDefinitionRegistry(BeanDefinitionRegistry registry) {
+        BeanDefinition bd = registry.getBeanDefinition("entityManagerFactory");
+        bd.setDependsOn("flyway");
+    }
+
+    @Override
+    public void postProcessBeanFactory(ConfigurableListableBeanFactory beanFactory) {}
+
+}

--- a/src/main/java/com/cookeep/cookeep/config/FlywayConfig.java
+++ b/src/main/java/com/cookeep/cookeep/config/FlywayConfig.java
@@ -9,14 +9,16 @@ import javax.sql.DataSource;
 @Configuration
 public class FlywayConfig {
 
-    @Bean(initMethod = "migrate")
+    @Bean
     public Flyway flyway(DataSource dataSource) {
-        return Flyway.configure()
+        Flyway flyway = Flyway.configure()
                 .dataSource(dataSource)
                 .locations("classpath:db/migration")
                 .baselineOnMigrate(true)
                 .baselineVersion("3")
                 .outOfOrder(false)
                 .load();
+        flyway.migrate();
+        return flyway;
     }
 }

--- a/src/main/java/com/cookeep/cookeep/domain/recipe/application/AiRecipeCacheService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/recipe/application/AiRecipeCacheService.java
@@ -2,6 +2,7 @@ package com.cookeep.cookeep.domain.recipe.application;
 
 import com.cookeep.cookeep.domain.recipe.dto.GeminiRecipeResponseDto;
 import com.cookeep.cookeep.domain.recipe.entity.Difficulty;
+import com.cookeep.cookeep.domain.recipe.entity.Feature;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.StringRedisTemplate;
@@ -23,7 +24,7 @@ public class AiRecipeCacheService {
     private static final Duration TTL = Duration.ofHours(24);
     private static final String KEY_PREFIX = "recipe:cache:";
 
-    public String buildCacheKey(List<Long> ingredientIds, Difficulty difficulty, List<String> dislikedIngredients) {
+    public String buildCacheKey(List<Long> ingredientIds, Feature feature, List<String> dislikedIngredients) {
         String sortedIds = ingredientIds.stream()
                 .sorted()
                 .map(String::valueOf)
@@ -36,7 +37,7 @@ public class AiRecipeCacheService {
                 .sorted()
                 .collect(Collectors.joining("_"));
 
-        return KEY_PREFIX + sortedIds + ":" + difficulty.name();
+        return KEY_PREFIX + sortedIds + ":" + feature.name() + ":" + dislikedPart;
     }
 
     public GeminiRecipeResponseDto get(String cacheKey) {

--- a/src/main/java/com/cookeep/cookeep/domain/recipe/application/AiRecipeService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/recipe/application/AiRecipeService.java
@@ -90,8 +90,12 @@ public class AiRecipeService {
             throw new AppException(ErrorCode.RECIPE_INGREDIENTS_REQUIRED);
         }
 
-        if (request.getDifficulty() == null) {
-            throw new AppException(ErrorCode.INVALID_DIFFICULTY);
+//        if (request.getDifficulty() == null) {
+//            throw new AppException(ErrorCode.INVALID_DIFFICULTY);
+//        }
+
+        if (request.getFeature() == null) {
+            throw new AppException(ErrorCode.INVALID_FEATURE);
         }
 
         // RateLimit 검증
@@ -122,7 +126,7 @@ public class AiRecipeService {
         // ── AI 호출을 세션 저장보다 먼저 ──
         // 캐시 조회
         String cacheKey = aiRecipeCacheService.buildCacheKey(
-                request.getIngredientIds(), request.getDifficulty(), dislikedIngredients);
+                request.getIngredientIds(), request.getFeature(), dislikedIngredients);
         GeminiRecipeResponseDto aiResponse = aiRecipeCacheService.get(cacheKey);
 
         // 4. AI 레시피 생성 (이름 + 단위만 전달, AI가 quantity 생성)
@@ -131,14 +135,15 @@ public class AiRecipeService {
             log.info("AI 레시피 캐시 히트. key={}", cacheKey);
         } else {
             aiResponse = geminiQueueService.generateRecipe(
-                    enrichedIngredients, request.getDifficulty(), dislikedIngredients);
+                    enrichedIngredients, request.getFeature(), dislikedIngredients);
             aiRecipeCacheService.put(cacheKey, aiResponse);
         }
 
         // 5. 세션 생성
         AiSession session = AiSession.builder()
                 .userId(userId)
-                .difficulty(request.getDifficulty())
+                //.difficulty(request.getDifficulty())
+                .feature(request.getFeature())
                 .attemptNumber(1)
                 .isCompleted(false)
                 .userIngredientIds(writeEnrichedIngredientsAsJson(enrichedIngredients))
@@ -164,6 +169,7 @@ public class AiRecipeService {
         return AiRecipeResponseDto.builder()
                 .sessionId(session.getId())
                 .changeCount(session.getAttemptNumber())
+                .feature(request.getFeature())
                 .recipe(aiResponse)
                 .youtubeReferences(youtubeReferences)
                 .build();
@@ -187,8 +193,12 @@ public class AiRecipeService {
             throw new AppException(ErrorCode.AI_RECIPE_CHANGE_LIMIT_EXCEEDED);
         }
 
-        if (session.getDifficulty() == null) {
-            throw new AppException(ErrorCode.SESSION_DIFFICULTY_NOT_FOUND);
+//        if (session.getDifficulty() == null) {
+//            throw new AppException(ErrorCode.SESSION_DIFFICULTY_NOT_FOUND);
+//        }
+
+        if (session.getFeature() == null) {
+            throw new AppException(ErrorCode.SESSION_FEATURE_NOT_FOUND);
         }
 
         // RateLimit 검증
@@ -211,7 +221,8 @@ public class AiRecipeService {
         // 5. AI 호출 (제외 리스트 포함)
         GeminiRecipeResponseDto aiResponse = geminiQueueService.generateRecipeWithExclusion(
                 ingredients,
-                session.getDifficulty(),
+                //session.getDifficulty(),
+                session.getFeature(),
                 excludedTitles,
                 dislikedIngredients
         );
@@ -235,6 +246,7 @@ public class AiRecipeService {
         return AiRecipeResponseDto.builder()
                 .sessionId(session.getId())
                 .changeCount(session.getAttemptNumber())
+                .feature(session.getFeature())
                 .recipe(aiResponse)
                 .youtubeReferences(youtubeReferences)
                 .build();
@@ -442,7 +454,7 @@ public class AiRecipeService {
             if (request.getIngredientIds() == null || request.getIngredientIds().isEmpty()) {
                 throw new AppException(ErrorCode.RECIPE_INGREDIENTS_REQUIRED);
             }
-            if (request.getDifficulty() == null) {
+            if (request.getFeature() == null) {
                 throw new AppException(ErrorCode.INVALID_DIFFICULTY);
             }
         }

--- a/src/main/java/com/cookeep/cookeep/domain/recipe/application/AiRecipeService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/recipe/application/AiRecipeService.java
@@ -447,7 +447,7 @@ public class AiRecipeService {
                 throw new AppException(ErrorCode.RECIPE_INGREDIENTS_REQUIRED);
             }
             if (request.getFeature() == null) {
-                throw new AppException(ErrorCode.INVALID_DIFFICULTY);
+                throw new AppException(ErrorCode.INVALID_FEATURE);
             }
         }
         // 재요청은 기존 세션에서 정보 가져옴

--- a/src/main/java/com/cookeep/cookeep/domain/recipe/application/AiRecipeService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/recipe/application/AiRecipeService.java
@@ -138,7 +138,6 @@ public class AiRecipeService {
         // 5. 세션 생성
         AiSession session = AiSession.builder()
                 .userId(userId)
-                //.difficulty(request.getDifficulty())
                 .feature(request.getFeature())
                 .attemptNumber(1)
                 .isCompleted(false)
@@ -189,9 +188,6 @@ public class AiRecipeService {
             throw new AppException(ErrorCode.AI_RECIPE_CHANGE_LIMIT_EXCEEDED);
         }
 
-//        if (session.getDifficulty() == null) {
-//            throw new AppException(ErrorCode.SESSION_DIFFICULTY_NOT_FOUND);
-//        }
 
         if (session.getFeature() == null) {
             throw new AppException(ErrorCode.SESSION_FEATURE_NOT_FOUND);

--- a/src/main/java/com/cookeep/cookeep/domain/recipe/application/AiRecipeService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/recipe/application/AiRecipeService.java
@@ -90,10 +90,6 @@ public class AiRecipeService {
             throw new AppException(ErrorCode.RECIPE_INGREDIENTS_REQUIRED);
         }
 
-//        if (request.getDifficulty() == null) {
-//            throw new AppException(ErrorCode.INVALID_DIFFICULTY);
-//        }
-
         if (request.getFeature() == null) {
             throw new AppException(ErrorCode.INVALID_FEATURE);
         }

--- a/src/main/java/com/cookeep/cookeep/domain/recipe/application/GeminiQueueService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/recipe/application/GeminiQueueService.java
@@ -5,6 +5,7 @@ import com.cookeep.cookeep.common.exception.ErrorCode;
 import com.cookeep.cookeep.domain.recipe.dto.GeminiRecipeResponseDto;
 import com.cookeep.cookeep.domain.recipe.dto.IngredientDetailDto;
 import com.cookeep.cookeep.domain.recipe.entity.Difficulty;
+import com.cookeep.cookeep.domain.recipe.entity.Feature;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -32,7 +33,8 @@ public class GeminiQueueService {
      */
     public GeminiRecipeResponseDto generateRecipe(
             List<IngredientDetailDto> ingredients,
-            Difficulty difficulty,
+            //Difficulty difficulty,
+            Feature feature,
             List<String> dislikedIngredients) {
 
         boolean acquired = false;
@@ -43,7 +45,7 @@ public class GeminiQueueService {
                 throw new AppException(ErrorCode.AI_SEARCH_FAILED);
             }
             log.info("Gemini 슬롯 획득. 남은 슬롯={}", semaphore.availablePermits());
-            return geminiService.generateRecipe(ingredients, difficulty, dislikedIngredients);
+            return geminiService.generateRecipe(ingredients, feature, dislikedIngredients);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             throw new AppException(ErrorCode.AI_SEARCH_FAILED);
@@ -57,7 +59,8 @@ public class GeminiQueueService {
 
     public GeminiRecipeResponseDto generateRecipeWithExclusion(
             List<IngredientDetailDto> ingredients,
-            Difficulty difficulty,
+            //Difficulty difficulty,
+            Feature feature,
             List<String> excludedTitles,
             List<String> dislikedIngredients) {
 
@@ -69,7 +72,7 @@ public class GeminiQueueService {
                 throw new AppException(ErrorCode.AI_SEARCH_FAILED);
             }
             return geminiService.generateRecipeWithExclusion(
-                    ingredients, difficulty, excludedTitles, dislikedIngredients);
+                    ingredients, feature, excludedTitles, dislikedIngredients);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             throw new AppException(ErrorCode.AI_SEARCH_FAILED);

--- a/src/main/java/com/cookeep/cookeep/domain/recipe/application/GeminiService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/recipe/application/GeminiService.java
@@ -6,6 +6,7 @@ import com.cookeep.cookeep.domain.recipe.dto.GeminiRecipeRequestDto;
 import com.cookeep.cookeep.domain.recipe.dto.GeminiRecipeResponseDto;
 import com.cookeep.cookeep.domain.recipe.dto.IngredientDetailDto;
 import com.cookeep.cookeep.domain.recipe.entity.Difficulty;
+import com.cookeep.cookeep.domain.recipe.entity.Feature;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
@@ -41,18 +42,20 @@ public class GeminiService {
 
     public GeminiRecipeResponseDto generateRecipe(
             List<IngredientDetailDto> ingredients,
-            Difficulty difficulty,
+            //Difficulty difficulty,
+            Feature feature,
             List<String> dislikedIngredients) {
-        return generateRecipeByPrompt(buildPrompt(ingredients, difficulty, List.of(), dislikedIngredients));
+        return generateRecipeByPrompt(buildPrompt(ingredients, feature, List.of(), dislikedIngredients));
     }
 
     public GeminiRecipeResponseDto generateRecipeWithExclusion(
             List<IngredientDetailDto> ingredients,
-            Difficulty difficulty,
+            //Difficulty difficulty,
+            Feature feature,
             List<String> excludedTitles,
             List<String> dislikedIngredients
     ) {
-        return generateRecipeByPrompt(buildPrompt(ingredients, difficulty, excludedTitles, dislikedIngredients));
+        return generateRecipeByPrompt(buildPrompt(ingredients, feature, excludedTitles, dislikedIngredients));
     }
 
     // 레시피 생성
@@ -183,7 +186,8 @@ public class GeminiService {
     // 프롬프트 생성
     private String buildPrompt(
             List<IngredientDetailDto> ingredients,
-            Difficulty difficulty,
+            //Difficulty difficulty,
+            Feature feature,
             List<String> excludedTitles,
             List<String> dislikedIngredients) {
 
@@ -206,8 +210,13 @@ public class GeminiService {
                         dislikedIngredients.stream().map(t -> "- " + t).collect(Collectors.joining("\n")) +
                         "\n위 재료는 additional_ingredients, optional_ingredients 어디에도 절대 포함하지 마세요.\n";
 
+        // feature가 ANY(아무거나)이면 종류 제한 없음, 그 외엔 해당 종류로 제한
+        String featureBlock = (feature == null || feature == Feature.ANY)
+                ? "\n[요리 종류] 제한 없음 (어떤 종류의 요리도 추천 가능)\n"
+                : "\n[요리 종류] " + feature.getDisplayName() + " 종류의 레시피를 추천하세요.\n";
+
         return "당신은 요리 레시피 전문가입니다.\n\n" +
-                "[난이도] " + difficulty.name() + "\n" +
+                featureBlock +
                 exclusionBlock + dislikedBlock +
                 "\n[재료 구성 규칙]\n" +
                 // 규칙 1: user_ingredients — 원본 데이터 그대로 사용

--- a/src/main/java/com/cookeep/cookeep/domain/recipe/dto/GeminiRecipeResponseDto.java
+++ b/src/main/java/com/cookeep/cookeep/domain/recipe/dto/GeminiRecipeResponseDto.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 import java.util.List;
 
@@ -14,6 +15,7 @@ import java.util.List;
 )
 @Getter
 @NoArgsConstructor
+@Setter
 @JsonIgnoreProperties(ignoreUnknown = true) //AI 에러 방지
 public class GeminiRecipeResponseDto {
 

--- a/src/main/java/com/cookeep/cookeep/domain/recipe/entity/AiSession.java
+++ b/src/main/java/com/cookeep/cookeep/domain/recipe/entity/AiSession.java
@@ -39,8 +39,8 @@ public class AiSession {
     private LocalDateTime updatedAt;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "difficulty")
-    private Difficulty difficulty;
+    @Column(name = "feature")
+    private Feature feature;
 
     @Column(name = "is_pinned")
     private Boolean isPinned;

--- a/src/main/java/com/cookeep/cookeep/domain/recipe/entity/Feature.java
+++ b/src/main/java/com/cookeep/cookeep/domain/recipe/entity/Feature.java
@@ -1,0 +1,22 @@
+package com.cookeep.cookeep.domain.recipe.entity;
+
+public enum Feature {
+
+    SOUP_STEW("국물/찌개"),
+    RICE_BOWL("밥/덮밥"),
+    NOODLE("면/요리"),
+    STIR_FRY_GRILL("볶음/구이"),
+    SALAD_HEALTHY("샐러드/건강식"),
+    SNACK_DESSERT("간식/디저트"),
+    ANY("아무거나");
+
+    private final String displayName;
+
+    Feature(String displayName) {
+        this.displayName = displayName;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+}

--- a/src/main/java/com/cookeep/cookeep/domain/recipe/entity/Feature.java
+++ b/src/main/java/com/cookeep/cookeep/domain/recipe/entity/Feature.java
@@ -4,7 +4,7 @@ public enum Feature {
 
     SOUP_STEW("국물/찌개"),
     RICE_BOWL("밥/덮밥"),
-    NOODLE("면/요리"),
+    NOODLE("면 요리"),
     STIR_FRY_GRILL("볶음/구이"),
     SALAD_HEALTHY("샐러드/건강식"),
     SNACK_DESSERT("간식/디저트"),

--- a/src/main/resources/db/migration/V5__ai_session_difficulty_to_feature.sql
+++ b/src/main/resources/db/migration/V5__ai_session_difficulty_to_feature.sql
@@ -1,0 +1,19 @@
+-- V{NEXT}__ai_session_difficulty_to_feature.sql
+-- ai_sessions 테이블의 difficulty 컬럼을 feature 컬럼으로 교체
+
+-- 1. feature 컬럼 추가
+ALTER TABLE `ai_sessions`
+    ADD COLUMN `feature`
+        ENUM('SOUP_STEW','RICE_BOWL','NOODLE','STIR_FRY_GRILL','SALAD_HEALTHY','SNACK_DESSERT','ANY')
+        COLLATE utf8mb4_unicode_ci DEFAULT NULL
+        AFTER `updated_at`;
+
+-- 2. 기존 difficulty 값을 feature로 이관
+--    (EASY/NORMAL/HARD 는 요리 종류가 아니므로 ANY로 매핑)
+UPDATE `ai_sessions`
+SET `feature` = 'ANY'
+WHERE `difficulty` IS NOT NULL;
+
+-- 3. 기존 difficulty 컬럼 삭제
+ALTER TABLE `ai_sessions`
+DROP COLUMN `difficulty`;

--- a/src/test/java/com/cookeep/cookeep/domain/recipe/application/AiRecipeServiceTest.java
+++ b/src/test/java/com/cookeep/cookeep/domain/recipe/application/AiRecipeServiceTest.java
@@ -23,6 +23,8 @@ import com.cookeep.cookeep.domain.recipe.entity.*;
 import com.cookeep.cookeep.domain.user.application.UserReader;
 import com.cookeep.cookeep.domain.user.dao.UserRepository;
 import com.cookeep.cookeep.domain.user.entity.User;
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.PropertyAccessor;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -66,6 +68,8 @@ public class AiRecipeServiceTest {
     @Mock private AiRateLimitService rateLimitService;
     @Mock private UserRepository userRepository;
     @Mock private UserReader userReader;
+    @Mock private GeminiQueueService geminiQueueService;
+    @Mock private AiRecipeCacheService aiRecipeCacheService;
 
     @Spy
     private ObjectMapper objectMapper = new ObjectMapper();
@@ -94,6 +98,9 @@ public class AiRecipeServiceTest {
 
     @BeforeEach
     void setUp() throws Exception {
+
+        objectMapper.setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
+
         user = User.builder().nickname("테스터").build();
 
         given(userReader.readById(anyLong()))
@@ -104,7 +111,7 @@ public class AiRecipeServiceTest {
 
         session = AiSession.builder()
                 .userId(1L)
-                .difficulty(Difficulty.EASY)
+                .feature(Feature.RICE_BOWL)
                 .attemptNumber(1)
                 .isCompleted(false)
                 .userIngredientIds("[]")
@@ -359,7 +366,7 @@ public class AiRecipeServiceTest {
                     """;
             session = AiSession.builder()
                     .userId(1L)
-                    .difficulty(Difficulty.EASY)
+                    .feature(Feature.RICE_BOWL)
                     .attemptNumber(1)
                     .isCompleted(false)
                     .userIngredientIds(ingredientsJson)
@@ -379,9 +386,9 @@ public class AiRecipeServiceTest {
             com.cookeep.cookeep.domain.recipe.dto.GeminiRecipeResponseDto response =
                     buildValidGeminiResponse();
 
-            given(geminiService.generateRecipeWithExclusion(
+            given(geminiQueueService.generateRecipeWithExclusion(
                     anyList(),
-                    any(Difficulty.class),
+                    any(Feature.class),
                     anyList(),
                     anyList()
             )).willReturn(response);
@@ -436,7 +443,7 @@ public class AiRecipeServiceTest {
             // Rate Limit에 걸렸으므로 Gemini는 절대 호출되면 안 됨
             verify(geminiService, never()).generateRecipeWithExclusion(
                     anyList(),
-                    any(Difficulty.class),
+                    any(Feature.class),
                     anyList(),
                     anyList()
             );
@@ -481,7 +488,7 @@ public class AiRecipeServiceTest {
             // attemptNumber를 MAX_RETRY_COUNT(5) 이상으로 설정
             session = AiSession.builder()
                     .userId(1L)
-                    .difficulty(Difficulty.EASY)
+                    .feature(Feature.RICE_BOWL)
                     .attemptNumber(5) // MAX_RETRY_COUNT = 5
                     .isCompleted(false)
                     .userIngredientIds("[{\"ingredientId\":1,\"name\":\"양파\",\"quantity\":null,\"unit\":\"개\"}]")
@@ -506,7 +513,7 @@ public class AiRecipeServiceTest {
             // 유저2 세션 추가 세팅
             AiSession session2 = AiSession.builder()
                     .userId(2L)
-                    .difficulty(Difficulty.EASY)
+                    .feature(Feature.RICE_BOWL)
                     .attemptNumber(1)
                     .isCompleted(false)
                     .userIngredientIds("[{\"ingredientId\":1,\"name\":\"양파\",\"quantity\":null,\"unit\":\"개\"}]")


### PR DESCRIPTION
# Issue
#268 

# Description
AI 레시피 요청 시 사용하던 difficulty(요리 난이도) 조건을 feature(요리 종류)로 전면 교체합니다.
기존에는 EASY / NORMAL / HARD 난이도를 기준으로 레시피를 요청했으나,
요구사항 변경에 따라 국물/찌개, 밥/덮밥, 면/요리 등 요리 종류를 기준으로 레시피를 요청하도록 수정했습니다.
엔티티·DTO·서비스·프롬프트·DB 스키마·캐시 키·테스트 전 계층에 걸쳐 일관되게 변경합니다.

# Changes
### 신규 파일
- Feature.java
  - Difficulty enum을 대체하는 신규 enum 추가
  - 7가지 요리 종류 값 정의: SOUP_STEW, RICE_BOWL, NOODLE, STIR_FRY_GRILL, SALAD_HEALTHY, SNACK_DESSERT, ANY 각 값에 한글 displayName 포함 (getDisplayName())

- V5_ai_session_difficulty_to_feature.sql (Flyway Migration)
  - ai_sessions 테이블 컬럼 변경
  - feature 컬럼 신규 추가 (ENUM: 7가지 Feature 값)
  - difficulty 컬럼 삭제

- FlywayDependencyPostProcessor
  - flyway 직접 호출하여 실헹하도록 변경

### 수정 파일
- AiSession.java (Entity)
  - @Column(name = "difficulty") + Difficulty 타입 → @Column(name = "feature") + Feature 타입으로 교체

- AiRecipeRequestDto.java
  - Difficulty difficulty → Feature feature 필드 변경

- AiRecipeResponseDto.java
  - Feature feature 필드 신규 추가 — 응답에 요리 종류 포함

- AiRecipeService.java
  - generateInitialRecipe(): difficulty → feature 참조 전체 교체
  - regenerateRecipe(): session.getDifficulty() → session.getFeature() 교체
  - 에러 코드 변경
    - INVALID_DIFFICULTY → INVALID_FEATURE
    - SESSION_DIFFICULTY_NOT_FOUND → SESSION_FEATURE_NOT_FOUND
  - AiRecipeResponseDto 빌더에 .feature(session.getFeature()) 추가

- GeminiQueueService.java
  - generateRecipe(), generateRecipeWithExclusion() 파라미터 Difficulty → Feature 변경

- GeminiService.java
  - generateRecipe(), generateRecipeWithExclusion() 파라미터 Difficulty → Feature 변경
  - buildPrompt() 내 프롬프트 블록 변경
    - [난이도] difficulty.name() → [요리 종류] feature.getDisplayName()
    - Feature.ANY인 경우 "제한 없음"으로 처리

- AiRecipeCacheService.java
  - buildCacheKey() 파라미터 Difficulty → Feature 변경


# Test Checklist
- AiRecipeServiceTest 수정