### PR TITLE
hotfix: deploy.yml 트리거를 develop → main으로 변경

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: CI/CD Pipeline
 
 on:
   push:
-    branches: [ develop ]
+    branches: [ main ]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
# Description
개발용 브랜치/운영용 브랜치 분리를 위해 `deploy.yml` 트리거를 `main` 브랜치로 수정했습니다.
리뷰 없이 병합하겠습니다!