### PR TITLE
COOKEEP-61 프로필 이미지 변경 기능 구현

### DIFF
--- a/src/main/java/com/cookeep/cookeep/api/controller/ProfileImageController.java
+++ b/src/main/java/com/cookeep/cookeep/api/controller/ProfileImageController.java
@@ -5,6 +5,7 @@ import com.cookeep.cookeep.api.dto.response.ProfileImageListResponseDto;
 import com.cookeep.cookeep.common.dto.DataResponse;
 import com.cookeep.cookeep.common.exception.ErrorCode;
 import com.cookeep.cookeep.config.ApiErrorCodeExamples;
+import com.cookeep.cookeep.domain.user.application.ProfileImageService;
 import com.cookeep.cookeep.domain.user.application.UserInfoService;
 import com.cookeep.cookeep.security.UserPrincipal;
 import io.swagger.v3.oas.annotations.Operation;
@@ -23,10 +24,12 @@ import org.springframework.web.bind.annotation.RestController;
 public class ProfileImageController {
 
     private final UserInfoService userInfoService;
+    private final ProfileImageService profileImageService;
 
     @Operation(summary = "프로필 이미지 목록 조회", description = "선택 가능한 프리셋 프로필 이미지 6종을 조회합니다.")
     @ApiErrorCodeExamples({
             ErrorCode.UNAUTHORIZED,
+            ErrorCode.USER_NOT_FOUND,
             ErrorCode.INTERNAL_SERVER_ERROR
     })
     @GetMapping("/profile-images")
@@ -34,6 +37,6 @@ public class ProfileImageController {
             @AuthenticationPrincipal UserPrincipal principal
     ) {
         Long userId = principal.userId();
-        return ResponseEntity.ok(DataResponse.from(userInfoService.getProfileImages(userId)));
+        return ResponseEntity.ok(DataResponse.from(profileImageService.getProfileImages(userId)));
     }
 }

--- a/src/main/java/com/cookeep/cookeep/api/controller/ProfileImageController.java
+++ b/src/main/java/com/cookeep/cookeep/api/controller/ProfileImageController.java
@@ -1,0 +1,39 @@
+package com.cookeep.cookeep.api.controller;
+
+
+import com.cookeep.cookeep.api.dto.response.ProfileImageListResponseDto;
+import com.cookeep.cookeep.common.dto.DataResponse;
+import com.cookeep.cookeep.common.exception.ErrorCode;
+import com.cookeep.cookeep.config.ApiErrorCodeExamples;
+import com.cookeep.cookeep.domain.user.application.UserInfoService;
+import com.cookeep.cookeep.security.UserPrincipal;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "프로필 이미지", description = "프로필 이미지 목록 관리 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/users")
+public class ProfileImageController {
+
+    private final UserInfoService userInfoService;
+
+    @Operation(summary = "프로필 이미지 목록 조회", description = "선택 가능한 프리셋 프로필 이미지 6종을 조회합니다.")
+    @ApiErrorCodeExamples({
+            ErrorCode.UNAUTHORIZED,
+            ErrorCode.INTERNAL_SERVER_ERROR
+    })
+    @GetMapping("/profile-images")
+    public ResponseEntity<DataResponse<ProfileImageListResponseDto>> getProfileImages(
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        Long userId = principal.userId();
+        return ResponseEntity.ok(DataResponse.from(userInfoService.getProfileImages(userId)));
+    }
+}

--- a/src/main/java/com/cookeep/cookeep/api/controller/UserInfoController.java
+++ b/src/main/java/com/cookeep/cookeep/api/controller/UserInfoController.java
@@ -2,6 +2,7 @@ package com.cookeep.cookeep.api.controller;
 
 import com.cookeep.cookeep.api.dto.request.*;
 import com.cookeep.cookeep.api.dto.response.DislikeIngredientResponseDto;
+import com.cookeep.cookeep.api.dto.response.ProfileImageListResponseDto;
 import com.cookeep.cookeep.api.dto.response.UserProfileResponseDTO;
 import com.cookeep.cookeep.common.dto.DataResponse;
 import com.cookeep.cookeep.common.exception.ErrorCode;
@@ -167,6 +168,22 @@ public class UserInfoController {
     ) {
         Long userId = principal.userId();
         userInfoService.updateDislikedIngredients(userId, requestDto);
+        return ResponseEntity.ok(DataResponse.ok());
+    }
+
+    @Operation(summary = "프로필 이미지 수정", description = "프리셋 프로필 이미지 6종 중 하나로 프로필 이미지를 변경합니다.")
+    @ApiErrorCodeExamples({
+            ErrorCode.UNAUTHORIZED,
+            ErrorCode.USER_NOT_FOUND,
+            ErrorCode.INVALID_PROFILE_IMAGE_ID,
+            ErrorCode.INTERNAL_SERVER_ERROR
+    })
+    @PatchMapping("/profile-images")
+    public ResponseEntity<DataResponse<Void>> updateProfileImage(
+            @AuthenticationPrincipal(expression = "userId") Long userId,
+            @Valid @RequestBody ProfileImageUpdateRequestDto request
+    ) {
+        userInfoService.updateProfileImage(userId, request);
         return ResponseEntity.ok(DataResponse.ok());
     }
 }

--- a/src/main/java/com/cookeep/cookeep/api/dto/request/ProfileImageUpdateRequestDto.java
+++ b/src/main/java/com/cookeep/cookeep/api/dto/request/ProfileImageUpdateRequestDto.java
@@ -1,0 +1,9 @@
+package com.cookeep.cookeep.api.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+
+public record ProfileImageUpdateRequestDto(
+
+        @NotNull
+        Integer imageId
+) { }

--- a/src/main/java/com/cookeep/cookeep/api/dto/response/MyProfileResponseDto.java
+++ b/src/main/java/com/cookeep/cookeep/api/dto/response/MyProfileResponseDto.java
@@ -13,7 +13,7 @@ import java.time.temporal.ChronoUnit;
 @Builder
 public class MyProfileResponseDto {
     private String nickname;
-    private String profilePlantImageUrl;
+    private String profileImageUrl;
     private String growingPlantName;
     private Long daysSinceJoined;
     private WeeklyGoalDto weeklyGoal;
@@ -36,11 +36,11 @@ public class MyProfileResponseDto {
         }
     }
 
-    public static MyProfileResponseDto of(User user, WeeklyGoal weeklyGoal, String growingPlantName) {
-        String profileImageUrl = null;
-        if (user.getProfilePlant() != null) {
-            profileImageUrl = user.getProfilePlant().getCurrentImageUrl();
-        }
+    public static MyProfileResponseDto of(User user, WeeklyGoal weeklyGoal, String growingPlantName, String profileImageUrl) {
+//        String profileImageUrl = null;
+//        if (user.getProfilePlant() != null) {
+//            profileImageUrl = user.getProfilePlant().getCurrentImageUrl();
+//        }
 
         long daysSinceJoined = ChronoUnit.DAYS.between(
                 user.getCreatedAt().toLocalDate(),
@@ -49,7 +49,7 @@ public class MyProfileResponseDto {
 
         return MyProfileResponseDto.builder()
             .nickname(user.getNickname())
-            .profilePlantImageUrl(profileImageUrl)
+            .profileImageUrl(profileImageUrl)
             .growingPlantName(growingPlantName)
             .daysSinceJoined(daysSinceJoined)
             .weeklyGoal(weeklyGoal != null ? WeeklyGoalDto.from(weeklyGoal) : null)

--- a/src/main/java/com/cookeep/cookeep/api/dto/response/ProfileImageListResponseDto.java
+++ b/src/main/java/com/cookeep/cookeep/api/dto/response/ProfileImageListResponseDto.java
@@ -1,0 +1,8 @@
+package com.cookeep.cookeep.api.dto.response;
+
+import java.util.List;
+
+public record ProfileImageListResponseDto(
+
+        List<ProfileImageResponseDto> profileImages
+) { }

--- a/src/main/java/com/cookeep/cookeep/api/dto/response/ProfileImageResponseDto.java
+++ b/src/main/java/com/cookeep/cookeep/api/dto/response/ProfileImageResponseDto.java
@@ -1,0 +1,8 @@
+package com.cookeep.cookeep.api.dto.response;
+
+public record ProfileImageResponseDto(
+
+        int imageId,
+        String imageUrl
+
+) { }

--- a/src/main/java/com/cookeep/cookeep/api/dto/response/UserProfileResponseDTO.java
+++ b/src/main/java/com/cookeep/cookeep/api/dto/response/UserProfileResponseDTO.java
@@ -7,6 +7,7 @@ public record UserProfileResponseDTO(
 	String phoneNumber,
 	String email,
 	Provider authProvider,
-	Boolean marketingPush
+	Boolean marketingPush,
+	String profileImageUrl
 ) {
 }

--- a/src/main/java/com/cookeep/cookeep/common/exception/ErrorCode.java
+++ b/src/main/java/com/cookeep/cookeep/common/exception/ErrorCode.java
@@ -91,6 +91,7 @@ public enum ErrorCode {
 	// USER
 	SAME_AS_CURRENT_PHONE_NUMBER(HttpStatus.BAD_REQUEST, "기존 등록된 전화번호와 동일한 전화번호입니다.", "USER-007"),
 	SAME_AS_CURRENT_EMAIL(HttpStatus.BAD_REQUEST, "기존 등록된 이메일과 동일한 이메일입니다.", "USER-008"),
+	INVALID_PROFILE_IMAGE_ID(HttpStatus.BAD_REQUEST, "유효하지 않은 프로필 이미지 ID입니다.", "USER-010"),
 
 	// NOTIFICATION
 	INVALID_ENDPOINT(HttpStatus.BAD_REQUEST, "subscription endpoint 정보가 누락되었습니다.", "NOTIFICATION-001"),

--- a/src/main/java/com/cookeep/cookeep/common/util/ImageFolder.java
+++ b/src/main/java/com/cookeep/cookeep/common/util/ImageFolder.java
@@ -8,7 +8,8 @@ import lombok.RequiredArgsConstructor;
 public enum ImageFolder {
 	PLANTS("plants"),
 	RECIPE_IMAGES("recipeImages"),
-	INGREDIENTS("ingredients");
+	INGREDIENTS("ingredients"),
+	PROFILE_IMAGES("profileImages");
 
 	private final String folderName;
 

--- a/src/main/java/com/cookeep/cookeep/domain/cookeeps/application/RankingCacheService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/cookeeps/application/RankingCacheService.java
@@ -5,6 +5,7 @@ import com.cookeep.cookeep.api.dto.response.RankingResponseDto.WateringRankDto;
 import com.cookeep.cookeep.domain.dailyrecipe.dao.DailyRecipeRepository;
 import com.cookeep.cookeep.domain.dailyrecipe.entity.DailyRecipe;
 import com.cookeep.cookeep.domain.plant.dao.WateringLogRepository;
+import com.cookeep.cookeep.domain.user.application.ProfileImageService;
 import com.cookeep.cookeep.domain.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.CacheEvict;
@@ -24,6 +25,7 @@ public class RankingCacheService {
 
     private final WateringLogRepository wateringLogRepository;
     private final DailyRecipeRepository dailyRecipeRepository;
+    private final ProfileImageService profileImageService;
 
     @Cacheable(cacheNames = "wateringRanking", key = "#monthStart.toLocalDate().toString()")
     @Transactional(readOnly = true)
@@ -36,9 +38,11 @@ public class RankingCacheService {
                 Object[] row = results.get(index);
                 User user = (User) row[0];
                 Long wateringCount = (Long) row[1];
-                String profileImageUrl = user.getProfilePlant() != null
-                    ? user.getProfilePlant().getCurrentImageUrl()
-                    : null;
+//                String profileImageUrl = user.getProfilePlant() != null
+//                    ? user.getProfilePlant().getCurrentImageUrl()
+//                    : null;
+                String profileImageUrl = profileImageService.resolveUrl(user.getProfileImageId());
+
                 return WateringRankDto.builder()
                     .rank(index + 1)
                     .nickname(user.getNickname())

--- a/src/main/java/com/cookeep/cookeep/domain/mycookeep/application/MyCookeepService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/mycookeep/application/MyCookeepService.java
@@ -6,6 +6,7 @@ import com.cookeep.cookeep.common.exception.AppException;
 import com.cookeep.cookeep.common.exception.ErrorCode;
 import com.cookeep.cookeep.domain.onboarding.dao.WeeklyGoalRepository;
 import com.cookeep.cookeep.domain.onboarding.entity.WeeklyGoal;
+import com.cookeep.cookeep.domain.user.application.ProfileImageService;
 import com.cookeep.cookeep.domain.user.application.UserReader;
 import com.cookeep.cookeep.domain.user.entity.User;
 import com.cookeep.cookeep.domain.plant.dao.UserPlantRepository;
@@ -25,6 +26,7 @@ public class MyCookeepService {
     private final UserReader userReader;
     private final WeeklyGoalRepository weeklyGoalRepository;
     private final UserPlantRepository userPlantRepository;
+    private final ProfileImageService profileImageService;
 
     @Transactional(readOnly = true)
     public MyProfileResponseDto getProfile(Long userId) {
@@ -43,7 +45,9 @@ public class MyCookeepService {
             .map(userPlant -> userPlant.getPlant().getPlantType().getDisplayName())
             .orElse(null);
 
-        return MyProfileResponseDto.of(user, weeklyGoal, growingPlantName);
+        String profileImageUrl = profileImageService.resolveUrl(user.getProfileImageId());
+
+        return MyProfileResponseDto.of(user, weeklyGoal, growingPlantName, profileImageUrl);
     }
 
     public void setWeeklyGoal(Long userId, WeeklyGoalRequestDto request) {

--- a/src/main/java/com/cookeep/cookeep/domain/user/application/ProfileImageService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/user/application/ProfileImageService.java
@@ -1,14 +1,22 @@
 package com.cookeep.cookeep.domain.user.application;
 
+import com.cookeep.cookeep.api.dto.response.ProfileImageListResponseDto;
+import com.cookeep.cookeep.api.dto.response.ProfileImageResponseDto;
 import com.cookeep.cookeep.common.util.ImageFolder;
 import com.cookeep.cookeep.domain.user.entity.ProfileImages;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Arrays;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class ProfileImageService {
+
+    private final UserReader userReader;
 
     @Value("${aws.s3.bucket}")
     private String bucket;
@@ -21,5 +29,17 @@ public class ProfileImageService {
         String folder = ImageFolder.PROFILE_IMAGES.getFolderName();
         return String.format("https://%s.s3.%s.amazonaws.com/%s/%s",
                 bucket, region, folder, image.getFileName());
+    }
+
+    @Transactional(readOnly = true)
+    public ProfileImageListResponseDto getProfileImages(Long userId) {
+        // 유저 존재 검증 (탈퇴/유효하지 않은 유저 필터링)
+        userReader.readById(userId);
+
+        List<ProfileImageResponseDto> images = Arrays.stream(ProfileImages.values())
+                .map(p -> new ProfileImageResponseDto(p.getImageId(), resolveUrl(p.getImageId())))
+                .toList();
+
+        return new ProfileImageListResponseDto(images);
     }
 }

--- a/src/main/java/com/cookeep/cookeep/domain/user/application/ProfileImageService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/user/application/ProfileImageService.java
@@ -1,0 +1,25 @@
+package com.cookeep.cookeep.domain.user.application;
+
+import com.cookeep.cookeep.common.util.ImageFolder;
+import com.cookeep.cookeep.domain.user.entity.ProfileImages;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ProfileImageService {
+
+    @Value("${aws.s3.bucket}")
+    private String bucket;
+
+    @Value("${aws.s3.region}")
+    private String region;
+
+    public String resolveUrl(int imageId) {
+        ProfileImages image = ProfileImages.fromId(imageId);
+        String folder = ImageFolder.PROFILE_IMAGES.getFolderName();
+        return String.format("https://%s.s3.%s.amazonaws.com/%s/%s",
+                bucket, region, folder, image.getFileName());
+    }
+}

--- a/src/main/java/com/cookeep/cookeep/domain/user/application/UserInfoService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/user/application/UserInfoService.java
@@ -257,18 +257,6 @@ public class UserInfoService {
         user.updateDislikedIngredients(requestDto.getDislikedIngredients());
     }
 
-    @Transactional(readOnly = true)
-    public ProfileImageListResponseDto getProfileImages(Long userId) {
-        // 유저 존재 검증 (탈퇴/유효하지 않은 유저 필터링)
-        userReader.readById(userId);
-
-        List<ProfileImageResponseDto> images = Arrays.stream(ProfileImages.values())
-                .map(p -> new ProfileImageResponseDto(p.getImageId(), profileImageService.resolveUrl(p.getImageId())))
-                .toList();
-
-        return new ProfileImageListResponseDto(images);
-    }
-
     @Transactional
     public void updateProfileImage(Long userId, ProfileImageUpdateRequestDto request) {
         User user = userReader.readById(userId);

--- a/src/main/java/com/cookeep/cookeep/domain/user/application/UserInfoService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/user/application/UserInfoService.java
@@ -1,15 +1,20 @@
 package com.cookeep.cookeep.domain.user.application;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
 import com.cookeep.cookeep.api.dto.request.*;
 import com.cookeep.cookeep.api.dto.response.DislikeIngredientResponseDto;
+import com.cookeep.cookeep.api.dto.response.ProfileImageListResponseDto;
+import com.cookeep.cookeep.api.dto.response.ProfileImageResponseDto;
 import com.cookeep.cookeep.api.dto.response.UserProfileResponseDTO;
 import com.cookeep.cookeep.common.exception.AppException;
 import com.cookeep.cookeep.common.exception.ErrorCode;
 import com.cookeep.cookeep.domain.user.dao.UserAuthRepository;
 import com.cookeep.cookeep.domain.user.dao.UserRepository;
+import com.cookeep.cookeep.domain.user.entity.ProfileImages;
 import com.cookeep.cookeep.domain.user.entity.Provider;
 import com.cookeep.cookeep.domain.user.entity.User;
 import com.cookeep.cookeep.domain.verification.application.EmailVerificationService;
@@ -33,6 +38,7 @@ public class UserInfoService {
     private final EmailVerificationService emailVerificationService;
     private final UserAuthRepository userAuthRepository;
     private final PasswordEncoder passwordEncoder;
+    private final ProfileImageService profileImageService;
 
     // 비밀번호 입력 최대 시도 횟수
     private static final int MAX_ATTEMPTS = 5;
@@ -51,10 +57,15 @@ public class UserInfoService {
             ? user.getPhoneNumber()
             : null;
 
+        // profileImageId가 설정된 경우에만 프리셋 이미지 URL 반환, 아니면 null
+        Integer profileImageId = user.getProfileImageId();
+        String profileImageUrl = (profileImageId != null)
+                ? profileImageService.resolveUrl(profileImageId)
+                : null;
 
         return new UserProfileResponseDTO(
             nickname, phoneNumber, email,
-            provider, marketingPush
+            provider, marketingPush, profileImageUrl
         );
     }
 
@@ -244,6 +255,28 @@ public class UserInfoService {
     public void updateDislikedIngredients(Long userId, DislikeIngredientRequestDto requestDto) {
         User user = userReader.readById(userId);
         user.updateDislikedIngredients(requestDto.getDislikedIngredients());
+    }
+
+    @Transactional(readOnly = true)
+    public ProfileImageListResponseDto getProfileImages(Long userId) {
+        // 유저 존재 검증 (탈퇴/유효하지 않은 유저 필터링)
+        userReader.readById(userId);
+
+        List<ProfileImageResponseDto> images = Arrays.stream(ProfileImages.values())
+                .map(p -> new ProfileImageResponseDto(p.getImageId(), profileImageService.resolveUrl(p.getImageId())))
+                .toList();
+
+        return new ProfileImageListResponseDto(images);
+    }
+
+    @Transactional
+    public void updateProfileImage(Long userId, ProfileImageUpdateRequestDto request) {
+        User user = userReader.readById(userId);
+
+        // 유효한 imageId인지 검증 (1~6 범위 밖이면 예외)
+        ProfileImages.fromId(request.imageId());
+
+        user.updateProfileImage(request.imageId());
     }
 
 }

--- a/src/main/java/com/cookeep/cookeep/domain/user/application/UserInfoService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/user/application/UserInfoService.java
@@ -57,11 +57,8 @@ public class UserInfoService {
             ? user.getPhoneNumber()
             : null;
 
-        // profileImageId가 설정된 경우에만 프리셋 이미지 URL 반환, 아니면 null
-        Integer profileImageId = user.getProfileImageId();
-        String profileImageUrl = (profileImageId != null)
-                ? profileImageService.resolveUrl(profileImageId)
-                : null;
+        // profileImageId -> 기본 1, 바꾼 경우 해당 아이디로
+        String profileImageUrl = profileImageService.resolveUrl(user.getProfileImageId());
 
         return new UserProfileResponseDTO(
             nickname, phoneNumber, email,

--- a/src/main/java/com/cookeep/cookeep/domain/user/entity/ProfileImages.java
+++ b/src/main/java/com/cookeep/cookeep/domain/user/entity/ProfileImages.java
@@ -1,5 +1,7 @@
 package com.cookeep.cookeep.domain.user.entity;
 
+import com.cookeep.cookeep.common.exception.AppException;
+import com.cookeep.cookeep.common.exception.ErrorCode;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -23,6 +25,6 @@ public enum ProfileImages {
                 return image;
             }
         }
-        throw new IllegalArgumentException("Invalid profile imageId: " + imageId);
+        throw new AppException(ErrorCode.INVALID_PROFILE_IMAGE_ID);
     }
 }

--- a/src/main/java/com/cookeep/cookeep/domain/user/entity/ProfileImages.java
+++ b/src/main/java/com/cookeep/cookeep/domain/user/entity/ProfileImages.java
@@ -1,0 +1,28 @@
+package com.cookeep.cookeep.domain.user.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ProfileImages {
+
+    IMAGE_1(1, "1.png"),
+    IMAGE_2(2, "2.png"),
+    IMAGE_3(3, "3.png"),
+    IMAGE_4(4, "4.png"),
+    IMAGE_5(5, "5.png"),
+    IMAGE_6(6, "6.png");
+
+    private final int imageId;
+    private final String fileName;
+
+    public static ProfileImages fromId(int imageId) {
+        for (ProfileImages image : ProfileImages.values()) {
+            if (image.imageId == imageId) {
+                return image;
+            }
+        }
+        throw new IllegalArgumentException("Invalid profile imageId: " + imageId);
+    }
+}

--- a/src/main/java/com/cookeep/cookeep/domain/user/entity/User.java
+++ b/src/main/java/com/cookeep/cookeep/domain/user/entity/User.java
@@ -120,8 +120,9 @@ public class User extends BaseEntity {
 	@Column(name = "is_first_ingredient_reward", nullable = false)
 	private boolean isFirstIngredientReward = false;
 
-	@Column(name = "profile_image_id")
-	private Integer profileImageId; // null -> 기본 식물 이미지 사용, 값 있으면 1~6번 프로필 이미지 사용
+	@Builder.Default
+	@Column(name = "profile_image_id", nullable = false)
+	private int profileImageId = 1; // 프로필 이미지 프리셋 ID (기본값 1)
 
 	// 유저가 API를 통해 직접 프로필을 변경할 때 호출
 	public void updateProfilePlant(UserPlant nesUserPlant) {
@@ -231,7 +232,7 @@ public class User extends BaseEntity {
 	}
 
 	// 유저선택 프로필 이미지 변경시 S3에서 가져옴
-	public void updateProfileImage(Integer profileImageId) {
+	public void updateProfileImage(int profileImageId) {
 		this.profileImageId = profileImageId;
 	}
 }

--- a/src/main/java/com/cookeep/cookeep/domain/user/entity/User.java
+++ b/src/main/java/com/cookeep/cookeep/domain/user/entity/User.java
@@ -120,6 +120,9 @@ public class User extends BaseEntity {
 	@Column(name = "is_first_ingredient_reward", nullable = false)
 	private boolean isFirstIngredientReward = false;
 
+	@Column(name = "profile_image_id")
+	private Integer profileImageId; // null -> 기본 식물 이미지 사용, 값 있으면 1~6번 프로필 이미지 사용
+
 	// 유저가 API를 통해 직접 프로필을 변경할 때 호출
 	public void updateProfilePlant(UserPlant nesUserPlant) {
 		this.profilePlant = nesUserPlant;
@@ -225,5 +228,10 @@ public class User extends BaseEntity {
 
 	public void markFirstIngredientRewarded() {
 		this.isFirstIngredientReward = true;
+	}
+
+	// 유저선택 프로필 이미지 변경시 S3에서 가져옴
+	public void updateProfileImage(Integer profileImageId) {
+		this.profileImageId = profileImageId;
 	}
 }

--- a/src/main/resources/db/migration/V9__add_profile_image_id_to_users.sql
+++ b/src/main/resources/db/migration/V9__add_profile_image_id_to_users.sql
@@ -1,4 +1,4 @@
 -- src/main/resources/db/migration/V9__add_profile_image_id_to_users.sql
 
 ALTER TABLE users
-    ADD COLUMN profile_image_id INT NULL DEFAULT 1;
+    ADD COLUMN profile_image_id INT NOT NULL DEFAULT 1;

--- a/src/main/resources/db/migration/V9__add_profile_image_id_to_users.sql
+++ b/src/main/resources/db/migration/V9__add_profile_image_id_to_users.sql
@@ -1,4 +1,4 @@
 -- src/main/resources/db/migration/V9__add_profile_image_id_to_users.sql
 
 ALTER TABLE users
-    ADD COLUMN profile_image_id INT NULL;
+    ADD COLUMN profile_image_id INT NULL DEFAULT 1;

--- a/src/main/resources/db/migration/V9__add_profile_image_id_to_users.sql
+++ b/src/main/resources/db/migration/V9__add_profile_image_id_to_users.sql
@@ -1,0 +1,4 @@
+-- src/main/resources/db/migration/V9__add_profile_image_id_to_users.sql
+
+ALTER TABLE users
+    ADD COLUMN profile_image_id INT NULL;


### PR DESCRIPTION
# Issue
#291 

# Description
프로필 이미지를 S3에 미리 등록된 6종의 프리셋 이미지 중 하나로 선택/변경할 수 있는 기능을 추가합니다. 기존에는 profile_plant_id 기반의 식물 이미지만 프로필로 사용했는데, 디폴트 프로필 이미지는 1번 아이디 이미지로 설정하고, 유저가 수정 시 해당 아이디로 바뀝니다.

# Changes
### ProfileImages.java
- imageId, fileName 필드
- fromId(int imageId): 유효하지 않은 id일 경우 AppException(ErrorCode.INVALID_PROFILE_IMAGE_ID) 발생

### ProfileImageService.java
- resolveUrl(int imageId): ImageFolder.PROFILE_IMAGES + ProfileImage를 조합해 S3 URL 문자열 생성
- getProfileImages(Long userId) — 유저 존재 검증 후 프리셋 이미지 6종 목록 조회

### common/util/ImageFolder.java
- 필드 추가: PROFILE_IMAGES("profileImages") enum 값 추가

### common/exception/ErrorCode.java
- 에러 코드 추가: INVALID_PROFILE_IMAGE_ID(HttpStatus.BAD_REQUEST, "유효하지 않은 프로필 이미지 ID입니다.", "USER-010")

### domain/user/entity/User.java
- 필드 추가: profileImageId (Integer) — 디폴트 1번, 변경 시 해당 프리셋 이미지 사용
- 메서드 추가: updateProfileImage(Integer profileImageId) — 프리셋 이미지로 변경 시 호출

### api/dto/response/UserProfileResponseDto.java
- 필드 추가: profileImageUrl — profileImageId 미설정 시 null 반환

### domain/user/application/UserInfoService.java
- 메서드 수정: getMyProfile(Long userId) — user.getProfileImageId()가 profileImageService.resolveUrl()로 URL 조립
- 메서드 추가: updateProfileImage(Long userId, ProfileImageUpdateRequestDto request) — imageId 유효성 검증(ProfileImage.fromId) 후 user.updateProfileImage() 호출

### api/controller/UserInfoController.java
- 엔드포인트 추가: PATCH /api/users/me/profile-image — 프리셋 이미지 중 하나로 프로필 이미지 변경

### api/controller/ProfileImageController.java
- 엔드포인트 추가: GET /api/users/profile-images — 선택 가능한 프리셋 이미지 6종 목록 조회

### src/main/resources/db/migration/V9__add_profile_image_id_to_users.sql
- users 테이블에 프로필 이미지 필드 추가

# Test Checklist
- [x] 기본 유저 정보 조회 시 profileImageUrl: null 출력 확인
- [x] 프로필 이미지 리스트 조회 시 아이디 별 이미지 url 정상 출력 확인
- [x] 프로필 이미지 변경 후 유저 정보 조회 시 등록된 이미지 url 출력 확인

# 전달사항
프로필 이미지가 프리셋 형태로 S3에 사전 등록된 이미지만 사용하므로 ProfileImages ENUM 파일로 url 매핑하는 방식으로 사용됩니다. 현재 6번까지 있는 상황이나, 추후 디자인 작업이 완료되면 아이디 번호와 에러 처리 코드를 수정할 예정입니다.
또한 UserPlantService 현재 유저가 키우는 식물이 바뀔 때마다 식물 프로필 이미지가 수정되는 코드가 있는데, 이는 COOKEEP-61 의 수정사항과 관련 없이 서로 다른 컬럼(식물-profilePlant, 캐릭터-profileImageId)으로 관리되어 식물 프로필의 업데이트가 캐릭터 업데이트에 영향을 미치지 않습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **새 기능**
  * 프로필 이미지 6종 목록을 확인할 수 있습니다.
  * 원하는 프로필 이미지를 선택해 변경할 수 있습니다.
  * 내 프로필 조회 시 선택한 프로필 이미지가 함께 표시됩니다.
  * 급수(워터링 랭킹) 화면에도 프로필 이미지가 반영됩니다.
* **유효성 검증**
  * 지원되지 않는 이미지 ID 입력 시 요청이 거부됩니다.
* **데이터베이스**
  * 사용자별 프로필 이미지 설정이 저장되어 유지됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->