### PR TITLE
[COOKEEP-50] ci: develop 브랜치 dev 서버 자동 배포 파이프라인 추가

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,11 +2,12 @@ name: CI/CD Pipeline
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, develop ]
   workflow_dispatch:
 
 jobs:
   build-and-deploy:
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
 
     steps:
@@ -89,4 +90,97 @@ jobs:
               -e EMAIL_USERNAME=${{ secrets.EMAIL_USERNAME }} \
               -e EMAIL_PASSWORD=${{ secrets.EMAIL_PASSWORD }} \
               ${{ secrets.DOCKER_USERNAME }}/cookeep:latest
+            docker image prune -f
+
+  build-and-deploy-dev:
+    if: github.ref == 'refs/heads/develop'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Build with Gradle
+        run: ./gradlew bootJar
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Build and push Docker image (ARM64)
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          platforms: linux/arm64
+          tags: ${{ secrets.DOCKER_USERNAME }}/cookeep:dev
+
+      - name: Deploy to Dev Server
+        uses: appleboy/ssh-action@v1.2.0
+        with:
+          host: ${{ secrets.DEV_SERVER_HOST }}
+          username: ubuntu
+          key: ${{ secrets.DEV_SERVER_SSH_KEY }}
+          script: |
+            docker pull ${{ secrets.DOCKER_USERNAME }}/cookeep:dev
+            docker network create cookeep-network 2>/dev/null || true
+            docker run -d \
+              --name cookeep-redis \
+              --network cookeep-network \
+              --restart unless-stopped \
+              -v redis-data:/data \
+              redis:7.2-alpine \
+              redis-server --appendonly yes --requirepass ${{ secrets.REDIS_PASSWORD }} \
+              2>/dev/null || true
+            docker stop cookeep || true
+            docker rm cookeep || true
+            docker run -d \
+              --name cookeep \
+              --network cookeep-network \
+              -p 8080:8080 \
+              -e TZ=Asia/Seoul \
+              -e REDIS_HOST=cookeep-redis \
+              -e REDIS_PORT=6379 \
+              -e REDIS_PASSWORD=${{ secrets.REDIS_PASSWORD }} \
+              -e DB_URL=${{ secrets.DEV_DB_URL }} \
+              -e DB_USERNAME=${{ secrets.DEV_DB_USERNAME }} \
+              -e DB_PASSWORD=${{ secrets.DEV_DB_PASSWORD }} \
+              -e KAKAO_CLIENT_ID=${{ secrets.KAKAO_CLIENT_ID }} \
+              -e KAKAO_CLIENT_SECRET=${{ secrets.KAKAO_CLIENT_SECRET }} \
+              -e KAKAO_REDIRECT_URI=${{ secrets.DEV_KAKAO_REDIRECT_URI }} \
+              -e GOOGLE_CLIENT_ID=${{ secrets.GOOGLE_CLIENT_ID }} \
+              -e GOOGLE_CLIENT_SECRET=${{ secrets.GOOGLE_CLIENT_SECRET }} \
+              -e GOOGLE_REDIRECT_URI=${{ secrets.GOOGLE_REDIRECT_URI }} \
+              -e JWT_ACCESS_SECRET_KEY=${{ secrets.JWT_ACCESS_SECRET_KEY }} \
+              -e JWT_REFRESH_SECRET_KEY=${{ secrets.JWT_REFRESH_SECRET_KEY }} \
+              -e GEMINI_API_KEY=${{ secrets.GEMINI_API_KEY }} \
+              -e YOUTUBE_API_KEY=${{ secrets.YOUTUBE_API_KEY }} \
+              -e AWS_ACCESS_KEY=${{ secrets.AWS_ACCESS_KEY }} \
+              -e AWS_SECRET_KEY=${{ secrets.AWS_SECRET_KEY }} \
+              -e S3_BUCKET_NAME=${{ secrets.S3_BUCKET_NAME }} \
+              -e SMS_KEY=${{ secrets.SMS_KEY }} \
+              -e SMS_SECRET=${{ secrets.SMS_SECRET }} \
+              -e SMS_SENDER=${{ secrets.SMS_SENDER }} \
+              -e VAPID_PUBLIC_KEY=${{ secrets.VAPID_PUBLIC_KEY }} \
+              -e VAPID_PRIVATE_KEY=${{ secrets.VAPID_PRIVATE_KEY }} \
+              -e EMAIL_USERNAME=${{ secrets.EMAIL_USERNAME }} \
+              -e EMAIL_PASSWORD=${{ secrets.EMAIL_PASSWORD }} \
+              ${{ secrets.DOCKER_USERNAME }}/cookeep:dev
             docker image prune -f


### PR DESCRIPTION
# Description
API 스펙 변경으로 인해 개발용/운영용 서버를 분리했습니다.
`develop` 브랜치에 push 시 Oracle Cloud dev 서버에 자동 배포되는 CI/CD 파이프라인을 추가합니다.

# Changes
## 변경 사항
- `develop` 브랜치 push 트리거 추가
- ARM64 Docker 이미지 빌드 및 `cookeep:dev` 태그로 push
- Oracle Cloud 인스턴스(일본 오사카)에 자동 배포
- dev 환경 전용 DB, OAuth Redirect URI Secret 분리

## 인프라 구성
- **Dev 서버**: Oracle Cloud Free Tier (VM.Standard.A1.Flex, 2 OCPU / 12GB RAM)
- **Dev DB**: Oracle Cloud 인스턴스 내 MySQL (cookeep_dev)
- **소셜 로그인**: 카카오만 지원 

## 추가된 GitHub Secrets
- `DEV_SERVER_HOST`, `DEV_SERVER_SSH_KEY`
- `DEV_DB_URL`, `DEV_DB_USERNAME`, `DEV_DB_PASSWORD`
- `DEV_KAKAO_REDIRECT_URI`

## 참고사항
신속한 서버 구축 확인을 위해 우선 리뷰 없이 병합하겠습니다. 확인 후 코멘트 남겨주시면 감사하겠습니다! (cc. @chwwwon)