### PR TITLE
COOKEEP-49 feat: 이미지 크롭 미리보기 및 전체보기 지원

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,6 +54,9 @@ dependencies {
 	// AWS S3
 	implementation 'software.amazon.awssdk:s3:2.25.27'
 
+	// 이미지 크롭
+	implementation 'net.coobird:thumbnailator:0.4.20'
+
 	// Web Push
 	implementation 'nl.martijndwars:web-push:5.1.1'
 	implementation 'org.bouncycastle:bcprov-jdk15on:1.70'

--- a/build.gradle
+++ b/build.gradle
@@ -57,8 +57,6 @@ dependencies {
 	// 이미지 크롭
 	implementation 'net.coobird:thumbnailator:0.4.20'
 
-	// SVG sanitizer
-	implementation 'com.googlecode.owasp-java-html-sanitizer:owasp-java-html-sanitizer:20240325.1'
 
 	// Web Push
 	implementation 'nl.martijndwars:web-push:5.1.1'

--- a/build.gradle
+++ b/build.gradle
@@ -57,6 +57,9 @@ dependencies {
 	// 이미지 크롭
 	implementation 'net.coobird:thumbnailator:0.4.20'
 
+	// SVG sanitizer
+	implementation 'com.googlecode.owasp-java-html-sanitizer:owasp-java-html-sanitizer:20240325.1'
+
 	// Web Push
 	implementation 'nl.martijndwars:web-push:5.1.1'
 	implementation 'org.bouncycastle:bcprov-jdk15on:1.70'

--- a/src/main/java/com/cookeep/cookeep/api/controller/DailyRecipeController.java
+++ b/src/main/java/com/cookeep/cookeep/api/controller/DailyRecipeController.java
@@ -120,6 +120,7 @@ public class DailyRecipeController {
                 request.getTitle(),
                 request.getDescription(),
                 request.getRecipeImageUrl(),
+                request.getCroppedImageUrl(),
                 request.getIsPublic()
         );
 
@@ -175,7 +176,7 @@ public class DailyRecipeController {
     ) {
         DailyRecipeService.DailyRecipeResult result = dailyRecipeService.updateDailyRecipe(
                 userId, dailyRecipeId, request.getTitle(), request.getDescription(),
-                request.getRecipeImageUrl(), request.getDeleteRecipeImage()
+                request.getRecipeImageUrl(), request.getCroppedImageUrl(), request.getDeleteRecipeImage()
         );
 
         return ResponseEntity.ok(DataResponse.from(DailyRecipeUpdateResponseDto.from(result.dailyRecipe(), result.reward())));

--- a/src/main/java/com/cookeep/cookeep/api/controller/ImageController.java
+++ b/src/main/java/com/cookeep/cookeep/api/controller/ImageController.java
@@ -27,13 +27,28 @@ public class ImageController {
 
 	private final S3Service s3Service;
 
-	@Operation(summary = "이미지 업로드", description = "S3에 이미지를 업로드하고 URL을 반환합니다. folder: PLANTS, RECIPE_IMAGES")
+	@Operation(
+		summary = "이미지 업로드",
+		description = "S3에 이미지를 업로드하고 URL을 반환합니다. folder: PLANTS, RECIPE_IMAGES" +
+			"cropX, cropY, cropWidth, cropHeight를 모두 전달하면 크롭된 이미지도 함께 업로드하여 croppedImageUrl을 반환합니다."
+	)
 	@PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
 	public ResponseEntity<DataResponse<ImageUploadResponseDto>> uploadImage(
 		@RequestPart("image") MultipartFile image,
-		@RequestParam(value = "folder") ImageFolder folder
+		@RequestParam(value = "folder") ImageFolder folder,
+		@RequestParam(value = "cropX", required = false) Integer cropX,
+		@RequestParam(value = "cropY", required = false) Integer cropY,
+		@RequestParam(value = "cropWidth", required = false) Integer cropWidth,
+		@RequestParam(value = "cropHeight", required = false) Integer cropHeight
 	) {
 		String imageUrl = s3Service.upload(image, folder.getFolderName());
+
+		boolean hasCrop = cropX != null && cropY != null && cropWidth != null && cropHeight != null;
+		if (hasCrop) {
+			String croppedImageUrl = s3Service.uploadCropped(image, folder.getFolderName(), cropX, cropY, cropWidth, cropHeight);
+			return ResponseEntity.ok(DataResponse.from(ImageUploadResponseDto.of(imageUrl, croppedImageUrl)));
+		}
+
 		return ResponseEntity.ok(DataResponse.from(ImageUploadResponseDto.from(imageUrl)));
 	}
 

--- a/src/main/java/com/cookeep/cookeep/api/dto/request/DailyRecipeCreateRequestDto.java
+++ b/src/main/java/com/cookeep/cookeep/api/dto/request/DailyRecipeCreateRequestDto.java
@@ -43,6 +43,13 @@ public class DailyRecipeCreateRequestDto {
     private String recipeImageUrl;
 
     @Schema(
+            description = "크롭된 미리보기 사진 URL (이미지 업로드 API에서 cropX/Y/Width/Height 전달 시 반환되는 croppedImageUrl)",
+            example = "https://cookeep-images.s3.amazonaws.com/recipeImages/abc-cropped.jpg",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    private String croppedImageUrl;
+
+    @Schema(
             description = "공개 여부 (true: 쿠킵스에 공개, false: 나만 보기)",
             example = "false",
             requiredMode = Schema.RequiredMode.REQUIRED

--- a/src/main/java/com/cookeep/cookeep/api/dto/request/DailyRecipeUpdateRequestDto.java
+++ b/src/main/java/com/cookeep/cookeep/api/dto/request/DailyRecipeUpdateRequestDto.java
@@ -34,6 +34,13 @@ public class DailyRecipeUpdateRequestDto {
     private String recipeImageUrl;
 
     @Schema(
+            description = "크롭된 미리보기 사진 URL (이미지 업로드 API에서 cropX/Y/Width/Height 전달 시 반환되는 croppedImageUrl)",
+            example = "https://cookeep-images.s3.amazonaws.com/recipeImages/abc-cropped.jpg",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    private String croppedImageUrl;
+
+    @Schema(
             description = "요리 사진 삭제 여부 (true 시 기존 사진을 S3에서 삭제하고 DB에서 제거)",
             example = "true",
             requiredMode = Schema.RequiredMode.NOT_REQUIRED

--- a/src/main/java/com/cookeep/cookeep/api/dto/response/DailyRecipeDetailResponseDto.java
+++ b/src/main/java/com/cookeep/cookeep/api/dto/response/DailyRecipeDetailResponseDto.java
@@ -29,8 +29,11 @@ public class DailyRecipeDetailResponseDto {
     @JsonRawValue
     private String content;
 
-    @Schema(description = "요리 사진 URL")
+    @Schema(description = "요리 사진 URL (원본, 전체보기에 사용)")
     private String recipeImageUrl;
+
+    @Schema(description = "크롭된 미리보기 사진 URL")
+    private String croppedImageUrl;
 
     @Schema(description = "공개 여부", example = "false")
     private Boolean isPublic;
@@ -48,6 +51,7 @@ public class DailyRecipeDetailResponseDto {
                 .description(dailyRecipe.getDescription())
                 .content(dailyRecipe.getContent())
                 .recipeImageUrl(dailyRecipe.getRecipeImageUrl())
+                .croppedImageUrl(dailyRecipe.getCroppedImageUrl())
                 .isPublic(dailyRecipe.getIsPublic())
                 .aiRecipeId(dailyRecipe.getAiRecipe() != null ? dailyRecipe.getAiRecipe().getId() : null)
                 .createdAt(dailyRecipe.getCreatedAt())

--- a/src/main/java/com/cookeep/cookeep/api/dto/response/DailyRecipeListResponseDto.java
+++ b/src/main/java/com/cookeep/cookeep/api/dto/response/DailyRecipeListResponseDto.java
@@ -21,8 +21,11 @@ public class DailyRecipeListResponseDto {
     @Schema(description = "레시피 제목", example = "고추장 마요 달걀밥")
     private String title;
 
-    @Schema(description = "요리 사진 URL")
+    @Schema(description = "요리 사진 URL (원본, 전체보기에 사용)")
     private String recipeImageUrl;
+
+    @Schema(description = "크롭된 미리보기 사진 URL")
+    private String croppedImageUrl;
 
     @Schema(description = "공개 여부", example = "false")
     private Boolean isPublic;
@@ -35,6 +38,7 @@ public class DailyRecipeListResponseDto {
                 .dailyRecipeId(dailyRecipe.getId())
                 .title(dailyRecipe.getTitle())
                 .recipeImageUrl(dailyRecipe.getRecipeImageUrl())
+                .croppedImageUrl(dailyRecipe.getCroppedImageUrl())
                 .isPublic(dailyRecipe.getIsPublic())
                 .createdAt(dailyRecipe.getCreatedAt())
                 .build();

--- a/src/main/java/com/cookeep/cookeep/api/dto/response/DailyRecipeUpdateResponseDto.java
+++ b/src/main/java/com/cookeep/cookeep/api/dto/response/DailyRecipeUpdateResponseDto.java
@@ -29,8 +29,11 @@ public class DailyRecipeUpdateResponseDto {
     @JsonRawValue
     private String content;
 
-    @Schema(description = "요리 사진 URL")
+    @Schema(description = "요리 사진 URL (원본, 전체보기에 사용)")
     private String recipeImageUrl;
+
+    @Schema(description = "크롭된 미리보기 사진 URL")
+    private String croppedImageUrl;
 
     @Schema(description = "공개 여부", example = "false")
     private Boolean isPublic;
@@ -51,6 +54,7 @@ public class DailyRecipeUpdateResponseDto {
                 .description(dailyRecipe.getDescription())
                 .content(dailyRecipe.getContent())
                 .recipeImageUrl(dailyRecipe.getRecipeImageUrl())
+                .croppedImageUrl(dailyRecipe.getCroppedImageUrl())
                 .isPublic(dailyRecipe.getIsPublic())
                 .aiRecipeId(dailyRecipe.getAiRecipe() != null ? dailyRecipe.getAiRecipe().getId() : null)
                 .createdAt(dailyRecipe.getCreatedAt())

--- a/src/main/java/com/cookeep/cookeep/api/dto/response/ImageUploadResponseDto.java
+++ b/src/main/java/com/cookeep/cookeep/api/dto/response/ImageUploadResponseDto.java
@@ -9,9 +9,18 @@ public class ImageUploadResponseDto {
 
 	private String imageUrl;
 
+	private String croppedImageUrl;
+
 	public static ImageUploadResponseDto from(String imageUrl) {
 		return ImageUploadResponseDto.builder()
 			.imageUrl(imageUrl)
+			.build();
+	}
+
+	public static ImageUploadResponseDto of(String imageUrl, String croppedImageUrl) {
+		return ImageUploadResponseDto.builder()
+			.imageUrl(imageUrl)
+			.croppedImageUrl(croppedImageUrl)
 			.build();
 	}
 }

--- a/src/main/java/com/cookeep/cookeep/common/exception/ErrorCode.java
+++ b/src/main/java/com/cookeep/cookeep/common/exception/ErrorCode.java
@@ -80,6 +80,7 @@ public enum ErrorCode {
 	CANNOT_BOOKMARK_OWN_RECIPE(HttpStatus.BAD_REQUEST, "자신의 레시피에는 북마크를 누를 수 없습니다.", "DAILY_RECIPE-007"),
 	DAILY_RECIPE_TITLE_BLANK(HttpStatus.BAD_REQUEST, "레시피 제목은 빈 값으로 수정할 수 없습니다.", "DAILY_RECIPE-008"),
 	DAILY_RECIPE_IMAGE_SAME_URL(HttpStatus.BAD_REQUEST, "기존 사진과 동일한 URL로 변경할 수 없습니다.", "DAILY_RECIPE-009"),
+	FILE_CROP_INVALID_BOUNDS(HttpStatus.BAD_REQUEST, "크롭 영역이 이미지 범위를 벗어났습니다.", "FILE-003"),
 
 	// AUTH
 	SAME_AS_PREVIOUS_PASSWORD(HttpStatus.BAD_REQUEST, "기존 등록된 비밀번호와 동일한 비밀번호입니다.", "AUTH-005"),

--- a/src/main/java/com/cookeep/cookeep/common/util/ImageCropService.java
+++ b/src/main/java/com/cookeep/cookeep/common/util/ImageCropService.java
@@ -1,0 +1,34 @@
+package com.cookeep.cookeep.common.util;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.cookeep.cookeep.common.exception.AppException;
+import com.cookeep.cookeep.common.exception.ErrorCode;
+
+import lombok.extern.slf4j.Slf4j;
+import net.coobird.thumbnailator.Thumbnails;
+
+@Slf4j
+@Service
+public class ImageCropService {
+
+	public byte[] crop(MultipartFile file, String outputFormat, int x, int y, int width, int height) {
+		try {
+			ByteArrayOutputStream baos = new ByteArrayOutputStream();
+			Thumbnails.of(file.getInputStream())
+				.sourceRegion(x, y, width, height)
+				.size(width, height)
+				.keepAspectRatio(false)
+				.outputFormat(outputFormat)
+				.toOutputStream(baos);
+			return baos.toByteArray();
+		} catch (IOException e) {
+			log.error("이미지 크롭 실패.", e);
+			throw new AppException(ErrorCode.FILE_UPLOAD_ERROR);
+		}
+	}
+}

--- a/src/main/java/com/cookeep/cookeep/common/util/ImageCropService.java
+++ b/src/main/java/com/cookeep/cookeep/common/util/ImageCropService.java
@@ -1,7 +1,10 @@
 package com.cookeep.cookeep.common.util;
 
+import java.awt.image.BufferedImage;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+
+import javax.imageio.ImageIO;
 
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
@@ -18,17 +21,30 @@ public class ImageCropService {
 
 	public byte[] crop(MultipartFile file, String outputFormat, int x, int y, int width, int height) {
 		try {
+			BufferedImage image = ImageIO.read(file.getInputStream());
+			validateCropBounds(x, y, width, height, image.getWidth(), image.getHeight());
+
 			ByteArrayOutputStream baos = new ByteArrayOutputStream();
-			Thumbnails.of(file.getInputStream())
+			Thumbnails.of(image)
 				.sourceRegion(x, y, width, height)
 				.size(width, height)
 				.keepAspectRatio(false)
 				.outputFormat(outputFormat)
 				.toOutputStream(baos);
 			return baos.toByteArray();
+		} catch (AppException e) {
+			throw e;
 		} catch (IOException e) {
 			log.error("이미지 크롭 실패.", e);
 			throw new AppException(ErrorCode.FILE_UPLOAD_ERROR);
+		}
+	}
+
+	private void validateCropBounds(int x, int y, int width, int height, int imageWidth, int imageHeight) {
+		if (x < 0 || y < 0 || width <= 0 || height <= 0
+			|| x + width > imageWidth
+			|| y + height > imageHeight) {
+			throw new AppException(ErrorCode.FILE_CROP_INVALID_BOUNDS);
 		}
 	}
 }

--- a/src/main/java/com/cookeep/cookeep/common/util/S3Service.java
+++ b/src/main/java/com/cookeep/cookeep/common/util/S3Service.java
@@ -1,8 +1,13 @@
 package com.cookeep.cookeep.common.util;
 
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Set;
 import java.util.UUID;
+
+import net.coobird.thumbnailator.Thumbnails;
+import net.coobird.thumbnailator.geometry.Positions;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -50,6 +55,40 @@ public class S3Service {
 			s3Client.putObject(request, RequestBody.fromBytes(file.getBytes()));
 		} catch (Exception e) {
 			log.error("S3 upload failed. bucket={}, folder={}", bucket, folder, e);
+			throw new AppException(ErrorCode.FILE_UPLOAD_ERROR);
+		}
+
+		return String.format("https://%s.s3.%s.amazonaws.com/%s", bucket, region, key);
+	}
+
+	public String uploadCropped(MultipartFile file, String folder, int x, int y, int width, int height) {
+		String originalFilename = file.getOriginalFilename();
+		String extension = extractExtension(originalFilename);
+		String outputFormat = "svg".equalsIgnoreCase(extension) ? "jpg" : extension;
+
+		String key = folder + "/" + UUID.randomUUID() + "-cropped." + outputFormat;
+
+		try {
+			ByteArrayOutputStream baos = new ByteArrayOutputStream();
+			Thumbnails.of(file.getInputStream())
+				.sourceRegion(x, y, width, height)
+				.size(width, height)
+				.keepAspectRatio(false)
+				.outputFormat(outputFormat)
+				.toOutputStream(baos);
+
+			PutObjectRequest request = PutObjectRequest.builder()
+				.bucket(bucket)
+				.key(key)
+				.contentType("image/" + outputFormat)
+				.build();
+
+			s3Client.putObject(request, RequestBody.fromBytes(baos.toByteArray()));
+		} catch (IOException e) {
+			log.error("이미지 크롭 실패. folder={}", folder, e);
+			throw new AppException(ErrorCode.FILE_UPLOAD_ERROR);
+		} catch (Exception e) {
+			log.error("S3 크롭 이미지 업로드 실패. bucket={}, folder={}", bucket, folder, e);
 			throw new AppException(ErrorCode.FILE_UPLOAD_ERROR);
 		}
 

--- a/src/main/java/com/cookeep/cookeep/common/util/S3Service.java
+++ b/src/main/java/com/cookeep/cookeep/common/util/S3Service.java
@@ -1,15 +1,5 @@
 package com.cookeep.cookeep.common.util;
 
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.util.Set;
-import java.util.UUID;
-
-import net.coobird.thumbnailator.Thumbnails;
-import net.coobird.thumbnailator.geometry.Positions;
-
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -18,97 +8,25 @@ import com.cookeep.cookeep.common.exception.ErrorCode;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import software.amazon.awssdk.core.sync.RequestBody;
-import software.amazon.awssdk.services.s3.S3Client;
-import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
-import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class S3Service {
 
-	private final S3Client s3Client;
-
-	@Value("${aws.s3.bucket}")
-	private String bucket;
-
-	@Value("${aws.s3.region}")
-	private String region;
+	private final S3Uploader s3Uploader;
+	private final ImageCropService imageCropService;
+	private final SvgValidator svgValidator;
 
 	public String upload(MultipartFile file, String folder) {
-		String originalFilename = file.getOriginalFilename();
-		String extension = extractExtension(originalFilename);
+		String extension = extractExtension(file.getOriginalFilename());
 
-		validateFile(file, extension, folder);
-
-		String key = folder + "/" + UUID.randomUUID() + "." + extension;
-		String contentType = resolveContentType(file, extension);
-
-		try {
-			PutObjectRequest request = PutObjectRequest.builder()
-				.bucket(bucket)
-				.key(key)
-				.contentType(contentType)
-				.build();
-
-			s3Client.putObject(request, RequestBody.fromBytes(file.getBytes()));
-		} catch (Exception e) {
-			log.error("S3 upload failed. bucket={}, folder={}", bucket, folder, e);
-			throw new AppException(ErrorCode.FILE_UPLOAD_ERROR);
+		if ("svg".equalsIgnoreCase(extension)) {
+			svgValidator.validate(file, folder);
+			return uploadBytes(file, folder, extension, "image/svg+xml");
 		}
 
-		return String.format("https://%s.s3.%s.amazonaws.com/%s", bucket, region, key);
-	}
-
-	public String uploadCropped(MultipartFile file, String folder, int x, int y, int width, int height) {
-		String originalFilename = file.getOriginalFilename();
-		String extension = extractExtension(originalFilename);
-		String outputFormat = "svg".equalsIgnoreCase(extension) ? "jpg" : extension;
-
-		String key = folder + "/" + UUID.randomUUID() + "-cropped." + outputFormat;
-
-		try {
-			ByteArrayOutputStream baos = new ByteArrayOutputStream();
-			Thumbnails.of(file.getInputStream())
-				.sourceRegion(x, y, width, height)
-				.size(width, height)
-				.keepAspectRatio(false)
-				.outputFormat(outputFormat)
-				.toOutputStream(baos);
-
-			PutObjectRequest request = PutObjectRequest.builder()
-				.bucket(bucket)
-				.key(key)
-				.contentType("image/" + outputFormat)
-				.build();
-
-			s3Client.putObject(request, RequestBody.fromBytes(baos.toByteArray()));
-		} catch (IOException e) {
-			log.error("이미지 크롭 실패. folder={}", folder, e);
-			throw new AppException(ErrorCode.FILE_UPLOAD_ERROR);
-		} catch (Exception e) {
-			log.error("S3 크롭 이미지 업로드 실패. bucket={}, folder={}", bucket, folder, e);
-			throw new AppException(ErrorCode.FILE_UPLOAD_ERROR);
-		}
-
-		return String.format("https://%s.s3.%s.amazonaws.com/%s", bucket, region, key);
-	}
-
-	public void delete(String imageUrl) {
-		String key = extractKeyFromUrl(imageUrl);
-
-		try {
-			DeleteObjectRequest request = DeleteObjectRequest.builder()
-				.bucket(bucket)
-				.key(key)
-				.build();
-
-			s3Client.deleteObject(request);
-		} catch (Exception e) {
-			log.error("S3 delete failed. bucket={}, key={}", bucket, key, e);
-			throw new AppException(ErrorCode.FILE_DELETE_ERROR);
-		}
+		return uploadBytes(file, folder, extension, file.getContentType());
 	}
 
 	private String extractExtension(String filename) {
@@ -118,57 +36,26 @@ public class S3Service {
 		return filename.substring(filename.lastIndexOf(".") + 1);
 	}
 
-	private String extractKeyFromUrl(String url) {
-		String prefix = String.format("https://%s.s3.%s.amazonaws.com/", bucket, region);
-		return url.replace(prefix, "");
-	}
-
-	// --- svg용 ---
-	// SVG 허용 폴더: INGREDIENTS (아이콘 전용)
-	private static final Set<String> SVG_ALLOWED_FOLDERS = Set.of(
-			ImageFolder.INGREDIENTS.getFolderName()
-	);
-
-	private void validateSvgContent(MultipartFile file) {
+	private String uploadBytes(MultipartFile file, String folder, String extension, String contentType) {
 		try {
-			String svg = new String(file.getBytes(), StandardCharsets.UTF_8).toLowerCase();
-
-			if (svg.contains("<script")
-					|| svg.contains("onload=")
-					|| svg.contains("onclick=")
-					|| svg.contains("<foreignobject")) {
-				throw new AppException(ErrorCode.FILE_UPLOAD_ERROR);
-			}
+			return s3Uploader.upload(file.getBytes(), folder, extension, contentType);
+		} catch (AppException e) {
+			throw e;
 		} catch (Exception e) {
+			log.error("파일 읽기 실패. folder={}", folder, e);
 			throw new AppException(ErrorCode.FILE_UPLOAD_ERROR);
 		}
 	}
 
-	private String resolveContentType(MultipartFile file, String extension) {
-		if ("svg".equalsIgnoreCase(extension)) {
-			return "image/svg+xml";
-		}
-		return file.getContentType();
+	public String uploadCropped(MultipartFile file, String folder, int x, int y, int width, int height) {
+		String extension = extractExtension(file.getOriginalFilename());
+		String outputFormat = "svg".equalsIgnoreCase(extension) ? "jpg" : extension;
+
+		byte[] cropped = imageCropService.crop(file, outputFormat, x, y, width, height);
+		return s3Uploader.uploadCropped(cropped, folder, outputFormat, "image/" + outputFormat);
 	}
 
-	private void validateFile(MultipartFile file, String extension, String folder) {
-		if ("svg".equalsIgnoreCase(extension)) {
-			validateSvgFolder(folder);
-			validateSvgContentType(file);
-			validateSvgContent(file);
-		}
+	public void delete(String imageUrl) {
+		s3Uploader.delete(imageUrl);
 	}
-
-	private void validateSvgFolder(String folder) {
-		if (!SVG_ALLOWED_FOLDERS.contains(folder)) {
-			throw new AppException(ErrorCode.FILE_UPLOAD_ERROR);
-		}
-	}
-
-	private void validateSvgContentType(MultipartFile file) {
-		if (!"image/svg+xml".equalsIgnoreCase(file.getContentType())) {
-			throw new AppException(ErrorCode.FILE_UPLOAD_ERROR);
-		}
-	}
-
 }

--- a/src/main/java/com/cookeep/cookeep/common/util/S3Service.java
+++ b/src/main/java/com/cookeep/cookeep/common/util/S3Service.java
@@ -54,6 +54,8 @@ public class S3Service {
 		try {
 			byte[] cropped = imageCropService.crop(file, outputFormat, x, y, width, height);
 			return s3Uploader.uploadCropped(cropped, folder, outputFormat, "image/" + outputFormat);
+		} catch (AppException e) {
+			throw e;
 		} catch (Exception e) {
 			log.warn("크롭 이미지 생성 실패, 원본만 반환합니다. folder={}", folder, e);
 			return null;

--- a/src/main/java/com/cookeep/cookeep/common/util/S3Service.java
+++ b/src/main/java/com/cookeep/cookeep/common/util/S3Service.java
@@ -51,8 +51,13 @@ public class S3Service {
 		String extension = extractExtension(file.getOriginalFilename());
 		String outputFormat = "svg".equalsIgnoreCase(extension) ? "jpg" : extension;
 
-		byte[] cropped = imageCropService.crop(file, outputFormat, x, y, width, height);
-		return s3Uploader.uploadCropped(cropped, folder, outputFormat, "image/" + outputFormat);
+		try {
+			byte[] cropped = imageCropService.crop(file, outputFormat, x, y, width, height);
+			return s3Uploader.uploadCropped(cropped, folder, outputFormat, "image/" + outputFormat);
+		} catch (Exception e) {
+			log.warn("크롭 이미지 생성 실패, 원본만 반환합니다. folder={}", folder, e);
+			return null;
+		}
 	}
 
 	public void delete(String imageUrl) {

--- a/src/main/java/com/cookeep/cookeep/common/util/S3Uploader.java
+++ b/src/main/java/com/cookeep/cookeep/common/util/S3Uploader.java
@@ -1,0 +1,93 @@
+package com.cookeep.cookeep.common.util;
+
+import java.util.UUID;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import com.cookeep.cookeep.common.exception.AppException;
+import com.cookeep.cookeep.common.exception.ErrorCode;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class S3Uploader {
+
+	private final S3Client s3Client;
+
+	@Value("${aws.s3.bucket}")
+	private String bucket;
+
+	@Value("${aws.s3.region}")
+	private String region;
+
+	public String upload(byte[] data, String folder, String extension, String contentType) {
+		String key = folder + "/" + UUID.randomUUID() + "." + extension;
+
+		try {
+			PutObjectRequest request = PutObjectRequest.builder()
+				.bucket(bucket)
+				.key(key)
+				.contentType(contentType)
+				.build();
+
+			s3Client.putObject(request, RequestBody.fromBytes(data));
+		} catch (Exception e) {
+			log.error("S3 upload failed. bucket={}, folder={}", bucket, folder, e);
+			throw new AppException(ErrorCode.FILE_UPLOAD_ERROR);
+		}
+
+		return buildUrl(key);
+	}
+
+	public String uploadCropped(byte[] data, String folder, String extension, String contentType) {
+		String key = folder + "/" + UUID.randomUUID() + "-cropped." + extension;
+
+		try {
+			PutObjectRequest request = PutObjectRequest.builder()
+				.bucket(bucket)
+				.key(key)
+				.contentType(contentType)
+				.build();
+
+			s3Client.putObject(request, RequestBody.fromBytes(data));
+		} catch (Exception e) {
+			log.error("S3 cropped image upload failed. bucket={}, folder={}", bucket, folder, e);
+			throw new AppException(ErrorCode.FILE_UPLOAD_ERROR);
+		}
+
+		return buildUrl(key);
+	}
+
+	public void delete(String imageUrl) {
+		String key = extractKey(imageUrl);
+
+		try {
+			DeleteObjectRequest request = DeleteObjectRequest.builder()
+				.bucket(bucket)
+				.key(key)
+				.build();
+
+			s3Client.deleteObject(request);
+		} catch (Exception e) {
+			log.error("S3 delete failed. bucket={}, key={}", bucket, key, e);
+			throw new AppException(ErrorCode.FILE_DELETE_ERROR);
+		}
+	}
+
+	public String buildUrl(String key) {
+		return String.format("https://%s.s3.%s.amazonaws.com/%s", bucket, region, key);
+	}
+
+	private String extractKey(String url) {
+		String prefix = String.format("https://%s.s3.%s.amazonaws.com/", bucket, region);
+		return url.replace(prefix, "");
+	}
+}

--- a/src/main/java/com/cookeep/cookeep/common/util/SvgValidator.java
+++ b/src/main/java/com/cookeep/cookeep/common/util/SvgValidator.java
@@ -1,0 +1,53 @@
+package com.cookeep.cookeep.common.util;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Set;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.cookeep.cookeep.common.exception.AppException;
+import com.cookeep.cookeep.common.exception.ErrorCode;
+
+@Component
+public class SvgValidator {
+
+	private static final Set<String> SVG_ALLOWED_FOLDERS = Set.of(
+		ImageFolder.INGREDIENTS.getFolderName()
+	);
+
+	public void validate(MultipartFile file, String folder) {
+		validateFolder(folder);
+		validateContentType(file);
+		validateContent(file);
+	}
+
+	private void validateFolder(String folder) {
+		if (!SVG_ALLOWED_FOLDERS.contains(folder)) {
+			throw new AppException(ErrorCode.FILE_UPLOAD_ERROR);
+		}
+	}
+
+	private void validateContentType(MultipartFile file) {
+		if (!"image/svg+xml".equalsIgnoreCase(file.getContentType())) {
+			throw new AppException(ErrorCode.FILE_UPLOAD_ERROR);
+		}
+	}
+
+	private void validateContent(MultipartFile file) {
+		try {
+			String svg = new String(file.getBytes(), StandardCharsets.UTF_8).toLowerCase();
+
+			if (svg.contains("<script")
+				|| svg.contains("onload=")
+				|| svg.contains("onclick=")
+				|| svg.contains("<foreignobject")) {
+				throw new AppException(ErrorCode.FILE_UPLOAD_ERROR);
+			}
+		} catch (AppException e) {
+			throw e;
+		} catch (Exception e) {
+			throw new AppException(ErrorCode.FILE_UPLOAD_ERROR);
+		}
+	}
+}

--- a/src/main/java/com/cookeep/cookeep/common/util/SvgValidator.java
+++ b/src/main/java/com/cookeep/cookeep/common/util/SvgValidator.java
@@ -1,12 +1,17 @@
 package com.cookeep.cookeep.common.util;
 
+import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Set;
 
-import org.owasp.html.HtmlPolicyBuilder;
-import org.owasp.html.PolicyFactory;
+import javax.xml.parsers.DocumentBuilderFactory;
+
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
+import org.w3c.dom.Document;
+import org.w3c.dom.NamedNodeMap;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
 
 import com.cookeep.cookeep.common.exception.AppException;
 import com.cookeep.cookeep.common.exception.ErrorCode;
@@ -18,24 +23,23 @@ public class SvgValidator {
 		ImageFolder.INGREDIENTS.getFolderName()
 	);
 
-	// 안전한 SVG 태그·속성만 허용하는 화이트리스트 정책
-	private static final PolicyFactory SVG_POLICY = new HtmlPolicyBuilder()
-		.allowElements(
-			"svg", "g", "path", "circle", "rect", "line", "polyline", "polygon",
-			"ellipse", "text", "tspan", "defs", "use", "symbol", "clipPath",
-			"linearGradient", "radialGradient", "stop", "mask", "pattern",
-			"image", "title", "desc"
-		)
-		.allowAttributes(
-			"xmlns", "viewBox", "width", "height", "x", "y", "x1", "y1", "x2", "y2",
-			"cx", "cy", "r", "rx", "ry", "d", "fill", "stroke", "stroke-width",
-			"stroke-linecap", "stroke-linejoin", "opacity", "transform",
-			"clip-path", "mask", "id", "class", "style",
-			"offset", "stop-color", "stop-opacity",
-			"gradientUnits", "gradientTransform", "patternUnits",
-			"font-size", "font-family", "text-anchor"
-		).globally()
-		.toFactory();
+	private static final Set<String> ALLOWED_ELEMENTS = Set.of(
+		"svg", "g", "path", "circle", "rect", "line", "polyline", "polygon",
+		"ellipse", "text", "tspan", "defs", "use", "symbol", "clippath",
+		"lineargradient", "radialgradient", "stop", "mask", "pattern",
+		"image", "title", "desc"
+	);
+
+	private static final Set<String> ALLOWED_ATTRIBUTES = Set.of(
+		"xmlns", "viewbox", "width", "height", "x", "y", "x1", "y1", "x2", "y2",
+		"cx", "cy", "r", "rx", "ry", "d", "fill", "stroke", "stroke-width",
+		"stroke-linecap", "stroke-linejoin", "opacity", "transform",
+		"clip-path", "mask", "id", "class", "style",
+		"offset", "stop-color", "stop-opacity",
+		"gradientunits", "gradienttransform", "patternunits",
+		"font-size", "font-family", "text-anchor",
+		"href", "xlink:href"
+	);
 
 	public void validate(MultipartFile file, String folder) {
 		validateFolder(folder);
@@ -57,16 +61,52 @@ public class SvgValidator {
 
 	private void validateContent(MultipartFile file) {
 		try {
-			String original = new String(file.getBytes(), StandardCharsets.UTF_8);
-			String sanitized = SVG_POLICY.sanitize(original);
+			byte[] bytes = file.getBytes();
+			String content = new String(bytes, StandardCharsets.UTF_8).toLowerCase();
 
-			if (!original.equals(sanitized)) {
-				throw new AppException(ErrorCode.FILE_UPLOAD_ERROR);
-			}
+			DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+			// XXE 방어
+			factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+			factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+			factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+
+			Document doc = factory.newDocumentBuilder()
+				.parse(new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8)));
+
+			validateNode(doc.getDocumentElement());
 		} catch (AppException e) {
 			throw e;
 		} catch (Exception e) {
 			throw new AppException(ErrorCode.FILE_UPLOAD_ERROR);
+		}
+	}
+
+	private void validateNode(Node node) {
+		if (node.getNodeType() != Node.ELEMENT_NODE) {
+			return;
+		}
+
+		String tagName = node.getLocalName() != null
+			? node.getLocalName().toLowerCase()
+			: node.getNodeName().toLowerCase();
+
+		if (!ALLOWED_ELEMENTS.contains(tagName)) {
+			throw new AppException(ErrorCode.FILE_UPLOAD_ERROR);
+		}
+
+		NamedNodeMap attrs = node.getAttributes();
+		if (attrs != null) {
+			for (int i = 0; i < attrs.getLength(); i++) {
+				String attrName = attrs.item(i).getNodeName().toLowerCase();
+				if (!ALLOWED_ATTRIBUTES.contains(attrName)) {
+					throw new AppException(ErrorCode.FILE_UPLOAD_ERROR);
+				}
+			}
+		}
+
+		NodeList children = node.getChildNodes();
+		for (int i = 0; i < children.getLength(); i++) {
+			validateNode(children.item(i));
 		}
 	}
 }

--- a/src/main/java/com/cookeep/cookeep/common/util/SvgValidator.java
+++ b/src/main/java/com/cookeep/cookeep/common/util/SvgValidator.java
@@ -3,6 +3,8 @@ package com.cookeep.cookeep.common.util;
 import java.nio.charset.StandardCharsets;
 import java.util.Set;
 
+import org.owasp.html.HtmlPolicyBuilder;
+import org.owasp.html.PolicyFactory;
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -15,6 +17,25 @@ public class SvgValidator {
 	private static final Set<String> SVG_ALLOWED_FOLDERS = Set.of(
 		ImageFolder.INGREDIENTS.getFolderName()
 	);
+
+	// 안전한 SVG 태그·속성만 허용하는 화이트리스트 정책
+	private static final PolicyFactory SVG_POLICY = new HtmlPolicyBuilder()
+		.allowElements(
+			"svg", "g", "path", "circle", "rect", "line", "polyline", "polygon",
+			"ellipse", "text", "tspan", "defs", "use", "symbol", "clipPath",
+			"linearGradient", "radialGradient", "stop", "mask", "pattern",
+			"image", "title", "desc"
+		)
+		.allowAttributes(
+			"xmlns", "viewBox", "width", "height", "x", "y", "x1", "y1", "x2", "y2",
+			"cx", "cy", "r", "rx", "ry", "d", "fill", "stroke", "stroke-width",
+			"stroke-linecap", "stroke-linejoin", "opacity", "transform",
+			"clip-path", "mask", "id", "class", "style",
+			"offset", "stop-color", "stop-opacity",
+			"gradientUnits", "gradientTransform", "patternUnits",
+			"font-size", "font-family", "text-anchor"
+		).globally()
+		.toFactory();
 
 	public void validate(MultipartFile file, String folder) {
 		validateFolder(folder);
@@ -36,12 +57,10 @@ public class SvgValidator {
 
 	private void validateContent(MultipartFile file) {
 		try {
-			String svg = new String(file.getBytes(), StandardCharsets.UTF_8).toLowerCase();
+			String original = new String(file.getBytes(), StandardCharsets.UTF_8);
+			String sanitized = SVG_POLICY.sanitize(original);
 
-			if (svg.contains("<script")
-				|| svg.contains("onload=")
-				|| svg.contains("onclick=")
-				|| svg.contains("<foreignobject")) {
+			if (!original.equals(sanitized)) {
 				throw new AppException(ErrorCode.FILE_UPLOAD_ERROR);
 			}
 		} catch (AppException e) {

--- a/src/main/java/com/cookeep/cookeep/domain/dailyrecipe/application/DailyRecipeService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/dailyrecipe/application/DailyRecipeService.java
@@ -63,7 +63,7 @@ public class DailyRecipeService {
 
     // 데일리 레시피 등록
     public DailyRecipeResult createDailyRecipe(Long userId, Long aiRecipeId, String title,
-                                               String description, String recipeImageUrl, Boolean isPublic) {
+                                               String description, String recipeImageUrl, String croppedImageUrl, Boolean isPublic) {
         User user = userReader.readById(userId);
 
         AiRecipe aiRecipe = aiRecipeRepository.findById(aiRecipeId)
@@ -87,6 +87,7 @@ public class DailyRecipeService {
                 .description(description)
                 .content(content)
                 .recipeImageUrl(recipeImageUrl)
+                .croppedImageUrl(croppedImageUrl)
                 .isPublic(isPublic != null ? isPublic : false)
                 .photoRewardCompleted(hasPhoto)
                 .user(user)
@@ -131,7 +132,7 @@ public class DailyRecipeService {
 
     // 데일리 레시피 수정 (제목, 한줄평, 사진)
     public DailyRecipeResult updateDailyRecipe(Long userId, Long dailyRecipeId, String title, String description,
-                                               String recipeImageUrl, Boolean deleteRecipeImage) {
+                                               String recipeImageUrl, String croppedImageUrl, Boolean deleteRecipeImage) {
         boolean isDeleteImage = Boolean.TRUE.equals(deleteRecipeImage);
 
         if ((title == null || title.isBlank())
@@ -151,9 +152,15 @@ public class DailyRecipeService {
                 .orElseThrow(() -> new AppException(ErrorCode.DAILY_RECIPE_NOT_FOUND));
 
         // 사진 삭제 요청: S3 삭제 후 DB null 업데이트
-        if (isDeleteImage && dailyRecipe.getRecipeImageUrl() != null) {
-            s3Service.delete(dailyRecipe.getRecipeImageUrl());
-            dailyRecipe.updateRecipeImageUrl(null);
+        if (isDeleteImage) {
+            if (dailyRecipe.getRecipeImageUrl() != null) {
+                s3Service.delete(dailyRecipe.getRecipeImageUrl());
+                dailyRecipe.updateRecipeImageUrl(null);
+            }
+            if (dailyRecipe.getCroppedImageUrl() != null) {
+                s3Service.delete(dailyRecipe.getCroppedImageUrl());
+                dailyRecipe.updateCroppedImageUrl(null);
+            }
         }
 
         if (title != null) {
@@ -171,6 +178,7 @@ public class DailyRecipeService {
                 throw new AppException(ErrorCode.DAILY_RECIPE_IMAGE_SAME_URL);
             }
             dailyRecipe.updateRecipeImageUrl(recipeImageUrl);
+            dailyRecipe.updateCroppedImageUrl(croppedImageUrl);
             if (!dailyRecipe.isPhotoRewardCompleted()) {
                 dailyRecipe.markPhotoRewardCompleted();
                 cookieService.updateCookie(userId, CookieLog.CookieLogType.BASIC_FOOD_PHOTO_REG);

--- a/src/main/java/com/cookeep/cookeep/domain/dailyrecipe/entity/DailyRecipe.java
+++ b/src/main/java/com/cookeep/cookeep/domain/dailyrecipe/entity/DailyRecipe.java
@@ -36,6 +36,9 @@ public class DailyRecipe extends BaseEntity {
     @Column(name = "recipe_image_url", length = 512)
     private String recipeImageUrl;
 
+    @Column(name = "cropped_image_url", length = 512)
+    private String croppedImageUrl;
+
     @Builder.Default
     @Column(name = "is_public", nullable = false)
     private Boolean isPublic = false;
@@ -70,6 +73,10 @@ public class DailyRecipe extends BaseEntity {
 
     public void updateRecipeImageUrl(String recipeImageUrl) {
         this.recipeImageUrl = recipeImageUrl;
+    }
+
+    public void updateCroppedImageUrl(String croppedImageUrl) {
+        this.croppedImageUrl = croppedImageUrl;
     }
 
     public void markPhotoRewardCompleted() {

--- a/src/main/resources/db/migration/V7__add_cropped_image_url_to_daily_recipes.sql
+++ b/src/main/resources/db/migration/V7__add_cropped_image_url_to_daily_recipes.sql
@@ -1,0 +1,2 @@
+ALTER TABLE daily_recipes
+    ADD COLUMN cropped_image_url VARCHAR(512) NULL;


### PR DESCRIPTION
# Related Issue
CLOSE #286 

# Description

사용자가 업로드한 요리 사진을 크롭하여 미리보기로 보여주고, 원본 사진은 전체보기로 확인할 수 있는 기능을 추가합니다.

1. `POST /api/images` 호출 시 크롭 좌표를 함께 전달하면 서버에서 크롭 이미지를 생성해 S3에 저장하고, 원본 URL(`imageUrl`)과 크롭 URL(`croppedImageUrl`)을 모두 반환합니다. 
2. 클라이언트는 두 URL을 레시피 등록/수정 시 함께 전달하며, 이후 조회 응답에서도 두 URL을 모두 받아 미리보기/전체보기 전환에 활용합니다.

또한 기존 S3Service의 비대한 책임을 `S3Uploader`, `ImageCropService`, `SvgValidator`로 분리하여 단일 책임 원칙을 적용하였습니다.

# Change

**이미지 업로드 API**
- `POST /api/images`에 `cropX`, `cropY`, `cropWidth`, `cropHeight` 쿼리 파라미터 추가 (선택)
- 4개 파라미터가 모두 전달된 경우 크롭 이미지를 S3에 추가 업로드
- 응답에 `croppedImageUrl` 필드 추가

**데일리 레시피**
- `daily_recipes` 테이블에 `cropped_image_url` 컬럼 추가 (V7 마이그레이션)
- `DailyRecipe` 엔티티에 `croppedImageUrl` 필드 및 `updateCroppedImageUrl()` 추가
- 레시피 생성/수정 요청 DTO에 `croppedImageUrl` 필드 추가
- 레시피 이미지 삭제 시 크롭 이미지도 S3에서 함께 삭제
- 상세 조회, 목록 조회, 수정 응답 DTO에 `croppedImageUrl` 포함

**리팩토링**
- `S3Service`를 파사드로 변경, 내부 책임을 세 클래스로 분리
  - `S3Uploader`: S3 업로드/삭제 전담
  - `ImageCropService`: Thumbnailator 기반 이미지 크롭 전담
  - `SvgValidator`: SVG 보안 검증 전담

# Test
- [x] Swagger 내에서 `POST /api/images`호출 통해 크롭 이미지, 원본 이미지 정상 반환되는 것 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 이미지 업로드 시 크롭 영역(cropX/Y/Width/Height)을 선택하면 미리보기용 크롭 이미지 URL을 함께 제공합니다.
  * 데일리 레시피 등록/수정/목록/상세/응답에 원본 이미지와 크롭된 이미지 URL(`croppedImageUrl`)이 모두 포함됩니다.
  * 크롭 이미지가 데일리 레시피에 저장되어 화면에서 더 선명한 이미지를 표시합니다.
* **버그 수정**
  * 이미지 삭제/교체 시 원본과 크롭 이미지가 함께 정리됩니다.
  * 크롭 영역이 유효하지 않으면 요청 오류로 안내합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->