### PR TITLE
[COOKEEP-60] 동일 이메일 중복 소셜 로그인 시 user_auths 중복 생성 버그 수정

### DIFF
--- a/src/main/java/com/cookeep/cookeep/common/exception/ErrorCode.java
+++ b/src/main/java/com/cookeep/cookeep/common/exception/ErrorCode.java
@@ -85,6 +85,7 @@ public enum ErrorCode {
 	SAME_AS_PREVIOUS_PASSWORD(HttpStatus.BAD_REQUEST, "기존 등록된 비밀번호와 동일한 비밀번호입니다.", "AUTH-005"),
 	PASSWORD_MISMATCH(HttpStatus.BAD_REQUEST, "현재 비밀번호가 일치하지 않습니다.", "AUTH-006"),
 	REGISTERED_EMAIL_MISMATCH(HttpStatus.BAD_REQUEST, "회원정보에 등록된 이메일과 일치하지 않습니다.", "AUTH-008"),
+	SOCIAL_EMAIL_NOT_PROVIDED(HttpStatus.BAD_REQUEST, "소셜 계정에서 이메일 정보를 가져올 수 없습니다.", "AUTH-010"),
 
 	// USER
 	SAME_AS_CURRENT_PHONE_NUMBER(HttpStatus.BAD_REQUEST, "기존 등록된 전화번호와 동일한 전화번호입니다.", "USER-007"),

--- a/src/main/java/com/cookeep/cookeep/domain/user/application/AuthService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/user/application/AuthService.java
@@ -193,7 +193,7 @@ public class AuthService {
 
 
 				if (existingUser.isPresent()) {
-					// 이미 다른 provider로 가입된 유저 → UserAuth 추가 없이 기존 유저로 로그인
+					// 해당 provider의 UserAuth가 없으면 기존 유저에 연결 생성
 					User user = existingUser.get();
 					return userAuthRepository.findByProviderAndUser(provider, user)
 							.orElseGet(() -> userAuthRepository.save(

--- a/src/main/java/com/cookeep/cookeep/domain/user/application/AuthService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/user/application/AuthService.java
@@ -188,6 +188,32 @@ public class AuthService {
 		// 신규 유저일 경우 User, UserAuth값을 새롭게 생성함
 		UserAuth userAuth = existingUserAuth
 			.orElseGet(() -> {
+
+				Optional<User> existingUser = userRepository.findByEmail(email);
+
+
+				if (existingUser.isPresent()) {
+					// 이미 다른 provider로 가입된 유저 → UserAuth 추가 없이 기존 유저로 로그인
+					User user = existingUser.get();
+					return userAuthRepository.findByProviderAndUser(provider, user)
+							.orElseGet(() -> userAuthRepository.save(
+									UserAuth.builder()
+											.user(user)
+											.provider(provider)
+											.providerUserId(socialId)
+											.build()));
+				}
+
+				// 완전히 신규 유저만 user + userAuth 모두 생성
+				User newUser = createSocialUser(email);
+				return userAuthRepository.save(
+						UserAuth.builder()
+								.user(newUser)
+								.provider(provider)
+								.providerUserId(socialId)
+								.build());
+
+				/*
 				// 동일한 이메일로 가입된 User가 존재하는지 확인
 				// 존재하지 않을 경우 새로운 유저 생성
 				User user = userRepository.findByEmail(email)
@@ -200,6 +226,8 @@ public class AuthService {
 						.provider(provider)
 						.providerUserId(socialId)
 						.build());
+
+				 */
 			});
 
 		User user = userAuth.getUser();

--- a/src/main/java/com/cookeep/cookeep/domain/user/application/KakaoOAuthProvider.java
+++ b/src/main/java/com/cookeep/cookeep/domain/user/application/KakaoOAuthProvider.java
@@ -1,5 +1,7 @@
 package com.cookeep.cookeep.domain.user.application;
 
+import com.cookeep.cookeep.common.exception.AppException;
+import com.cookeep.cookeep.common.exception.ErrorCode;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatusCode;
@@ -80,6 +82,13 @@ public class KakaoOAuthProvider implements OAuthProvider {
 			.retrieve()
 			.bodyToMono(KakaoUserInfoResponseDTO.class)
 			.block();
+
+		String email = kakaoUserInfo.kakaoAccount().email();
+		Boolean isEmailVerified = kakaoUserInfo.kakaoAccount().isEmailVerified();
+
+		if (email == null || Boolean.FALSE.equals(isEmailVerified)) {
+			throw new AppException(ErrorCode.SOCIAL_EMAIL_NOT_PROVIDED);
+		}
 
 		return new OAuthUserInfoDTO(
 			String.valueOf(kakaoUserInfo.id()),

--- a/src/main/java/com/cookeep/cookeep/domain/user/application/KakaoOAuthProvider.java
+++ b/src/main/java/com/cookeep/cookeep/domain/user/application/KakaoOAuthProvider.java
@@ -85,8 +85,9 @@ public class KakaoOAuthProvider implements OAuthProvider {
 
 		String email = kakaoUserInfo.kakaoAccount().email();
 		Boolean isEmailVerified = kakaoUserInfo.kakaoAccount().isEmailVerified();
+		Boolean isEmailValid = kakaoUserInfo.kakaoAccount().isEmailValid();
 
-		if (email == null || Boolean.FALSE.equals(isEmailVerified)) {
+		if (email == null || !Boolean.TRUE.equals(isEmailVerified) || !Boolean.TRUE.equals(isEmailValid)) {
 			throw new AppException(ErrorCode.SOCIAL_EMAIL_NOT_PROVIDED);
 		}
 

--- a/src/main/java/com/cookeep/cookeep/domain/user/dao/UserAuthRepository.java
+++ b/src/main/java/com/cookeep/cookeep/domain/user/dao/UserAuthRepository.java
@@ -18,4 +18,6 @@ public interface UserAuthRepository extends JpaRepository<UserAuth, Long> {
 
 	@Query("select ua.provider from UserAuth ua where ua.user.userId = :userId")
 	Provider findProviderByUserId(@Param("userId") Long userId);
+
+	Optional<UserAuth> findByProviderAndUser(Provider provider, User user);
 }

--- a/src/main/java/com/cookeep/cookeep/domain/user/dto/KakaoUserInfoResponseDTO.java
+++ b/src/main/java/com/cookeep/cookeep/domain/user/dto/KakaoUserInfoResponseDTO.java
@@ -18,6 +18,9 @@ public record KakaoUserInfoResponseDTO(
 		String email,
 
 		@JsonProperty("is_email_verified")
-				Boolean isEmailVerified
+		Boolean isEmailVerified,
+
+		@JsonProperty("is_email_valid")
+		Boolean isEmailValid
 	) {}
 }

--- a/src/main/java/com/cookeep/cookeep/domain/user/dto/KakaoUserInfoResponseDTO.java
+++ b/src/main/java/com/cookeep/cookeep/domain/user/dto/KakaoUserInfoResponseDTO.java
@@ -15,6 +15,9 @@ public record KakaoUserInfoResponseDTO(
 	@JsonIgnoreProperties(ignoreUnknown = true)
 	public record KakaoAccount(
 		@JsonProperty("email")
-		String email
+		String email,
+
+		@JsonProperty("is_email_verified")
+				Boolean isEmailVerified
 	) {}
 }

--- a/src/main/resources/db/migration/V7__add_unique_constraint.sql
+++ b/src/main/resources/db/migration/V7__add_unique_constraint.sql
@@ -1,0 +1,4 @@
+-- src/main/resources/db/migration/V7__add_unique_constraint.sql
+
+ALTER TABLE user_auths
+    ADD CONSTRAINT uq_user_provider UNIQUE (user_id, provider);


### PR DESCRIPTION
# Issue
#290 

# 문제
동일 이메일로 로컬 회원가입 후 소셜 로그인(구글/카카오) 시, 기존 유저에 UserAuth가 추가되는 게 아니라 동일한 user_id에 새로운 UserAuth 레코드가 중복 생성되는 버그 존재
→ findProviderByUserId가 단일 결과를 기대하는데 2개가 반환되어 환경설정 화면 진입 시 IncorrectResultSizeDataAccessException 발생 (500 에러)

# 원인
socialLogin()에서 동일 이메일의 기존 유저를 찾은 경우에도 findByProviderAndUser 체크 없이 UserAuth를 무조건 INSERT하고 있었음

# Changes
- DB: 중복 생성된 user_auths 레코드 삭제 (공용 계정 외 영향 유저 4명)
- AuthService: socialLogin() 내 기존 유저 존재 시 findByProviderAndUser로 UserAuth 중복 여부를 먼저 확인 후 없을 때만 INSERT하도록 수정
- UserAuthRepository: findByProviderAndUser(Provider, User) 메서드 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 소셜 로그인 시 이메일이 없거나 검증되지 않은 계정은 명확한 오류로 처리되도록 개선했습니다.
  * 동일한 소셜 계정으로 반복 로그인할 때 기존 연결 정보를 재사용해 중복 처리를 줄였습니다.
  * 동일 이메일의 기존 계정이 있으면 새 계정 생성 대신 기존 계정과 소셜 연결을 이어가도록 변경했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->