### PR TITLE
COOKEEP-40 refactor: 쿠키 보상 응답 구조 통일 (CookieRewardDto 도입)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: CI/CD Pipeline
 
 on:
   push:
-    branches: [ develop ]
+    branches: [ main ]
   workflow_dispatch:
 
 jobs:

--- a/src/main/java/com/cookeep/cookeep/api/controller/DailyRecipeController.java
+++ b/src/main/java/com/cookeep/cookeep/api/controller/DailyRecipeController.java
@@ -124,7 +124,7 @@ public class DailyRecipeController {
         );
 
         return ResponseEntity.status(201)
-                .body(DataResponse.created(DailyRecipeCreateResponseDto.from(result.dailyRecipe(), result.weeklyGoalAchieved(), result.photoCookieAwarded())));
+                .body(DataResponse.created(DailyRecipeCreateResponseDto.from(result.dailyRecipe(), result.reward())));
     }
 
     @Operation(
@@ -178,7 +178,7 @@ public class DailyRecipeController {
                 request.getRecipeImageUrl(), request.getDeleteRecipeImage()
         );
 
-        return ResponseEntity.ok(DataResponse.from(DailyRecipeUpdateResponseDto.from(result.dailyRecipe(), result.weeklyGoalAchieved(), result.photoCookieAwarded())));
+        return ResponseEntity.ok(DataResponse.from(DailyRecipeUpdateResponseDto.from(result.dailyRecipe(), result.reward())));
     }
 
     @Operation(

--- a/src/main/java/com/cookeep/cookeep/api/controller/PendingCookieRewardController.java
+++ b/src/main/java/com/cookeep/cookeep/api/controller/PendingCookieRewardController.java
@@ -1,5 +1,7 @@
 package com.cookeep.cookeep.api.controller;
 
+import com.cookeep.cookeep.api.dto.response.ClaimPendingRewardResponseDto;
+import com.cookeep.cookeep.api.dto.response.CookieRewardDto;
 import com.cookeep.cookeep.common.dto.DataResponse;
 import com.cookeep.cookeep.domain.cookie.application.CookieService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -30,10 +32,10 @@ public class PendingCookieRewardController {
             @ApiResponse(responseCode = "404", description = "존재하지 않는 보상")
     })
     @PostMapping("/pending/{pendingRewardId}/claim")
-    public ResponseEntity<DataResponse<Integer>> claimPendingReward(
+    public ResponseEntity<DataResponse<ClaimPendingRewardResponseDto>> claimPendingReward(
             @AuthenticationPrincipal(expression = "userId") Long userId,
             @PathVariable Long pendingRewardId) {
-        int cookieCnt = cookieService.claimPendingReward(userId, pendingRewardId);
-        return ResponseEntity.ok(DataResponse.from(cookieCnt));
+        CookieRewardDto reward = cookieService.claimPendingReward(userId, pendingRewardId);
+        return ResponseEntity.ok(DataResponse.from(ClaimPendingRewardResponseDto.from(reward)));
     }
 }

--- a/src/main/java/com/cookeep/cookeep/api/controller/RecipeLikeController.java
+++ b/src/main/java/com/cookeep/cookeep/api/controller/RecipeLikeController.java
@@ -56,7 +56,7 @@ public class RecipeLikeController {
 			dailyRecipeId,
 			result.isLiked(),
 			(int) likeCount,
-			result.weeklyGoalAchieved()
+			result.reward()
 		);
 
 		return ResponseEntity.ok(DataResponse.from(response));

--- a/src/main/java/com/cookeep/cookeep/api/dto/response/AiRecipeAdoptResponseDto.java
+++ b/src/main/java/com/cookeep/cookeep/api/dto/response/AiRecipeAdoptResponseDto.java
@@ -1,12 +1,10 @@
 package com.cookeep.cookeep.api.dto.response;
 
-import com.cookeep.cookeep.domain.cookie.entity.CookieLog;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
-import java.util.List;
 
 @Schema(
         name = "AiRecipeAdoptResponse",
@@ -46,39 +44,6 @@ public class AiRecipeAdoptResponseDto {
     )
     private LocalDateTime completedAt;
 
-    @Schema(
-            description = "이번 채택으로 주간 목표 달성 여부 (COOKING / USE_EXPIRING_INGREDIENT)",
-            example = "false"
-    )
-    private boolean weeklyGoalAchieved;
-
-    @Schema(
-            description = "첫 레시피 채택 쿠키 지급 여부",
-            example = "true"
-    )
-    private boolean recipeRewardGranted;
-
-    @Schema(
-            description = "임박 재료 사용 쿠키 지급 여부 (BONUS_URGENT_INGREDIENT_USE)",
-            example = "true"
-    )
-    private boolean urgentIngredientRewardGranted;
-
     @Schema(description = "이번 채택으로 지급된 리워드 정보")
-    private RewardInfo reward;
-
-    @Getter
-    @Builder
-    public static class RewardInfo {
-        @Schema(description = "리워드 지급 여부", example = "true")
-        private Boolean granted;
-
-        @Schema(description = "지급된 총 쿠키 포인트", example = "4")
-        private Integer points;
-
-        @Schema(description = "지급된 쿠키 로그 타입 목록",
-                example = "[\"ONBOARDING_RECIPE\", \"BONUS_WEEKLY_GOAL_ACHIEVE\", \"BONUS_URGENT_INGREDIENT_USE\"]")
-        private List<CookieLog.CookieLogType> grantedTypes;
-    }
-
+    private CookieRewardDto reward;
 }

--- a/src/main/java/com/cookeep/cookeep/api/dto/response/ClaimPendingRewardResponseDto.java
+++ b/src/main/java/com/cookeep/cookeep/api/dto/response/ClaimPendingRewardResponseDto.java
@@ -1,0 +1,18 @@
+package com.cookeep.cookeep.api.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Schema(name = "ClaimPendingRewardResponse", description = "대기 중인 쿠키 보상 수령 응답 DTO")
+@Getter
+@Builder
+public class ClaimPendingRewardResponseDto {
+
+    @Schema(description = "지급된 리워드 정보")
+    private CookieRewardDto reward;
+
+    public static ClaimPendingRewardResponseDto from(CookieRewardDto reward) {
+        return ClaimPendingRewardResponseDto.builder().reward(reward).build();
+    }
+}

--- a/src/main/java/com/cookeep/cookeep/api/dto/response/ConsumeIngredientsResponseDto.java
+++ b/src/main/java/com/cookeep/cookeep/api/dto/response/ConsumeIngredientsResponseDto.java
@@ -21,54 +21,20 @@ public class ConsumeIngredientsResponseDto {
             description = "리워드 정보",
             requiredMode = Schema.RequiredMode.REQUIRED
     )
-    private RewardInfo reward;
-
-    @Schema(description = "오늘 첫 소비 쿠키(BASIC_DAILY_FIRST_CONSUME) 지급 여부", example = "true")
-    private boolean dailyFirstConsumeAchieved;
-
-    @Schema(description = "이번 소비로 주간 목표(COOKING) 달성 여부", example = "false")
-    private boolean weeklyGoalAchieved;
-
-    @Getter
-    @Builder
-    @AllArgsConstructor
-    public static class RewardInfo {
-        @Schema(
-                description = "리워드 지급 여부",
-                example = "true",
-                requiredMode = Schema.RequiredMode.REQUIRED
-        )
-        private Boolean granted;
-
-        @Schema(
-                description = "지급된 리워드 포인트",
-                example = "3",
-                requiredMode = Schema.RequiredMode.REQUIRED
-        )
-        private Integer points;
-
-        @Schema(
-                description = "지급된 쿠키 로그 타입 목록",
-                example = "[\"BASIC_DAILY_FIRST_CONSUME\", \"BONUS_URGENT_INGREDIENT_USE\"]",
-                requiredMode = Schema.RequiredMode.NOT_REQUIRED
-        )
-        private List<CookieLog.CookieLogType> grantedTypes;
-    }
+    private CookieRewardDto reward;
 
     public static ConsumeIngredientsResponseDto of(
             boolean granted,
             int points,
-            List<CookieLog.CookieLogType> grantedTypes,
-            boolean dailyFirstConsumeAchieved,
-            boolean weeklyGoalAchieved) {
+            List<CookieLog.CookieLogType> types,
+            int currentCookieCount) {
         return ConsumeIngredientsResponseDto.builder()
-                .reward(RewardInfo.builder()
+                .reward(CookieRewardDto.builder()
                         .granted(granted)
                         .points(points)
-                        .grantedTypes(grantedTypes)
+                        .types(types)
+                        .currentCookieCount(currentCookieCount)
                         .build())
-                .dailyFirstConsumeAchieved(dailyFirstConsumeAchieved)
-                .weeklyGoalAchieved(weeklyGoalAchieved)
                 .build();
     }
 }

--- a/src/main/java/com/cookeep/cookeep/api/dto/response/CookieRewardDto.java
+++ b/src/main/java/com/cookeep/cookeep/api/dto/response/CookieRewardDto.java
@@ -1,0 +1,22 @@
+package com.cookeep.cookeep.api.dto.response;
+
+import com.cookeep.cookeep.domain.cookie.entity.CookieLog;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Schema(name = "CookieReward", description = "쿠키 리워드 결과")
+@Getter
+@Builder
+public class CookieRewardDto {
+
+    private Boolean granted;
+
+    private Integer points;
+
+    private List<CookieLog.CookieLogType> types;
+
+    private Integer currentCookieCount;
+}

--- a/src/main/java/com/cookeep/cookeep/api/dto/response/DailyRecipeCreateResponseDto.java
+++ b/src/main/java/com/cookeep/cookeep/api/dto/response/DailyRecipeCreateResponseDto.java
@@ -27,20 +27,16 @@ public class DailyRecipeCreateResponseDto {
     @Schema(description = "등록 시각", example = "2026-02-07T14:30:00")
     private LocalDateTime createdAt;
 
-    @Schema(description = "이번 액션으로 주간 목표 달성 여부", example = "false")
-    private boolean weeklyGoalAchieved;
+    @Schema(description = "이번 등록으로 지급된 리워드 정보")
+    private CookieRewardDto reward;
 
-    @Schema(description = "사진 업로드 보상 쿠키 지급 여부", example = "true")
-    private boolean photoCookieAwarded;
-
-    public static DailyRecipeCreateResponseDto from(DailyRecipe dailyRecipe, boolean weeklyGoalAchieved, boolean photoCookieAwarded) {
+    public static DailyRecipeCreateResponseDto from(DailyRecipe dailyRecipe, CookieRewardDto reward) {
         return DailyRecipeCreateResponseDto.builder()
                 .dailyRecipeId(dailyRecipe.getId())
                 .title(dailyRecipe.getTitle())
                 .message("새로운 데일리 레시피가 등록되었습니다.")
                 .createdAt(dailyRecipe.getCreatedAt())
-                .weeklyGoalAchieved(weeklyGoalAchieved)
-                .photoCookieAwarded(photoCookieAwarded)
+                .reward(reward)
                 .build();
     }
 }

--- a/src/main/java/com/cookeep/cookeep/api/dto/response/DailyRecipeUpdateResponseDto.java
+++ b/src/main/java/com/cookeep/cookeep/api/dto/response/DailyRecipeUpdateResponseDto.java
@@ -41,13 +41,10 @@ public class DailyRecipeUpdateResponseDto {
     @Schema(description = "등록 시각", example = "2026-02-07T14:30:00")
     private LocalDateTime createdAt;
 
-    @Schema(description = "이번 수정으로 주간 목표 달성 여부", example = "false")
-    private boolean weeklyGoalAchieved;
+    @Schema(description = "이번 수정으로 지급된 리워드 정보")
+    private CookieRewardDto reward;
 
-    @Schema(description = "이번 수정으로 사진 업로드 보상 쿠키 지급 여부", example = "true")
-    private boolean photoCookieAwarded;
-
-    public static DailyRecipeUpdateResponseDto from(DailyRecipe dailyRecipe, boolean weeklyGoalAchieved, boolean photoCookieAwarded) {
+    public static DailyRecipeUpdateResponseDto from(DailyRecipe dailyRecipe, CookieRewardDto reward) {
         return DailyRecipeUpdateResponseDto.builder()
                 .dailyRecipeId(dailyRecipe.getId())
                 .title(dailyRecipe.getTitle())
@@ -57,8 +54,7 @@ public class DailyRecipeUpdateResponseDto {
                 .isPublic(dailyRecipe.getIsPublic())
                 .aiRecipeId(dailyRecipe.getAiRecipe() != null ? dailyRecipe.getAiRecipe().getId() : null)
                 .createdAt(dailyRecipe.getCreatedAt())
-                .weeklyGoalAchieved(weeklyGoalAchieved)
-                .photoCookieAwarded(photoCookieAwarded)
+                .reward(reward)
                 .build();
     }
 }

--- a/src/main/java/com/cookeep/cookeep/api/dto/response/RecipeLikeResponseDto.java
+++ b/src/main/java/com/cookeep/cookeep/api/dto/response/RecipeLikeResponseDto.java
@@ -1,14 +1,20 @@
 package com.cookeep.cookeep.api.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 
+@Schema(name = "RecipeLikeResponse", description = "레시피 좋아요 토글 응답 DTO")
 @Getter
 @Builder
 public class RecipeLikeResponseDto {
+	@Schema(description = "데일리 레시피 ID")
 	private Long dailyRecipeId;
+	@Schema(description = "좋아요 여부")
 	private boolean isLiked;
+	@Schema(description = "현재 좋아요 수")
 	private Integer likeCount;
+	@Schema(description = "쿠키 리워드 정보 (좋아요 취소 시 null)")
 	private CookieRewardDto reward;
 
 	public static RecipeLikeResponseDto from(Long dailyRecipeId, boolean isLiked, Integer likeCount) {

--- a/src/main/java/com/cookeep/cookeep/api/dto/response/RecipeLikeResponseDto.java
+++ b/src/main/java/com/cookeep/cookeep/api/dto/response/RecipeLikeResponseDto.java
@@ -7,20 +7,24 @@ import lombok.Getter;
 @Builder
 public class RecipeLikeResponseDto {
 	private Long dailyRecipeId;
-	private boolean isLiked; // true: 좋아요 추가, false: 좋아요 취소
-	private Integer likeCount; // 현재 좋아요 수
-	private boolean weeklyGoalAchieved; // 이번 액션으로 주간 목표 달성 여부
+	private boolean isLiked;
+	private Integer likeCount;
+	private CookieRewardDto reward;
 
 	public static RecipeLikeResponseDto from(Long dailyRecipeId, boolean isLiked, Integer likeCount) {
-		return from(dailyRecipeId, isLiked, likeCount, false);
-	}
-
-	public static RecipeLikeResponseDto from(Long dailyRecipeId, boolean isLiked, Integer likeCount, boolean weeklyGoalAchieved) {
 		return RecipeLikeResponseDto.builder()
 			.dailyRecipeId(dailyRecipeId)
 			.isLiked(isLiked)
 			.likeCount(likeCount)
-			.weeklyGoalAchieved(weeklyGoalAchieved)
+			.build();
+	}
+
+	public static RecipeLikeResponseDto from(Long dailyRecipeId, boolean isLiked, Integer likeCount, CookieRewardDto reward) {
+		return RecipeLikeResponseDto.builder()
+			.dailyRecipeId(dailyRecipeId)
+			.isLiked(isLiked)
+			.likeCount(likeCount)
+			.reward(reward)
 			.build();
 	}
 }

--- a/src/main/java/com/cookeep/cookeep/api/dto/response/UserIngredientListCreateResponseDto.java
+++ b/src/main/java/com/cookeep/cookeep/api/dto/response/UserIngredientListCreateResponseDto.java
@@ -3,7 +3,6 @@ package com.cookeep.cookeep.api.dto.response;
 import com.cookeep.cookeep.domain.cookie.entity.CookieLog;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
 
 import java.util.List;
@@ -19,46 +18,25 @@ public class UserIngredientListCreateResponseDto {
     @Schema(description = "등록된 식재료 수", example = "4")
     private int count;
 
-    @Schema(description = "온보딩 쿠키 지급 여부", example = "true")
-    private boolean ingredientRewardGranted;
-
     @Schema(description = "이번 등록으로 지급된 리워드 정보")
-    private RewardInfo reward;
-
-    @Getter
-    @Builder
-    @AllArgsConstructor
-    public static class RewardInfo {
-        @Schema(description = "리워드 지급 여부", example = "true")
-        private Boolean granted;
-
-        @Schema(description = "지급된 총 쿠키 포인트", example = "1")
-        private Integer points;
-
-        @Schema(description = "지급된 쿠키 로그 타입 목록", example = "[\"ONBOARDING_INGREDIENT\"]")
-        private List<CookieLog.CookieLogType> grantedTypes;
-    }
+    private CookieRewardDto reward;
 
     public static UserIngredientListCreateResponseDto of(
             List<UserIngredientCreateResponseDto> ingredients,
-            boolean ingredientRewardGranted) {
+            boolean ingredientRewardGranted,
+            int currentCookieCount) {
 
-        List<CookieLog.CookieLogType> grantedTypes = ingredientRewardGranted
+        List<CookieLog.CookieLogType> types = ingredientRewardGranted
                 ? List.of(CookieLog.CookieLogType.ONBOARDING_INGREDIENT)
                 : List.of();
 
-        RewardInfo rewardInfo = RewardInfo.builder()
+        CookieRewardDto reward = CookieRewardDto.builder()
                 .granted(ingredientRewardGranted)
                 .points(ingredientRewardGranted ? CookieLog.CookieLogType.ONBOARDING_INGREDIENT.getDefaultAmount() : 0)
-                .grantedTypes(grantedTypes)
+                .types(types)
+                .currentCookieCount(currentCookieCount)
                 .build();
 
-        return new UserIngredientListCreateResponseDto(
-                ingredients,
-                ingredients.size(),
-                ingredientRewardGranted,
-                rewardInfo
-        );
+        return new UserIngredientListCreateResponseDto(ingredients, ingredients.size(), reward);
     }
-
 }

--- a/src/main/java/com/cookeep/cookeep/domain/cookie/application/CookieService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/cookie/application/CookieService.java
@@ -1,5 +1,6 @@
 package com.cookeep.cookeep.domain.cookie.application;
 
+import com.cookeep.cookeep.api.dto.response.CookieRewardDto;
 import com.cookeep.cookeep.common.exception.AppException;
 import com.cookeep.cookeep.common.exception.ErrorCode;
 import com.cookeep.cookeep.domain.cookie.dao.CookieLogRepository;
@@ -16,6 +17,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.util.List;
 
 @Slf4j
 @Service
@@ -111,9 +113,9 @@ public class CookieService {
         );
     }
 
-    // 대기 중인 보상 쿠키 수령 후 최종 쿠키 개수 반환
+    // 대기 중인 보상 쿠키 수령
     @Transactional
-    public int claimPendingReward(Long userId, Long pendingRewardId) {
+    public CookieRewardDto claimPendingReward(Long userId, Long pendingRewardId) {
         PendingCookieReward pending = pendingCookieRewardRepository
                 .findByIdForUpdate(pendingRewardId)
                 .orElseThrow(() -> new AppException(ErrorCode.PENDING_REWARD_NOT_FOUND));
@@ -122,10 +124,15 @@ public class CookieService {
             throw new AppException(ErrorCode.PENDING_REWARD_FORBIDDEN);
         }
 
-        pending.claim(); // 엔티티에서 CLAIMED 상태 검증 및 플래그 변경
+        CookieLog.CookieLogType rewardType = pending.getRewardType();
+        pending.claim();
+        updateCookie(userId, rewardType);
 
-        updateCookie(userId, pending.getRewardType()); // 실제 쿠키 지급
-
-        return getMyCookies(userId); // 지급 후 최종 쿠키 개수 반환
+        return CookieRewardDto.builder()
+                .granted(true)
+                .points(rewardType.getDefaultAmount())
+                .types(List.of(rewardType))
+                .currentCookieCount(getMyCookies(userId))
+                .build();
     }
 }

--- a/src/main/java/com/cookeep/cookeep/domain/dailyrecipe/application/DailyRecipeService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/dailyrecipe/application/DailyRecipeService.java
@@ -1,5 +1,6 @@
 package com.cookeep.cookeep.domain.dailyrecipe.application;
 
+import com.cookeep.cookeep.api.dto.response.CookieRewardDto;
 import com.cookeep.cookeep.api.dto.response.DailyRecipeCalendarResponseDto;
 import com.cookeep.cookeep.common.exception.AppException;
 import com.cookeep.cookeep.common.exception.ErrorCode;
@@ -26,6 +27,7 @@ import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.temporal.TemporalAdjusters;
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -44,7 +46,7 @@ public class DailyRecipeService {
     private final ObjectMapper objectMapper;
     private final S3Service s3Service;
 
-    public record DailyRecipeResult(DailyRecipe dailyRecipe, boolean weeklyGoalAchieved, boolean photoCookieAwarded) {}
+    public record DailyRecipeResult(DailyRecipe dailyRecipe, CookieRewardDto reward) {}
 
     // 채택된 AI 레시피 목록 조회
     @Transactional(readOnly = true)
@@ -103,7 +105,19 @@ public class DailyRecipeService {
             goalAchieved = weeklyGoalService.handleGoalProgress(userId, GoalActionType.PHOTO_RECORD);
         }
 
-        return new DailyRecipeResult(dailyRecipe, goalAchieved, hasPhoto);
+        List<CookieLog.CookieLogType> rewardTypes = new ArrayList<>();
+        rewardTypes.add(CookieLog.CookieLogType.BASIC_LOAD_RECIPE);
+        if (hasPhoto) rewardTypes.add(CookieLog.CookieLogType.BASIC_FOOD_PHOTO_REG);
+        if (goalAchieved) rewardTypes.add(CookieLog.CookieLogType.BONUS_WEEKLY_GOAL_ACHIEVE);
+        int totalPoints = rewardTypes.stream().mapToInt(CookieLog.CookieLogType::getDefaultAmount).sum();
+        CookieRewardDto reward = CookieRewardDto.builder()
+                .granted(true)
+                .points(totalPoints)
+                .types(rewardTypes)
+                .currentCookieCount(cookieService.getMyCookies(userId))
+                .build();
+
+        return new DailyRecipeResult(dailyRecipe, reward);
     }
 
     // 데일리 레시피 상세 조회
@@ -165,7 +179,18 @@ public class DailyRecipeService {
             }
         }
 
-        return new DailyRecipeResult(dailyRecipe, goalAchieved, photoCookieAwarded);
+        List<CookieLog.CookieLogType> rewardTypes = new ArrayList<>();
+        if (photoCookieAwarded) rewardTypes.add(CookieLog.CookieLogType.BASIC_FOOD_PHOTO_REG);
+        if (goalAchieved) rewardTypes.add(CookieLog.CookieLogType.BONUS_WEEKLY_GOAL_ACHIEVE);
+        int totalPoints = rewardTypes.stream().mapToInt(CookieLog.CookieLogType::getDefaultAmount).sum();
+        CookieRewardDto reward = CookieRewardDto.builder()
+                .granted(!rewardTypes.isEmpty())
+                .points(totalPoints)
+                .types(rewardTypes)
+                .currentCookieCount(cookieService.getMyCookies(userId))
+                .build();
+
+        return new DailyRecipeResult(dailyRecipe, reward);
     }
 
     // 데일리 레시피 공개 범위 수정

--- a/src/main/java/com/cookeep/cookeep/domain/dailyrecipe/application/RecipeLikeService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/dailyrecipe/application/RecipeLikeService.java
@@ -67,10 +67,11 @@ public class RecipeLikeService {
 	}
 
 	private CookieRewardDto createWeeklyGoalReward(boolean goalAchieved, Long userId) {
-		List<CookieLog.CookieLogType> types = goalAchieved
-				? List.of(CookieLog.CookieLogType.BONUS_WEEKLY_GOAL_ACHIEVE) : List.of();
-		int points = goalAchieved
-				? CookieLog.CookieLogType.BONUS_WEEKLY_GOAL_ACHIEVE.getDefaultAmount() : 0;
+		var weeklyGoalType = CookieLog.CookieLogType.BONUS_WEEKLY_GOAL_ACHIEVE;
+
+		List<CookieLog.CookieLogType> types = goalAchieved ? List.of(weeklyGoalType) : List.of();
+		int points = goalAchieved ? weeklyGoalType.getDefaultAmount() : 0;
+
 		return CookieRewardDto.builder()
 				.granted(goalAchieved)
 				.points(points)

--- a/src/main/java/com/cookeep/cookeep/domain/dailyrecipe/application/RecipeLikeService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/dailyrecipe/application/RecipeLikeService.java
@@ -41,37 +41,42 @@ public class RecipeLikeService {
 		DailyRecipe dailyRecipe = dailyRecipeRepository.findById(dailyRecipeId)
 			.orElseThrow(() -> new AppException(ErrorCode.DAILY_RECIPE_NOT_FOUND));
 
-		// 자신의 글에 좋아요 불가
 		if (dailyRecipe.getUser().getUserId().equals(userId)) {
 			throw new AppException(ErrorCode.CANNOT_LIKE_OWN_RECIPE);
 		}
 
 		var existingLike = recipeLikeRepository.findByDailyRecipeAndUser(dailyRecipe, user);
 
-		// 이미 좋아요를 눌렀으면 삭제
-		if (existingLike.isPresent()) {
-			recipeLikeRepository.delete(existingLike.get());
-			dailyRecipe.decrementLikeCount();
-			weeklyGoalService.handleGoalUndo(userId, GoalActionType.RECIPE_LIKE);
-			return new ToggleLikeResult(false, null);
-		}
+		return existingLike.isPresent()
+			? cancelLike(existingLike.get(), dailyRecipe, userId)
+			: addLike(user, dailyRecipe, userId);
+	}
 
-		// 좋아요 추가
-		RecipeLike recipeLike = RecipeLike.builder()
-			.dailyRecipe(dailyRecipe)
-			.user(user)
-			.build();
-		recipeLikeRepository.save(recipeLike);
+	private ToggleLikeResult cancelLike(RecipeLike existingLike, DailyRecipe dailyRecipe, Long userId) {
+		recipeLikeRepository.delete(existingLike);
+		dailyRecipe.decrementLikeCount();
+		weeklyGoalService.handleGoalUndo(userId, GoalActionType.RECIPE_LIKE);
+		return new ToggleLikeResult(false, null);
+	}
+
+	private ToggleLikeResult addLike(User user, DailyRecipe dailyRecipe, Long userId) {
+		recipeLikeRepository.save(RecipeLike.builder().dailyRecipe(dailyRecipe).user(user).build());
 		dailyRecipe.incrementLikeCount();
 		boolean goalAchieved = weeklyGoalService.handleGoalProgress(userId, GoalActionType.RECIPE_LIKE);
+		return new ToggleLikeResult(true, createWeeklyGoalReward(goalAchieved, userId));
+	}
+
+	private CookieRewardDto createWeeklyGoalReward(boolean goalAchieved, Long userId) {
 		List<CookieLog.CookieLogType> types = goalAchieved
 				? List.of(CookieLog.CookieLogType.BONUS_WEEKLY_GOAL_ACHIEVE) : List.of();
-		int points = goalAchieved ? CookieLog.CookieLogType.BONUS_WEEKLY_GOAL_ACHIEVE.getDefaultAmount() : 0;
-		CookieRewardDto reward = CookieRewardDto.builder()
-				.granted(goalAchieved).points(points).types(types)
+		int points = goalAchieved
+				? CookieLog.CookieLogType.BONUS_WEEKLY_GOAL_ACHIEVE.getDefaultAmount() : 0;
+		return CookieRewardDto.builder()
+				.granted(goalAchieved)
+				.points(points)
+				.types(types)
 				.currentCookieCount(cookieService.getMyCookies(userId))
 				.build();
-		return new ToggleLikeResult(true, reward);
 	}
 
 	// 특정 레시피의 좋아요 수 조회

--- a/src/main/java/com/cookeep/cookeep/domain/dailyrecipe/application/RecipeLikeService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/dailyrecipe/application/RecipeLikeService.java
@@ -1,8 +1,11 @@
 package com.cookeep.cookeep.domain.dailyrecipe.application;
 
 import com.cookeep.cookeep.api.dto.response.CookeepsFeedResponseDto;
+import com.cookeep.cookeep.api.dto.response.CookieRewardDto;
 import com.cookeep.cookeep.common.exception.AppException;
 import com.cookeep.cookeep.common.exception.ErrorCode;
+import com.cookeep.cookeep.domain.cookie.application.CookieService;
+import com.cookeep.cookeep.domain.cookie.entity.CookieLog;
 import com.cookeep.cookeep.domain.dailyrecipe.dao.DailyRecipeRepository;
 import com.cookeep.cookeep.domain.dailyrecipe.dao.RecipeLikeRepository;
 import com.cookeep.cookeep.domain.dailyrecipe.entity.DailyRecipe;
@@ -11,6 +14,8 @@ import com.cookeep.cookeep.domain.onboarding.application.WeeklyGoalService;
 import com.cookeep.cookeep.domain.onboarding.entity.GoalActionType;
 import com.cookeep.cookeep.domain.user.application.UserReader;
 import com.cookeep.cookeep.domain.user.entity.User;
+
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -26,8 +31,9 @@ public class RecipeLikeService {
 	private final DailyRecipeRepository dailyRecipeRepository;
 	private final UserReader userReader;
 	private final WeeklyGoalService weeklyGoalService;
+	private final CookieService cookieService;
 
-	public record ToggleLikeResult(boolean isLiked, boolean weeklyGoalAchieved) {}
+	public record ToggleLikeResult(boolean isLiked, CookieRewardDto reward) {}
 
 	// 좋아요 추가/삭제 토글
 	public ToggleLikeResult toggleLike(Long userId, Long dailyRecipeId) {
@@ -47,7 +53,7 @@ public class RecipeLikeService {
 			recipeLikeRepository.delete(existingLike.get());
 			dailyRecipe.decrementLikeCount();
 			weeklyGoalService.handleGoalUndo(userId, GoalActionType.RECIPE_LIKE);
-			return new ToggleLikeResult(false, false); // 좋아요 취소
+			return new ToggleLikeResult(false, null);
 		}
 
 		// 좋아요 추가
@@ -58,7 +64,14 @@ public class RecipeLikeService {
 		recipeLikeRepository.save(recipeLike);
 		dailyRecipe.incrementLikeCount();
 		boolean goalAchieved = weeklyGoalService.handleGoalProgress(userId, GoalActionType.RECIPE_LIKE);
-		return new ToggleLikeResult(true, goalAchieved); // 좋아요 추가
+		List<CookieLog.CookieLogType> types = goalAchieved
+				? List.of(CookieLog.CookieLogType.BONUS_WEEKLY_GOAL_ACHIEVE) : List.of();
+		int points = goalAchieved ? CookieLog.CookieLogType.BONUS_WEEKLY_GOAL_ACHIEVE.getDefaultAmount() : 0;
+		CookieRewardDto reward = CookieRewardDto.builder()
+				.granted(goalAchieved).points(points).types(types)
+				.currentCookieCount(cookieService.getMyCookies(userId))
+				.build();
+		return new ToggleLikeResult(true, reward);
 	}
 
 	// 특정 레시피의 좋아요 수 조회

--- a/src/main/java/com/cookeep/cookeep/domain/ingredient/useringredient/application/ConsumeIngredientService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/ingredient/useringredient/application/ConsumeIngredientService.java
@@ -97,8 +97,8 @@ public class ConsumeIngredientService {
         log.info("User {} consumed {} ingredients. dailyGranted: {}, urgentCount: {}, weeklyGoalAchieved: {}",
                 userId, userIngredients.size(), dailyGranted, urgentCount, weeklyGoalAchieved);
 
-        return ConsumeIngredientsResponseDto.of(
-                !grantedTypes.isEmpty(), points, grantedTypes, dailyGranted, weeklyGoalAchieved);
+        int currentCookieCount = cookieService.getMyCookies(userId);
+        return ConsumeIngredientsResponseDto.of(!grantedTypes.isEmpty(), points, grantedTypes, currentCookieCount);
 
     }
 

--- a/src/main/java/com/cookeep/cookeep/domain/ingredient/useringredient/application/UserIngredientServiceImpl.java
+++ b/src/main/java/com/cookeep/cookeep/domain/ingredient/useringredient/application/UserIngredientServiceImpl.java
@@ -97,8 +97,9 @@ public class UserIngredientServiceImpl implements UserIngredientService {
 
         // 최초 재료 등록 온보딩 쿠키 지급 (일회성)
         boolean rewardGranted = grantFirstIngredientRewardIfEligible(user);
+        int currentCookieCount = cookieService.getMyCookies(userId);
 
-        return UserIngredientListCreateResponseDto.of(results, rewardGranted);
+        return UserIngredientListCreateResponseDto.of(results, rewardGranted, currentCookieCount);
     }
 
     private UserIngredientCreateResponseDto createOne(

--- a/src/main/java/com/cookeep/cookeep/domain/recipe/application/AiRecipeService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/recipe/application/AiRecipeService.java
@@ -291,7 +291,7 @@ public class AiRecipeService {
         // 10. COOKING / USE_EXPIRING_INGREDIENT 중 하나라도 달성되면 weeklyGoalAchieved = true
         boolean weeklyGoalAchieved = cookingGoalAchieved || expiringGoalAchieved;
 
-        // 11. RewardInfo 빌드
+        // 11. CookieRewardDto 빌드
         List<CookieLog.CookieLogType> grantedTypes = new java.util.ArrayList<>();
         int totalPoints = 0;
         if (rewardGranted) {
@@ -302,20 +302,23 @@ public class AiRecipeService {
             grantedTypes.add(CookieLog.CookieLogType.BONUS_URGENT_INGREDIENT_USE);
             totalPoints += CookieLog.CookieLogType.BONUS_URGENT_INGREDIENT_USE.getDefaultAmount();
         }
-        AiRecipeAdoptResponseDto.RewardInfo rewardInfo = AiRecipeAdoptResponseDto.RewardInfo.builder()
-                .granted(!grantedTypes.isEmpty())
-                .points(totalPoints)
-                .grantedTypes(grantedTypes)
-                .build();
+        if (weeklyGoalAchieved) {
+            grantedTypes.add(CookieLog.CookieLogType.BONUS_WEEKLY_GOAL_ACHIEVE);
+            totalPoints += CookieLog.CookieLogType.BONUS_WEEKLY_GOAL_ACHIEVE.getDefaultAmount();
+        }
+        com.cookeep.cookeep.api.dto.response.CookieRewardDto rewardInfo =
+                com.cookeep.cookeep.api.dto.response.CookieRewardDto.builder()
+                        .granted(!grantedTypes.isEmpty())
+                        .points(totalPoints)
+                        .types(grantedTypes)
+                        .currentCookieCount(cookieService.getMyCookies(userId))
+                        .build();
 
         return AiRecipeAdoptResponseDto.builder()
                 .sessionId(session.getId())
                 .recipeId(savedRecipe.getId())
                 .message("레시피가 성공적으로 채택되었습니다.")
                 .completedAt(session.getCompletedAt())
-                .weeklyGoalAchieved(weeklyGoalAchieved)
-                .recipeRewardGranted(rewardGranted)
-                .urgentIngredientRewardGranted(urgentRewardGranted)
                 .reward(rewardInfo)
                 .build();
     }

--- a/src/test/java/com/cookeep/cookeep/domain/dailyrecipe/application/DailyRecipeServiceTest.java
+++ b/src/test/java/com/cookeep/cookeep/domain/dailyrecipe/application/DailyRecipeServiceTest.java
@@ -2,6 +2,8 @@ package com.cookeep.cookeep.domain.dailyrecipe.application;
 
 import com.cookeep.cookeep.domain.cookie.application.CookieService;
 import com.cookeep.cookeep.domain.cookie.entity.CookieLog;
+
+import static org.mockito.ArgumentMatchers.anyLong;
 import com.cookeep.cookeep.domain.dailyrecipe.dao.DailyRecipeRepository;
 import com.cookeep.cookeep.domain.dailyrecipe.entity.DailyRecipe;
 import com.cookeep.cookeep.domain.onboarding.application.WeeklyGoalService;
@@ -90,41 +92,45 @@ class DailyRecipeServiceTest {
         }
 
         @Test
-        @DisplayName("사진 포함 등록 시 목표 달성이면 weeklyGoalAchieved=true를 반환한다")
+        @DisplayName("사진 포함 등록 시 목표 달성이면 reward.types에 BONUS_WEEKLY_GOAL_ACHIEVE가 포함된다")
         void 사진포함_등록_목표달성_true반환() {
             given(weeklyGoalService.handleGoalProgress(1L, GoalActionType.PHOTO_RECORD)).willReturn(true);
 
             DailyRecipeService.DailyRecipeResult result =
                     dailyRecipeService.createDailyRecipe(1L, 10L, null, null, "https://s3.example.com/photo.jpg", false);
 
-            assertThat(result.weeklyGoalAchieved()).isTrue();
+            assertThat(result.reward().getTypes())
+                    .contains(CookieLog.CookieLogType.BONUS_WEEKLY_GOAL_ACHIEVE);
         }
 
         @Test
-        @DisplayName("사진 없이 등록 시 weeklyGoalAchieved=false를 반환한다")
+        @DisplayName("사진 없이 등록 시 reward.types에 BONUS_WEEKLY_GOAL_ACHIEVE가 없다")
         void 사진없음_등록_weeklyGoalAchieved_false() {
             DailyRecipeService.DailyRecipeResult result =
                     dailyRecipeService.createDailyRecipe(1L, 10L, null, null, null, false);
 
-            assertThat(result.weeklyGoalAchieved()).isFalse();
+            assertThat(result.reward().getTypes())
+                    .doesNotContain(CookieLog.CookieLogType.BONUS_WEEKLY_GOAL_ACHIEVE);
         }
 
         @Test
-        @DisplayName("사진 포함 등록 시 photoCookieAwarded=true를 반환한다")
+        @DisplayName("사진 포함 등록 시 reward.types에 BASIC_FOOD_PHOTO_REG가 포함된다")
         void 사진포함_등록_photoCookieAwarded_true() {
             DailyRecipeService.DailyRecipeResult result =
                     dailyRecipeService.createDailyRecipe(1L, 10L, null, null, "https://s3.example.com/photo.jpg", false);
 
-            assertThat(result.photoCookieAwarded()).isTrue();
+            assertThat(result.reward().getTypes())
+                    .contains(CookieLog.CookieLogType.BASIC_FOOD_PHOTO_REG);
         }
 
         @Test
-        @DisplayName("사진 없이 등록 시 photoCookieAwarded=false를 반환한다")
+        @DisplayName("사진 없이 등록 시 reward.types에 BASIC_FOOD_PHOTO_REG가 없다")
         void 사진없음_등록_photoCookieAwarded_false() {
             DailyRecipeService.DailyRecipeResult result =
                     dailyRecipeService.createDailyRecipe(1L, 10L, null, null, null, false);
 
-            assertThat(result.photoCookieAwarded()).isFalse();
+            assertThat(result.reward().getTypes())
+                    .doesNotContain(CookieLog.CookieLogType.BASIC_FOOD_PHOTO_REG);
         }
 
         @Test
@@ -194,7 +200,7 @@ class DailyRecipeServiceTest {
         }
 
         @Test
-        @DisplayName("보상 미완료 레시피에 처음 사진 추가 시 photoCookieAwarded=true를 반환한다")
+        @DisplayName("보상 미완료 레시피에 처음 사진 추가 시 reward.types에 BASIC_FOOD_PHOTO_REG가 포함된다")
         void 신규사진_추가_photoCookieAwarded_true() {
             given(dailyRecipeRepository.findByIdAndUser(100L, user))
                     .willReturn(Optional.of(rewardPendingRecipe));
@@ -202,11 +208,12 @@ class DailyRecipeServiceTest {
             DailyRecipeService.DailyRecipeResult result =
                     dailyRecipeService.updateDailyRecipe(1L, 100L, null, null, "https://s3.example.com/new.jpg", false);
 
-            assertThat(result.photoCookieAwarded()).isTrue();
+            assertThat(result.reward().getTypes())
+                    .contains(CookieLog.CookieLogType.BASIC_FOOD_PHOTO_REG);
         }
 
         @Test
-        @DisplayName("보상 완료된 레시피에 사진 교체 시 photoCookieAwarded=false를 반환한다")
+        @DisplayName("보상 완료된 레시피에 사진 교체 시 reward.types에 BASIC_FOOD_PHOTO_REG가 없다")
         void 보상완료_사진교체_photoCookieAwarded_false() {
             given(dailyRecipeRepository.findByIdAndUser(100L, user))
                     .willReturn(Optional.of(rewardCompletedRecipe));
@@ -214,7 +221,8 @@ class DailyRecipeServiceTest {
             DailyRecipeService.DailyRecipeResult result =
                     dailyRecipeService.updateDailyRecipe(1L, 100L, null, null, "https://s3.example.com/replaced.jpg", false);
 
-            assertThat(result.photoCookieAwarded()).isFalse();
+            assertThat(result.reward().getTypes())
+                    .doesNotContain(CookieLog.CookieLogType.BASIC_FOOD_PHOTO_REG);
         }
 
         @Test
@@ -240,7 +248,7 @@ class DailyRecipeServiceTest {
         }
 
         @Test
-        @DisplayName("신규 사진 추가 시 목표 달성이면 weeklyGoalAchieved=true를 반환한다")
+        @DisplayName("신규 사진 추가 시 목표 달성이면 reward.types에 BONUS_WEEKLY_GOAL_ACHIEVE가 포함된다")
         void 신규사진_추가_목표달성_true반환() {
             given(dailyRecipeRepository.findByIdAndUser(100L, user))
                     .willReturn(Optional.of(rewardPendingRecipe));
@@ -249,7 +257,8 @@ class DailyRecipeServiceTest {
             DailyRecipeService.DailyRecipeResult result =
                     dailyRecipeService.updateDailyRecipe(1L, 100L, null, null, "https://s3.example.com/new.jpg", false);
 
-            assertThat(result.weeklyGoalAchieved()).isTrue();
+            assertThat(result.reward().getTypes())
+                    .contains(CookieLog.CookieLogType.BONUS_WEEKLY_GOAL_ACHIEVE);
         }
 
         @Test

--- a/src/test/java/com/cookeep/cookeep/domain/dailyrecipe/application/RecipeLikeServiceTest.java
+++ b/src/test/java/com/cookeep/cookeep/domain/dailyrecipe/application/RecipeLikeServiceTest.java
@@ -1,6 +1,8 @@
 package com.cookeep.cookeep.domain.dailyrecipe.application;
 
 import com.cookeep.cookeep.api.dto.response.CookeepsFeedResponseDto;
+import com.cookeep.cookeep.domain.cookie.application.CookieService;
+import com.cookeep.cookeep.domain.cookie.entity.CookieLog;
 import com.cookeep.cookeep.common.exception.AppException;
 import com.cookeep.cookeep.common.exception.ErrorCode;
 import com.cookeep.cookeep.domain.dailyrecipe.dao.DailyRecipeRepository;
@@ -52,6 +54,9 @@ class RecipeLikeServiceTest {
 
     @Mock
     private WeeklyGoalService weeklyGoalService;
+
+    @Mock
+    private CookieService cookieService;
 
     @InjectMocks
     private RecipeLikeService recipeLikeService;
@@ -109,23 +114,24 @@ class RecipeLikeServiceTest {
         }
 
         @Test
-        @DisplayName("좋아요 추가 시 목표 달성이면 weeklyGoalAchieved=true를 반환한다")
+        @DisplayName("좋아요 추가 시 목표 달성이면 reward.types에 BONUS_WEEKLY_GOAL_ACHIEVE가 포함된다")
         void 좋아요추가_목표달성_true반환() {
             given(weeklyGoalService.handleGoalProgress(1L, GoalActionType.RECIPE_LIKE)).willReturn(true);
 
             RecipeLikeService.ToggleLikeResult result = recipeLikeService.toggleLike(1L, 100L);
 
-            assertThat(result.weeklyGoalAchieved()).isTrue();
+            assertThat(result.reward().getTypes())
+                    .contains(CookieLog.CookieLogType.BONUS_WEEKLY_GOAL_ACHIEVE);
         }
 
         @Test
-        @DisplayName("좋아요 추가 시 목표 미달성이면 weeklyGoalAchieved=false를 반환한다")
+        @DisplayName("좋아요 추가 시 목표 미달성이면 reward.types가 비어있다")
         void 좋아요추가_목표미달성_false반환() {
             given(weeklyGoalService.handleGoalProgress(1L, GoalActionType.RECIPE_LIKE)).willReturn(false);
 
             RecipeLikeService.ToggleLikeResult result = recipeLikeService.toggleLike(1L, 100L);
 
-            assertThat(result.weeklyGoalAchieved()).isFalse();
+            assertThat(result.reward().getTypes()).isEmpty();
         }
     }
 
@@ -162,11 +168,11 @@ class RecipeLikeServiceTest {
         }
 
         @Test
-        @DisplayName("좋아요 취소 시 weeklyGoalAchieved=false를 반환한다")
-        void 좋아요취소_weeklyGoalAchieved_false() {
+        @DisplayName("좋아요 취소 시 reward는 null이다")
+        void 좋아요취소_reward_null() {
             RecipeLikeService.ToggleLikeResult result = recipeLikeService.toggleLike(1L, 100L);
 
-            assertThat(result.weeklyGoalAchieved()).isFalse();
+            assertThat(result.reward()).isNull();
         }
 
         @Test

--- a/src/test/java/com/cookeep/cookeep/domain/ingredient/application/ConsumeIngredientServiceTest.java
+++ b/src/test/java/com/cookeep/cookeep/domain/ingredient/application/ConsumeIngredientServiceTest.java
@@ -164,7 +164,8 @@ public class ConsumeIngredientServiceTest {
             ConsumeIngredientsResponseDto result =
                     consumeIngredientService.consumeIngredients(1L, buildRequest(List.of(1L)));
 
-            assertThat(result.isWeeklyGoalAchieved()).isTrue();
+            assertThat(result.getReward().getTypes())
+                    .contains(CookieLog.CookieLogType.BONUS_WEEKLY_GOAL_ACHIEVE);
         }
 
         @Test
@@ -178,7 +179,8 @@ public class ConsumeIngredientServiceTest {
             ConsumeIngredientsResponseDto result =
                     consumeIngredientService.consumeIngredients(1L, buildRequest(List.of(1L)));
 
-            assertThat(result.isWeeklyGoalAchieved()).isFalse();
+            assertThat(result.getReward().getTypes())
+                    .doesNotContain(CookieLog.CookieLogType.BONUS_WEEKLY_GOAL_ACHIEVE);
         }
 
         @Test
@@ -190,7 +192,8 @@ public class ConsumeIngredientServiceTest {
             ConsumeIngredientsResponseDto result =
                     consumeIngredientService.consumeIngredients(1L, buildRequest(List.of(1L)));
 
-            assertThat(result.isWeeklyGoalAchieved()).isFalse();
+            assertThat(result.getReward().getTypes())
+                    .doesNotContain(CookieLog.CookieLogType.BONUS_WEEKLY_GOAL_ACHIEVE);
         }
 
         @Test
@@ -204,7 +207,8 @@ public class ConsumeIngredientServiceTest {
             ConsumeIngredientsResponseDto result =
                     consumeIngredientService.consumeIngredients(1L, buildRequest(List.of(1L, 2L, 3L)));
 
-            assertThat(result.isWeeklyGoalAchieved()).isTrue();
+            assertThat(result.getReward().getTypes())
+                    .contains(CookieLog.CookieLogType.BONUS_WEEKLY_GOAL_ACHIEVE);
         }
     }
 
@@ -238,7 +242,8 @@ public class ConsumeIngredientServiceTest {
             ConsumeIngredientsResponseDto result =
                     consumeIngredientService.consumeIngredients(1L, buildRequest(List.of(1L)));
 
-            assertThat(result.isDailyFirstConsumeAchieved()).isTrue();
+            assertThat(result.getReward().getTypes())
+                    .contains(CookieLog.CookieLogType.BASIC_DAILY_FIRST_CONSUME);
         }
 
         @Test
@@ -267,7 +272,8 @@ public class ConsumeIngredientServiceTest {
             ConsumeIngredientsResponseDto result =
                     consumeIngredientService.consumeIngredients(1L, buildRequest(List.of(1L)));
 
-            assertThat(result.isDailyFirstConsumeAchieved()).isFalse();
+            assertThat(result.getReward().getTypes())
+                    .doesNotContain(CookieLog.CookieLogType.BASIC_DAILY_FIRST_CONSUME);
         }
 
         @Test
@@ -282,7 +288,8 @@ public class ConsumeIngredientServiceTest {
                     consumeIngredientService.consumeIngredients(1L, buildRequest(List.of(1L)));
 
             assertThat(result.getReward().getGranted()).isTrue();
-            assertThat(result.isWeeklyGoalAchieved()).isFalse();
+            assertThat(result.getReward().getTypes())
+                    .doesNotContain(CookieLog.CookieLogType.BONUS_WEEKLY_GOAL_ACHIEVE);
         }
     }
 
@@ -329,7 +336,7 @@ public class ConsumeIngredientServiceTest {
             ConsumeIngredientsResponseDto result =
                     consumeIngredientService.consumeIngredients(1L, buildRequest(List.of(1L)));
 
-            assertThat(result.getReward().getGrantedTypes())
+            assertThat(result.getReward().getTypes())
                     .containsExactly(CookieLog.CookieLogType.BASIC_DAILY_FIRST_CONSUME);
         }
 
@@ -345,7 +352,7 @@ public class ConsumeIngredientServiceTest {
                     consumeIngredientService.consumeIngredients(1L, buildRequest(List.of(1L)));
 
             assertThat(result.getReward().getGranted()).isFalse();
-            assertThat(result.getReward().getGrantedTypes()).isEmpty();
+            assertThat(result.getReward().getTypes()).isEmpty();
             assertThat(result.getReward().getPoints()).isZero();
         }
 
@@ -360,8 +367,26 @@ public class ConsumeIngredientServiceTest {
             ConsumeIngredientsResponseDto result =
                     consumeIngredientService.consumeIngredients(1L, buildRequest(List.of(1L)));
 
-            assertThat(result.getReward().getGrantedTypes())
+            assertThat(result.getReward().getTypes())
                     .contains(CookieLog.CookieLogType.BONUS_WEEKLY_GOAL_ACHIEVE);
+        }
+
+        @Test
+        @DisplayName("임박 재료 소비 + 하루 첫 소비가 동시 성립할 때 두 타입이 모두 포함된다")
+        void 임박재료_첫소비_동시성립_두타입_모두포함() {
+            given(userIngredientRepository.findAllByIngredientIdInAndUser_UserId(anyList(), anyLong()))
+                    .willReturn(List.of(buildUrgentIngredient()));
+            given(cookieService.grantDailyCookie(1L, CookieLog.CookieLogType.BASIC_DAILY_FIRST_CONSUME))
+                    .willReturn(true);
+            given(weeklyGoalService.handleGoalProgress(1L, GoalActionType.USE_EXPIRING_INGREDIENT))
+                    .willReturn(true);
+
+            ConsumeIngredientsResponseDto result =
+                    consumeIngredientService.consumeIngredients(1L, buildRequest(List.of(1L)));
+
+            assertThat(result.getReward().getTypes())
+                    .contains(CookieLog.CookieLogType.BASIC_DAILY_FIRST_CONSUME,
+                              CookieLog.CookieLogType.BONUS_WEEKLY_GOAL_ACHIEVE);
         }
 
         @Test
@@ -373,7 +398,7 @@ public class ConsumeIngredientServiceTest {
             ConsumeIngredientsResponseDto result =
                     consumeIngredientService.consumeIngredients(1L, buildRequest(List.of(1L)));
 
-            assertThat(result.getReward().getGrantedTypes())
+            assertThat(result.getReward().getTypes())
                     .doesNotContain(CookieLog.CookieLogType.BONUS_URGENT_INGREDIENT_USE);
             verify(cookieService, never())
                     .grantDailyCookie(anyLong(), eq(CookieLog.CookieLogType.BONUS_URGENT_INGREDIENT_USE));

--- a/src/test/java/com/cookeep/cookeep/domain/ingredient/application/UserIngredientServiceRewardTest.java
+++ b/src/test/java/com/cookeep/cookeep/domain/ingredient/application/UserIngredientServiceRewardTest.java
@@ -100,14 +100,14 @@ public class UserIngredientServiceRewardTest {
     class OnboardingIngredientReward {
 
         @Test
-        @DisplayName("최초 식재료 등록 시 ingredientRewardGranted=true를 반환한다")
+        @DisplayName("최초 식재료 등록 시 reward.granted=true를 반환한다")
         void 최초등록_ingredientRewardGranted_true() {
             given(userRepository.findById(anyLong())).willReturn(Optional.of(firstTimeUser));
 
             UserIngredientListCreateResponseDto result =
                     userIngredientService.createAll(1L, List.of(buildRequest()));
 
-            assertThat(result.isIngredientRewardGranted()).isTrue();
+            assertThat(result.getReward().getGranted()).isTrue();
         }
 
         @Test
@@ -130,7 +130,7 @@ public class UserIngredientServiceRewardTest {
             UserIngredientListCreateResponseDto result =
                     userIngredientService.createAll(1L, List.of(buildRequest()));
 
-            assertThat(result.getReward().getGrantedTypes())
+            assertThat(result.getReward().getTypes())
                     .containsExactly(CookieLog.CookieLogType.ONBOARDING_INGREDIENT);
         }
 
@@ -146,14 +146,14 @@ public class UserIngredientServiceRewardTest {
         }
 
         @Test
-        @DisplayName("이미 보상을 받은 유저는 ingredientRewardGranted=false를 반환한다")
+        @DisplayName("이미 보상을 받은 유저는 reward.granted=false를 반환한다")
         void 기존유저_ingredientRewardGranted_false() {
             given(userRepository.findById(anyLong())).willReturn(Optional.of(rewardedUser));
 
             UserIngredientListCreateResponseDto result =
                     userIngredientService.createAll(1L, List.of(buildRequest()));
 
-            assertThat(result.isIngredientRewardGranted()).isFalse();
+            assertThat(result.getReward().getGranted()).isFalse();
         }
 
         @Test
@@ -175,7 +175,7 @@ public class UserIngredientServiceRewardTest {
             UserIngredientListCreateResponseDto result =
                     userIngredientService.createAll(1L, List.of(buildRequest()));
 
-            assertThat(result.getReward().getGrantedTypes()).isEmpty();
+            assertThat(result.getReward().getTypes()).isEmpty();
         }
 
         @Test

--- a/src/test/java/com/cookeep/cookeep/domain/recipe/application/AiRecipeServiceTest.java
+++ b/src/test/java/com/cookeep/cookeep/domain/recipe/application/AiRecipeServiceTest.java
@@ -193,7 +193,7 @@ public class AiRecipeServiceTest {
         }
 
         @Test
-        @DisplayName("COOKING 목표 달성 시 weeklyGoalAchieved=true를 반환한다")
+        @DisplayName("COOKING 목표 달성 시 reward.types에 BONUS_WEEKLY_GOAL_ACHIEVE가 포함된다")
         void COOKING_달성_true() {
             given(userIngredientRepository.findAllByIngredientIdInAndUser_UserId(anyList(), eq(1L)))
                     .willReturn(List.of(buildNormalIngredient()));
@@ -201,19 +201,20 @@ public class AiRecipeServiceTest {
 
             AiRecipeAdoptResponseDto result = aiRecipeService.adoptRecipe(1L, 10L);
 
-            assertThat(result.isWeeklyGoalAchieved()).isTrue();
+            assertThat(result.getReward().getTypes())
+                    .contains(CookieLog.CookieLogType.BONUS_WEEKLY_GOAL_ACHIEVE);
         }
 
         @Test
-        @DisplayName("COOKING 미달성 + 임박 재료 없으면 weeklyGoalAchieved=false를 반환한다")
+        @DisplayName("COOKING 미달성 + 임박 재료 없으면 reward.types에 BONUS_WEEKLY_GOAL_ACHIEVE가 없다")
         void COOKING_미달성_임박없음_false() {
             given(userIngredientRepository.findAllByIngredientIdInAndUser_UserId(anyList(), eq(1L)))
                     .willReturn(List.of(buildNormalIngredient()));
-            // weeklyGoalService 기본값이 false이므로 별도 stubbing 불필요
 
             AiRecipeAdoptResponseDto result = aiRecipeService.adoptRecipe(1L, 10L);
 
-            assertThat(result.isWeeklyGoalAchieved()).isFalse();
+            assertThat(result.getReward().getTypes())
+                    .doesNotContain(CookieLog.CookieLogType.BONUS_WEEKLY_GOAL_ACHIEVE);
         }
 
         @Test
@@ -258,7 +259,7 @@ public class AiRecipeServiceTest {
         }
 
         @Test
-        @DisplayName("임박 재료 포함 채택으로 USE_EXPIRING 달성 시 weeklyGoalAchieved=true를 반환한다")
+        @DisplayName("임박 재료 포함 채택으로 USE_EXPIRING 달성 시 reward.types에 BONUS_WEEKLY_GOAL_ACHIEVE가 포함된다")
         void 임박재료_USE_EXPIRING_달성_true() {
             given(userIngredientRepository.findAllByIngredientIdInAndUser_UserId(anyList(), eq(1L)))
                     .willReturn(List.of(buildUrgentIngredient()));
@@ -267,19 +268,20 @@ public class AiRecipeServiceTest {
 
             AiRecipeAdoptResponseDto result = aiRecipeService.adoptRecipe(1L, 10L);
 
-            assertThat(result.isWeeklyGoalAchieved()).isTrue();
+            assertThat(result.getReward().getTypes())
+                    .contains(CookieLog.CookieLogType.BONUS_WEEKLY_GOAL_ACHIEVE);
         }
 
         @Test
-        @DisplayName("임박 재료 있지만 USE_EXPIRING 미달성 + COOKING 미달성이면 weeklyGoalAchieved=false를 반환한다")
+        @DisplayName("임박 재료 있지만 USE_EXPIRING 미달성 + COOKING 미달성이면 reward.types에 BONUS_WEEKLY_GOAL_ACHIEVE가 없다")
         void 임박재료_USE_EXPIRING_미달성_COOKING_미달성_false() {
             given(userIngredientRepository.findAllByIngredientIdInAndUser_UserId(anyList(), eq(1L)))
                     .willReturn(List.of(buildUrgentIngredient()));
 
-            // 기본값이 false이므로 별도 stubbing 불필요
             AiRecipeAdoptResponseDto result = aiRecipeService.adoptRecipe(1L, 10L);
 
-            assertThat(result.isWeeklyGoalAchieved()).isFalse();
+            assertThat(result.getReward().getTypes())
+                    .doesNotContain(CookieLog.CookieLogType.BONUS_WEEKLY_GOAL_ACHIEVE);
         }
     }
 
@@ -298,9 +300,8 @@ public class AiRecipeServiceTest {
             AiRecipeAdoptResponseDto result = aiRecipeService.adoptRecipe(1L, 10L);
 
             assertThat(result.getReward()).isNotNull();
-            assertThat(result.getReward().getGrantedTypes())
+            assertThat(result.getReward().getTypes())
                     .contains(CookieLog.CookieLogType.ONBOARDING_RECIPE);
-            assertThat(result.isRecipeRewardGranted()).isTrue();
         }
 
         @Test
@@ -313,9 +314,8 @@ public class AiRecipeServiceTest {
 
             AiRecipeAdoptResponseDto result = aiRecipeService.adoptRecipe(1L, 10L);
 
-            assertThat(result.getReward().getGrantedTypes())
+            assertThat(result.getReward().getTypes())
                     .contains(CookieLog.CookieLogType.BONUS_URGENT_INGREDIENT_USE);
-            assertThat(result.isUrgentIngredientRewardGranted()).isTrue();
         }
 
         @Test
@@ -334,7 +334,7 @@ public class AiRecipeServiceTest {
             AiRecipeAdoptResponseDto result = aiRecipeService.adoptRecipe(1L, 10L);
 
             assertThat(result.getReward().getGranted()).isFalse();
-            assertThat(result.getReward().getGrantedTypes()).isEmpty();
+            assertThat(result.getReward().getTypes()).isEmpty();
             assertThat(result.getReward().getPoints()).isZero();
         }
 


### PR DESCRIPTION
# Related Issue
CLOSE #263 

# Description

쿠키 지급 케이스별로 응답 DTO가 제각각이었고, 각 DTO마다 중복된 inner static class `RewardInfo`와 용도가 겹치는 boolean 필드들이 난립해 있었습니다.

이에 공통 `CookieRewardDto`를 도입해, 14일 이상 미접속 후 접속 경우를 제외한 모든 쿠키 보상 응답 구조를 통일하고, 지급된 쿠키 타입을 `types: List<CookieLogType>`으로 명시하도록 변경했습니다.
또한 각 보상 응답에 `currentCookieCount`(지급 후 현재 보유 쿠키 수)를 추가해 프론트가 별도 조회 없이 최신 쿠키 잔액을 알 수 있도록 했습니다.

# Changes

- `CookieRewardDto` 신설 (`granted`, `points`, `types`, `currentCookieCount`)
- `ClaimPendingRewardResponseDto` 신설 — `claimPendingReward` 응답을 `reward` 필드로 래핑해 다른 API와 구조 통일
- 각 응답 DTO의 inner `RewardInfo` 제거 → `CookieRewardDto`로 대체
  - `UserIngredientListCreateResponseDto`
  - `AiRecipeAdoptResponseDto`
  - `ConsumeIngredientsResponseDto`
  - `DailyRecipeCreateResponseDto` / `DailyRecipeUpdateResponseDto`
  - `RecipeLikeResponseDto`
- 중복 boolean 필드 제거 (`ingredientRewardGranted`, `weeklyGoalAchieved`, `photoCookieAwarded`, `recipeRewardGranted`, `urgentIngredientRewardGranted`, `dailyFirstConsumeAchieved`)
- `DailyRecipeResult` record에서 `weeklyGoalAchieved`, `photoCookieAwarded` 제거 → `reward` 필드 하나로 통합
- `CookieService.claimPendingReward` 반환 타입 `int` → `CookieRewardDto`
- `RecipeLikeService`에 `CookieService` 주입, `ToggleLikeResult`의 `weeklyGoalAchieved` → `CookieRewardDto reward` 교체 (좋아요 취소 시 `null`)
- `AiRecipeService`: `BONUS_WEEKLY_GOAL_ACHIEVE` 타입 누락 버그 수정
- 관련 테스트 일괄 수정 (`DailyRecipeServiceTest`, `RecipeLikeServiceTest`, `ConsumeIngredientServiceTest`, `AiRecipeServiceTest`, `UserIngredientServiceRewardTest`)

# 참고사항
노션의 [쿠키 지급 및 사용 개발 현황(정책서 기반)](https://www.notion.so/2f53f76f8724802c9eb9ec67c57e487b?source=copy_link) 페이지에 각 지급 항목 별로 CookieLogType, 관련 응답 DTO, 관련 Controller, 변경된 API 링크 등을 상세하게 적어두었습니다.

그리고 제가 수정 거친 API들은 API 명세서 내에 비고 란에 '26/6/18 현정 수정 완료' 적어두었고,
기존에 형원님이 만드셨던 이전 버전의 응답들도 지우진 않고 `26/6/18 이전 버전`으로 토글로 만들어뒀습니다. 참고해주시면 감사하겠습니다!!