### PR TITLE
COOKEEP-28 [BE] 비선호 식재료 조회/수정 API 구현

### DIFF
--- a/src/main/java/com/cookeep/cookeep/api/controller/UserInfoController.java
+++ b/src/main/java/com/cookeep/cookeep/api/controller/UserInfoController.java
@@ -178,7 +178,7 @@ public class UserInfoController {
             @ApiResponse(responseCode = "401", description = "회원 인증 실패, AccessToken이 없거나 유효하지 않음"),
             @ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음")
     })
-    @PatchMapping("/dislike-ingredients")
+    @PutMapping("/dislike-ingredients")
     public ResponseEntity<DataResponse<Void>> updateDislikedIngredients(
             @AuthenticationPrincipal UserPrincipal principal,
             @Valid @RequestBody DislikeIngredientRequestDto requestDto

--- a/src/main/java/com/cookeep/cookeep/api/controller/UserInfoController.java
+++ b/src/main/java/com/cookeep/cookeep/api/controller/UserInfoController.java
@@ -1,10 +1,7 @@
 package com.cookeep.cookeep.api.controller;
 
-import com.cookeep.cookeep.api.dto.request.NicknameUpdateRequestDto;
-import com.cookeep.cookeep.api.dto.request.UpdateEmailRequestDTO;
-import com.cookeep.cookeep.api.dto.request.UpdateMarketingPushDTO;
-import com.cookeep.cookeep.api.dto.request.UpdatePasswordRequestDTO;
-import com.cookeep.cookeep.api.dto.request.VerifyPasswordRequestDTO;
+import com.cookeep.cookeep.api.dto.request.*;
+import com.cookeep.cookeep.api.dto.response.DislikeIngredientResponseDto;
 import com.cookeep.cookeep.api.dto.response.UserProfileResponseDTO;
 import com.cookeep.cookeep.common.dto.DataResponse;
 import com.cookeep.cookeep.common.exception.ErrorCode;
@@ -156,6 +153,38 @@ public class UserInfoController {
     ) {
         Long userId = principal.userId();
         userInfoService.updateMarketingPush(userId, updateMarketingPushDTO);
+        return ResponseEntity.ok(DataResponse.ok());
+    }
+
+
+    @Operation(summary = "비선호 식재료 목록 조회", description = "현재 유저의 비선호 식재료명 목록을 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "401", description = "회원 인증 실패, AccessToken이 없거나 유효하지 않음"),
+            @ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음")
+    })
+    @GetMapping("/dislike-ingredients")
+    public ResponseEntity<DataResponse<DislikeIngredientResponseDto>> getDislikedIngredients(
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        Long userId = principal.userId();
+        return ResponseEntity.ok(DataResponse.from(userInfoService.getDislikedIngredients(userId)));
+    }
+
+    @Operation(summary = "비선호 식재료 수정", description = "현재 유저의 비선호 식재료 전체 목록을 교체합니다. 빈 배열 전달 시 전체 삭제됩니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "수정 성공"),
+            @ApiResponse(responseCode = "400", description = "요청 파라미터 오류"),
+            @ApiResponse(responseCode = "401", description = "회원 인증 실패, AccessToken이 없거나 유효하지 않음"),
+            @ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음")
+    })
+    @PatchMapping("/dislike-ingredients")
+    public ResponseEntity<DataResponse<Void>> updateDislikedIngredients(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @Valid @RequestBody DislikeIngredientRequestDto requestDto
+    ) {
+        Long userId = principal.userId();
+        userInfoService.updateDislikedIngredients(userId, requestDto);
         return ResponseEntity.ok(DataResponse.ok());
     }
 }

--- a/src/main/java/com/cookeep/cookeep/api/controller/UserInfoController.java
+++ b/src/main/java/com/cookeep/cookeep/api/controller/UserInfoController.java
@@ -157,7 +157,7 @@ public class UserInfoController {
     }
 
 
-    @Operation(summary = "비선호 식재료 목록 조회", description = "현재 유저의 비선호 식재료명 목록을 조회합니다.")
+    @Operation(summary = "비선호 식재료 목록 조회", description = "현재 유저의 비선호 식재료명 목록을 조회.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "조회 성공"),
             @ApiResponse(responseCode = "401", description = "회원 인증 실패, AccessToken이 없거나 유효하지 않음"),
@@ -171,7 +171,7 @@ public class UserInfoController {
         return ResponseEntity.ok(DataResponse.from(userInfoService.getDislikedIngredients(userId)));
     }
 
-    @Operation(summary = "비선호 식재료 수정", description = "현재 유저의 비선호 식재료 전체 목록을 교체합니다. 빈 배열 전달 시 전체 삭제됩니다.")
+    @Operation(summary = "비선호 식재료 수정", description = "현재 유저의 비선호 식재료 전체 목록을 교체. 빈 배열 전달 시 전체 삭제.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "수정 성공"),
             @ApiResponse(responseCode = "400", description = "요청 파라미터 오류"),

--- a/src/main/java/com/cookeep/cookeep/api/dto/request/DislikeIngredientRequestDto.java
+++ b/src/main/java/com/cookeep/cookeep/api/dto/request/DislikeIngredientRequestDto.java
@@ -1,0 +1,13 @@
+package com.cookeep.cookeep.api.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+import java.util.List;
+
+@Schema(description = "비선호 식재료 수정 요청 DTO")
+public record DislikeIngredientRequestDto(
+        @NotNull
+        @Schema(description = "수정할 비선호 식재료명 전체 목록 (빈 배열이면 전체 삭제)", example = "[\"상추\", \"깻잎\"]")
+        List<String> dislikedIngredients
+) { }

--- a/src/main/java/com/cookeep/cookeep/api/dto/request/DislikeIngredientRequestDto.java
+++ b/src/main/java/com/cookeep/cookeep/api/dto/request/DislikeIngredientRequestDto.java
@@ -2,12 +2,18 @@ package com.cookeep.cookeep.api.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.util.List;
 
 @Schema(description = "비선호 식재료 수정 요청 DTO")
-public record DislikeIngredientRequestDto(
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class DislikeIngredientRequestDto {
+
         @NotNull
-        @Schema(description = "수정할 비선호 식재료명 전체 목록 (빈 배열이면 전체 삭제)", example = "[\"상추\", \"깻잎\"]")
-        List<String> dislikedIngredients
-) { }
+        private List<@NotNull String> dislikedIngredients;
+}

--- a/src/main/java/com/cookeep/cookeep/api/dto/response/DislikeIngredientResponseDto.java
+++ b/src/main/java/com/cookeep/cookeep/api/dto/response/DislikeIngredientResponseDto.java
@@ -1,0 +1,18 @@
+package com.cookeep.cookeep.api.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Schema(description = "비선호 식재료 조회 응답 DTO")
+@Getter
+@Builder
+@AllArgsConstructor
+public class DislikeIngredientResponseDto {
+
+    @Schema(description = "비선호 식재료명 목록", example = "[\"상추\", \"깻잎\"]")
+    private List<String> dislikedIngredients;
+}

--- a/src/main/java/com/cookeep/cookeep/domain/user/application/UserInfoService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/user/application/UserInfoService.java
@@ -3,13 +3,8 @@ package com.cookeep.cookeep.domain.user.application;
 import java.util.Map;
 import java.util.Optional;
 
-import com.cookeep.cookeep.api.dto.request.NicknameUpdateRequestDto;
-import com.cookeep.cookeep.api.dto.request.SendCodeRequestDTO;
-import com.cookeep.cookeep.api.dto.request.UpdateEmailRequestDTO;
-import com.cookeep.cookeep.api.dto.request.UpdateMarketingPushDTO;
-import com.cookeep.cookeep.api.dto.request.UpdatePasswordRequestDTO;
-import com.cookeep.cookeep.api.dto.request.VerifyCodeRequestDTO;
-import com.cookeep.cookeep.api.dto.request.VerifyPasswordRequestDTO;
+import com.cookeep.cookeep.api.dto.request.*;
+import com.cookeep.cookeep.api.dto.response.DislikeIngredientResponseDto;
 import com.cookeep.cookeep.api.dto.response.UserProfileResponseDTO;
 import com.cookeep.cookeep.common.exception.AppException;
 import com.cookeep.cookeep.common.exception.ErrorCode;
@@ -249,4 +244,21 @@ public class UserInfoService {
 
         user.updateMarketingPush(newMarketingPush);
     }
+
+    // 유저의 비선호식재료 목록 조회
+    @Transactional(readOnly = true)
+    public DislikeIngredientResponseDto getDislikedIngredients(Long userId) {
+        User user = userReader.readById(userId);
+        return DislikeIngredientResponseDto.builder()
+                .dislikedIngredients(user.getDislikedIngredients()) // 없으면 빈 리스트 반환
+                .build();
+    }
+
+    // 유저의 비선호식재료 목록 수정
+    @Transactional
+    public void updateDislikedIngredients(Long userId, DislikeIngredientRequestDto requestDto) {
+        User user = userReader.readById(userId);
+        user.updateDislikedIngredients(requestDto.dislikedIngredients());
+    }
+
 }

--- a/src/main/java/com/cookeep/cookeep/domain/user/application/UserInfoService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/user/application/UserInfoService.java
@@ -258,7 +258,7 @@ public class UserInfoService {
     @Transactional
     public void updateDislikedIngredients(Long userId, DislikeIngredientRequestDto requestDto) {
         User user = userReader.readById(userId);
-        user.updateDislikedIngredients(requestDto.dislikedIngredients());
+        user.updateDislikedIngredients(requestDto.getDislikedIngredients());
     }
 
 }

--- a/src/main/java/com/cookeep/cookeep/domain/user/entity/User.java
+++ b/src/main/java/com/cookeep/cookeep/domain/user/entity/User.java
@@ -106,6 +106,9 @@ public class User extends BaseEntity {
 	@Column(nullable = false)
 	private boolean isCookeepsOnboarded = false; // 쿠킵스 온보딩 모달 확인 여부
 
+	private static final com.fasterxml.jackson.databind.ObjectMapper OBJECT_MAPPER
+			= new com.fasterxml.jackson.databind.ObjectMapper();
+
 	@Column(name = "disliked_ingredients", columnDefinition = "JSON")
 	private String dislikedIngredientsJson; // 못먹는 재료 목록 (JSON 배열로 저장)
 
@@ -190,7 +193,7 @@ public class User extends BaseEntity {
 			return Collections.emptyList();
 		}
 		try {
-			return new com.fasterxml.jackson.databind.ObjectMapper()
+			return OBJECT_MAPPER
 					.readValue(dislikedIngredientsJson, new com.fasterxml.jackson.core.type.TypeReference<List<String>>() {});
 		} catch (Exception e) {
 			return Collections.emptyList();
@@ -202,7 +205,7 @@ public class User extends BaseEntity {
 		try {
 			this.dislikedIngredientsJson = ingredients == null || ingredients.isEmpty()
 					? null
-					: new com.fasterxml.jackson.databind.ObjectMapper().writeValueAsString(ingredients);
+					: OBJECT_MAPPER.writeValueAsString(ingredients);
 		} catch (Exception e) {
 			this.dislikedIngredientsJson = null;
 		}


### PR DESCRIPTION
# Issue
#270 

# Description
비선호 식재료 조회 및 수정 API를 추가합니다.
기존 온보딩 단계에서만 등록 가능했던 비선호 식재료를 마이페이지 등에서도 조회하고 수정할 수 있도록 엔드포인트를 구현합니다.
Jira: COOKEEP-28

# Changes
### 신규 파일
- DislikeIngredientRequestDto — 비선호 식재료 수정 요청 DTO
- DislikeIngredientResponseDto — 비선호 식재료 조회 응답 DTO

### 수정 파일
- UserInfoController — 비선호 식재료 조회(GET), 수정(PATCH) 엔드포인트 추가
- UserInfoService — getDislikedIngredients(), updateDislikedIngredients() 메서드 추가

### API
- GET /api/users/me/dislike-ingredients — 현재 유저의 비선호 식재료 목록 반환
  - API 명세서: https://www.notion.so/37a3f76f8724809181ddedc8b471589b
- PATCH /api/users/me/dislike-ingredients — 비선호 식재료 전체 목록 교체 (빈 배열 시 전체 삭제)
  - API 명세서: https://www.notion.so/37a3f76f872480e59742e9191b957b27

# Test Checklist
- [x] GET /api/users/me/dislike-ingredients — 비선호 식재료가 있는 유저 조회 시 목록 정상 반환
- [x] GET /api/users/me/dislike-ingredients — 비선호 식재료가 없는 유저 조회 시 빈 배열 반환
- [x] PATCH /api/users/me/dislike-ingredients — 식재료 목록 수정 후 변경된 값으로 저장
- [x] PATCH /api/users/me/dislike-ingredients — 빈 배열 전달 시 기존 비선호 식재료 전체 삭제
- [x] 인증 토큰 없이 요청 시 401 반환
- [x] 존재하지 않는 유저로 요청 시 404 반환