### PR TITLE
feat: 로그인 실패 계정 잠금 및 비활성 회원 인증 차단

### DIFF
--- a/src/main/java/com/cookeep/cookeep/api/controller/VerificationController.java
+++ b/src/main/java/com/cookeep/cookeep/api/controller/VerificationController.java
@@ -148,13 +148,11 @@ public class VerificationController {
 		@ApiResponse(responseCode = "429", description = "인증 재요청이 너무 빠름"),
 		@ApiResponse(responseCode = "500", description = "서버 오류")
 	})
-	@PostMapping("/users/me/password/send-code")
-	public ResponseEntity<DataResponse<Void>> sendPasswordVerificationCode(
-		@AuthenticationPrincipal UserPrincipal principal,
+	@PostMapping("/auth/account-unlock/send-code")
+	public ResponseEntity<DataResponse<Void>> sendAccountUnlockCode(
 		@Valid @RequestBody SendCodeRequestDTO sendCodeRequestDTO
 	) {
-		Long userId = principal.userId();
-		userInfoService.sendPasswordVerificationCode(userId, sendCodeRequestDTO);
+		authService.sendAccountUnlockCode(sendCodeRequestDTO);
 		return ResponseEntity.ok(DataResponse.ok());
 	}
 
@@ -169,13 +167,11 @@ public class VerificationController {
 		@ApiResponse(responseCode = "429", description = "인증 시도 횟수 초과"),
 		@ApiResponse(responseCode = "500", description = "서버 오류")
 	})
-	@PostMapping("/users/me/password/verify-code")
-	public ResponseEntity<DataResponse<Void>> verifyPasswordVerificationCode(
-		@AuthenticationPrincipal UserPrincipal principal,
+	@PostMapping("/auth/account-unlock/verify-code")
+	public ResponseEntity<DataResponse<Void>> verifyAccountUnlockCode(
 		@Valid @RequestBody VerifyCodeRequestDTO verifyCodeRequestDTO
 	) {
-		Long userId = principal.userId();
-		userInfoService.verifyPasswordVerificationCode(userId, verifyCodeRequestDTO);
+		authService.verifyAccountUnlockCode(verifyCodeRequestDTO);
 		return ResponseEntity.ok(DataResponse.ok());
 	}
 }

--- a/src/main/java/com/cookeep/cookeep/common/exception/ErrorCode.java
+++ b/src/main/java/com/cookeep/cookeep/common/exception/ErrorCode.java
@@ -122,6 +122,7 @@ public enum ErrorCode {
 	DAILY_RECIPE_FORBIDDEN(HttpStatus.FORBIDDEN, "본인의 레시피가 아닙니다.", "DAILY_RECIPE-001"),
 
 	// USER
+	USER_ACCOUNT_WITHDRAWN(HttpStatus.FORBIDDEN, "탈퇴한 회원입니다.", "USER-010"),
 	SOCIAL_USER_EMAIL_CHANGE_NOT_ALLOWED(HttpStatus.FORBIDDEN, "소셜 로그인 사용자는 이메일을 변경할 수 없습니다.", "USER-009"),
 
 	// ==============================
@@ -183,6 +184,7 @@ public enum ErrorCode {
 	// ==============================
 
 	// AUTH
+	USER_ACCOUNT_LOCKED(HttpStatus.LOCKED, "잠긴 회원입니다. 본인인증 후 다시 시도해주세요.", "AUTH-010"),
 	PASSWORD_VERIFICATION_LOCKED(HttpStatus.LOCKED, "비밀번호 입력 횟수를 초과했습니다. 본인인증 후 다시 시도해주세요.", "AUTH-007"),
 
 	// ==============================

--- a/src/main/java/com/cookeep/cookeep/domain/user/application/AuthService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/user/application/AuthService.java
@@ -55,6 +55,8 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class AuthService {
 
+	private static final int MAX_PASSWORD_ATTEMPTS = 5;
+
 	private final UserRepository userRepository;
 	private final UserAuthRepository userAuthRepository;
 	private final UserSessionRepository userSessionRepository;
@@ -420,7 +422,8 @@ public class AuthService {
 		}
 	}
 
-	@Transactional
+	// 로그인 실패 횟수는 예외가 발생해도 저장되어야 하므로 rollback 대상에서 제외하였음
+	@Transactional(noRollbackFor = AppException.class)
 	public LoginResponseDTO login(LoginRequestDTO loginRequestDTO) {
 		String email = loginRequestDTO.email();
 		String password = loginRequestDTO.password();
@@ -429,11 +432,41 @@ public class AuthService {
 		User user = userRepository.findByEmail(email)
 			.orElseThrow(() -> new AppException(ErrorCode.EMAIL_NOT_REGISTERED));
 
+		// 사용자가 새로운 토큰을 발급 받을 수 있는 상태인지 검증
+		// LOCK, WITHDRAWN 상태일 경우 예외 발생
+		assertTokenIssuable(user);
+
 		// 비밀번호가 틀렸을 경우
 		if (!passwordEncoder.matches(password, user.getPassword())) {
-			throw new AppException(ErrorCode.AUTH_PASSWORD_MISMATCH);
+			int passwordCnt = Optional.ofNullable(user.getPasswordCnt()).orElse(0) + 1;
+
+			// 지정된 최대 횟수를 초과한 경우
+			if (passwordCnt >= MAX_PASSWORD_ATTEMPTS) {
+				user.updatePasswordCnt(MAX_PASSWORD_ATTEMPTS);
+				user.updateUserStatus(UserStatus.LOCK);
+				log.warn("User account locked by login password failures. userId={}", user.getUserId());
+				throw new AppException(
+					ErrorCode.PASSWORD_VERIFICATION_LOCKED,
+					Map.of(
+						"failedCount", String.valueOf(MAX_PASSWORD_ATTEMPTS),
+						"maxCount", String.valueOf(MAX_PASSWORD_ATTEMPTS)
+					)
+				);
+			}
+
+			// 최대 횟수 미만일 경우 실패 횟수만 누적하고 AUTH_PASSWORD_MISMATCH로 응답
+			user.updatePasswordCnt(passwordCnt);
+			throw new AppException(
+				ErrorCode.AUTH_PASSWORD_MISMATCH,
+				Map.of(
+					"failedCount", String.valueOf(passwordCnt),
+					"maxCount", String.valueOf(MAX_PASSWORD_ATTEMPTS)
+				)
+			);
 		}
 
+		// 로그인에 성공한 경우 비밀번호 검증 실패 횟수 초기화
+		user.updatePasswordCnt(0);
 		TokenPair tokenPair = issueTokensAndUpsertSession(user);
 
 		UserStatus userStatus = user.getUserStatus();

--- a/src/main/java/com/cookeep/cookeep/domain/user/application/AuthService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/user/application/AuthService.java
@@ -84,6 +84,10 @@ public class AuthService {
 		}
 
 		User user = userReader.readById(userId);
+
+		// 사용자가 새로운 토큰을 발급 받을 수 있는 상태인지 검증
+		// LOCK, WITHDRAWN 상태일 경우 예외 발생
+		assertTokenIssuable(user);
 		boolean isRewarded = issueComebackReward(user);
 		user.updateLastAccessAt(LocalDateTime.now());
 
@@ -134,8 +138,9 @@ public class AuthService {
 	}
 
 	private TokenPair issueTokensAndUpsertSession(User user) {
-		// 기존 구독 삭제 (새 기기로 갱신)
-		//webPushSubscriptionRepository.deleteAllByUser_UserId(user.getUserId());
+		// 사용자가 새로운 토큰을 발급 받을 수 있는 상태인지 검증
+		// LOCK, WITHDRAWN 상태일 경우 예외 발생
+		assertTokenIssuable(user);
 
 		boolean isRewarded = issueComebackReward(user);
 		user.updateLastAccessAt(LocalDateTime.now());
@@ -155,6 +160,18 @@ public class AuthService {
 		userSessionRepository.save(userSession);
 
 		return new TokenPair(accessToken, refreshToken, isRewarded);
+	}
+
+	// 사용자가 새로운 토큰을 발급받을 수 있는 상태인지 검증
+	// LOCK, WITHDRAWN 상태일 경우 토큰 발급 제한
+	private void assertTokenIssuable(User user) {
+		if (user.getUserStatus() == UserStatus.LOCK) {
+			throw new AppException(ErrorCode.USER_ACCOUNT_LOCKED);
+		}
+
+		if (user.getUserStatus() == UserStatus.WITHDRAWN) {
+			throw new AppException(ErrorCode.USER_ACCOUNT_WITHDRAWN);
+		}
 	}
 
 	// 닉네임 제약 위반 시 재시도 횟수를 제한하기 위한 값 (무한 반복 방지)
@@ -190,7 +207,12 @@ public class AuthService {
 			.orElseGet(() -> {
 				// 동일한 이메일로 가입된 User가 존재하는지 확인
 				// 존재하지 않을 경우 새로운 유저 생성
+				// 기존 이메일 계정이 LOCK/WITHDRAWN일 경우 새로운 소셜 계정 연결이 생기는 걸 막음
 				User user = userRepository.findByEmail(email)
+					.map(existingUser -> {
+						assertTokenIssuable(existingUser);
+						return existingUser;
+					})
 					.orElseGet(() -> createSocialUser(email));
 
 				// 기존 유저든 신규 유저든 UserAuth가 추가됨

--- a/src/main/java/com/cookeep/cookeep/domain/user/application/AuthService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/user/application/AuthService.java
@@ -55,14 +55,13 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class AuthService {
 
-	private static final int MAX_PASSWORD_ATTEMPTS = 5;
-
 	private final UserRepository userRepository;
 	private final UserAuthRepository userAuthRepository;
 	private final UserSessionRepository userSessionRepository;
 	private final JwtTokenProvider jwtTokenProvider;
 	private final UserReader userReader;
 	private final PasswordEncoder passwordEncoder;
+	private final LoginPasswordFailureService loginPasswordFailureService;
 	private final NicknameGenerator nicknameGenerator;
 	private final EmailVerificationService emailVerificationService;
 	private final CookieService cookieService;
@@ -453,8 +452,7 @@ public class AuthService {
 		}
 	}
 
-	// 로그인 실패 횟수는 예외가 발생해도 저장되어야 하므로 rollback 대상에서 제외하였음
-	@Transactional(noRollbackFor = AppException.class)
+	@Transactional
 	public LoginResponseDTO login(LoginRequestDTO loginRequestDTO) {
 		String email = loginRequestDTO.email();
 		String password = loginRequestDTO.password();
@@ -469,29 +467,25 @@ public class AuthService {
 
 		// 비밀번호가 틀렸을 경우
 		if (!passwordEncoder.matches(password, user.getPassword())) {
-			int passwordCnt = Optional.ofNullable(user.getPasswordCnt()).orElse(0) + 1;
+			int passwordCnt = loginPasswordFailureService.increasePasswordFailCount(user.getUserId());
 
 			// 지정된 최대 횟수를 초과한 경우
-			if (passwordCnt >= MAX_PASSWORD_ATTEMPTS) {
-				user.updatePasswordCnt(MAX_PASSWORD_ATTEMPTS);
-				user.updateUserStatus(UserStatus.LOCK);
-				log.warn("User account locked by login password failures. userId={}", user.getUserId());
+			if (passwordCnt >= LoginPasswordFailureService.MAX_PASSWORD_ATTEMPTS) {
 				throw new AppException(
 					ErrorCode.PASSWORD_VERIFICATION_LOCKED,
 					Map.of(
-						"failedCount", String.valueOf(MAX_PASSWORD_ATTEMPTS),
-						"maxCount", String.valueOf(MAX_PASSWORD_ATTEMPTS)
+						"failedCount", String.valueOf(LoginPasswordFailureService.MAX_PASSWORD_ATTEMPTS),
+						"maxCount", String.valueOf(LoginPasswordFailureService.MAX_PASSWORD_ATTEMPTS)
 					)
 				);
 			}
 
 			// 최대 횟수 미만일 경우 실패 횟수만 누적하고 AUTH_PASSWORD_MISMATCH로 응답
-			user.updatePasswordCnt(passwordCnt);
 			throw new AppException(
 				ErrorCode.AUTH_PASSWORD_MISMATCH,
 				Map.of(
 					"failedCount", String.valueOf(passwordCnt),
-					"maxCount", String.valueOf(MAX_PASSWORD_ATTEMPTS)
+					"maxCount", String.valueOf(LoginPasswordFailureService.MAX_PASSWORD_ATTEMPTS)
 				)
 			);
 		}

--- a/src/main/java/com/cookeep/cookeep/domain/user/application/AuthService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/user/application/AuthService.java
@@ -315,6 +315,37 @@ public class AuthService {
 		emailVerificationService.verifyCode(email, VerificationPurpose.RESET_PASSWORD, code);
 	}
 
+	// 비밀번호 검증 실패로 인해 계정이 LOCK된 경우 이메일 인증 요청
+	@Transactional
+	public void sendAccountUnlockCode(SendCodeRequestDTO sendCodeRequestDTO) {
+		User user = userRepository.findByEmail(sendCodeRequestDTO.email())
+			.orElseThrow(() -> new AppException(ErrorCode.EMAIL_NOT_REGISTERED));
+
+		if (user.getUserStatus() == UserStatus.WITHDRAWN) {
+			throw new AppException(ErrorCode.USER_ACCOUNT_WITHDRAWN);
+		}
+
+		emailVerificationService.sendCode(user.getEmail(), VerificationPurpose.PASSWORD_VERIFICATION);
+	}
+
+	// 비밀번호 검증 실패로 인해 계정이 LOCK된 경우 이메일 인증 확인
+	@Transactional
+	public void verifyAccountUnlockCode(VerifyCodeRequestDTO verifyCodeRequestDTO) {
+		User user = userRepository.findByEmail(verifyCodeRequestDTO.email())
+			.orElseThrow(() -> new AppException(ErrorCode.EMAIL_NOT_REGISTERED));
+
+		if (user.getUserStatus() == UserStatus.WITHDRAWN) {
+			throw new AppException(ErrorCode.USER_ACCOUNT_WITHDRAWN);
+		}
+
+		emailVerificationService.verifyCode(
+			verifyCodeRequestDTO.email(), VerificationPurpose.PASSWORD_VERIFICATION, verifyCodeRequestDTO.code()
+		);
+
+		user.updatePasswordCnt(0);
+		user.updateUserStatus(UserStatus.ACTIVE);
+	}
+
 	@Transactional
 	public SignUpResponseDTO signUp(SignupRequestDTO signupRequestDTO) {
 		String email = signupRequestDTO.email();

--- a/src/main/java/com/cookeep/cookeep/domain/user/application/LoginPasswordFailureService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/user/application/LoginPasswordFailureService.java
@@ -1,0 +1,39 @@
+package com.cookeep.cookeep.domain.user.application;
+
+import java.util.Optional;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.cookeep.cookeep.domain.user.entity.User;
+import com.cookeep.cookeep.domain.user.entity.UserStatus;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class LoginPasswordFailureService {
+
+	static final int MAX_PASSWORD_ATTEMPTS = 5;
+
+	private final UserReader userReader;
+
+	@Transactional(propagation = Propagation.REQUIRES_NEW)
+	public int increasePasswordFailCount(Long userId) {
+		User user = userReader.readById(userId);
+		int passwordCnt = Optional.ofNullable(user.getPasswordCnt()).orElse(0) + 1;
+
+		if (passwordCnt >= MAX_PASSWORD_ATTEMPTS) {
+			user.updatePasswordCnt(MAX_PASSWORD_ATTEMPTS);
+			user.updateUserStatus(UserStatus.LOCK);
+			log.warn("User account locked by login password failures. userId={}", userId);
+			return MAX_PASSWORD_ATTEMPTS;
+		}
+
+		user.updatePasswordCnt(passwordCnt);
+		return passwordCnt;
+	}
+}

--- a/src/main/java/com/cookeep/cookeep/domain/user/application/UserInfoService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/user/application/UserInfoService.java
@@ -173,36 +173,6 @@ public class UserInfoService {
         );
     }
 
-    // 비밀번호 검증 실패 시 이메일 인증 요청
-    public void sendPasswordVerificationCode(Long userId, SendCodeRequestDTO sendCodeRequestDTO) {
-        User user = userReader.readById(userId);
-        String email = sendCodeRequestDTO.email();
-
-        // 현재 등록된 전화번호와 동일하지 않은 경우
-        if (!email.equals(user.getEmail())) {
-            throw new AppException(ErrorCode.REGISTERED_EMAIL_MISMATCH);
-        }
-
-        emailVerificationService.sendCode(email, VerificationPurpose.PASSWORD_VERIFICATION);
-    }
-
-    // 비밀번호 검증 실패 시 이메일 인증 확인
-    @Transactional
-    public void verifyPasswordVerificationCode(Long userId, VerifyCodeRequestDTO verifyCodeRequestDTO) {
-        User user = userReader.readById(userId);
-        String email = verifyCodeRequestDTO.email();
-        String code = verifyCodeRequestDTO.code();
-
-        // 현재 등록된 이메일과 동일하지 않은 경우
-        if (!email.equals(user.getEmail())) {
-            throw new AppException(ErrorCode.REGISTERED_EMAIL_MISMATCH);
-        }
-
-        emailVerificationService.verifyCode(email, VerificationPurpose.PASSWORD_VERIFICATION, code);
-
-        user.updatePasswordCnt(0);
-    }
-
     // 비밀번호 변경
     @Transactional
     public void updateMyPassword(Long userId, UpdatePasswordRequestDTO updatePasswordRequestDTO) {

--- a/src/test/java/com/cookeep/cookeep/domain/user/application/AuthServiceTest.java
+++ b/src/test/java/com/cookeep/cookeep/domain/user/application/AuthServiceTest.java
@@ -12,15 +12,19 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
+import com.cookeep.cookeep.api.dto.request.LoginRequestDTO;
+import com.cookeep.cookeep.api.dto.request.SendCodeRequestDTO;
 import com.cookeep.cookeep.api.dto.request.SignupRequestDTO;
+import com.cookeep.cookeep.api.dto.request.TokenRefreshRequestDTO;
+import com.cookeep.cookeep.api.dto.request.VerifyCodeRequestDTO;
 import com.cookeep.cookeep.api.dto.response.SignUpResponseDTO;
 import com.cookeep.cookeep.common.exception.AppException;
 import com.cookeep.cookeep.common.exception.ErrorCode;
@@ -29,9 +33,12 @@ import com.cookeep.cookeep.domain.notification.dao.WebPushSubscriptionRepository
 import com.cookeep.cookeep.domain.user.dao.UserAuthRepository;
 import com.cookeep.cookeep.domain.user.dao.UserRepository;
 import com.cookeep.cookeep.domain.user.dao.UserSessionRepository;
+import com.cookeep.cookeep.domain.user.dto.OAuthUserInfoDTO;
+import com.cookeep.cookeep.domain.user.entity.Provider;
 import com.cookeep.cookeep.domain.user.entity.User;
 import com.cookeep.cookeep.domain.user.entity.UserAuth;
 import com.cookeep.cookeep.domain.user.entity.UserSession;
+import com.cookeep.cookeep.domain.user.entity.UserStatus;
 import com.cookeep.cookeep.domain.verification.application.EmailVerificationService;
 import com.cookeep.cookeep.domain.verification.entity.VerificationPurpose;
 import com.cookeep.cookeep.security.JwtTokenProvider;
@@ -70,10 +77,26 @@ class AuthServiceTest {
 	private WebPushSubscriptionRepository webPushSubscriptionRepository;
 
 	@Mock
-	private List<OAuthProvider> oAuthProviders;
+	private OAuthProvider oAuthProvider;
 
-	@InjectMocks
 	private AuthService authService;
+
+	@BeforeEach
+	void setUp() {
+		authService = new AuthService(
+			userRepository,
+			userAuthRepository,
+			userSessionRepository,
+			jwtTokenProvider,
+			userReader,
+			passwordEncoder,
+			nicknameGenerator,
+			emailVerificationService,
+			cookieService,
+			webPushSubscriptionRepository,
+			List.of(oAuthProvider)
+		);
+	}
 
 	@Test
 	@DisplayName("signUp creates user when SIGNUP email verification is completed")
@@ -163,5 +186,255 @@ class AuthServiceTest {
 		verify(userRepository, never()).saveAndFlush(any(User.class));
 		verify(passwordEncoder, never()).encode(any());
 		verify(jwtTokenProvider, never()).createAccessToken(any());
+	}
+
+	@Test
+	@DisplayName("login increments password count when password does not match")
+	void login_passwordMismatch_incrementsPasswordCount() {
+		User user = user("test@example.com", UserStatus.ACTIVE);
+		user.updatePasswordCnt(2);
+
+		given(userRepository.findByEmail(user.getEmail())).willReturn(Optional.of(user));
+		given(passwordEncoder.matches("wrong-password", user.getPassword())).willReturn(false);
+
+		assertThatThrownBy(() -> authService.login(new LoginRequestDTO(user.getEmail(), "wrong-password")))
+			.isInstanceOf(AppException.class)
+			.extracting("errorCode")
+			.isEqualTo(ErrorCode.AUTH_PASSWORD_MISMATCH);
+
+		assertThat(user.getPasswordCnt()).isEqualTo(3);
+		verify(jwtTokenProvider, never()).createAccessToken(any());
+	}
+
+	@Test
+	@DisplayName("login locks user when password mismatch reaches max attempts")
+	void login_maxPasswordMismatch_locksUser() {
+		User user = user("test@example.com", UserStatus.ACTIVE);
+		user.updatePasswordCnt(4);
+
+		given(userRepository.findByEmail(user.getEmail())).willReturn(Optional.of(user));
+		given(passwordEncoder.matches("wrong-password", user.getPassword())).willReturn(false);
+
+		assertThatThrownBy(() -> authService.login(new LoginRequestDTO(user.getEmail(), "wrong-password")))
+			.isInstanceOf(AppException.class)
+			.extracting("errorCode")
+			.isEqualTo(ErrorCode.PASSWORD_VERIFICATION_LOCKED);
+
+		assertThat(user.getPasswordCnt()).isEqualTo(5);
+		assertThat(user.getUserStatus()).isEqualTo(UserStatus.LOCK);
+		verify(jwtTokenProvider, never()).createAccessToken(any());
+	}
+
+	@Test
+	@DisplayName("login resets password count and issues tokens when password matches")
+	void login_passwordMatches_resetsPasswordCountAndIssuesTokens() {
+		User user = user("test@example.com", UserStatus.ACTIVE);
+		user.updatePasswordCnt(3);
+
+		given(userRepository.findByEmail(user.getEmail())).willReturn(Optional.of(user));
+		given(passwordEncoder.matches("password1", user.getPassword())).willReturn(true);
+		given(jwtTokenProvider.createAccessToken(user.getUserId())).willReturn("access-token");
+		given(jwtTokenProvider.createRefreshToken(user.getUserId())).willReturn("refresh-token");
+		given(userSessionRepository.findByUser(user)).willReturn(Optional.empty());
+		given(userSessionRepository.save(any(UserSession.class))).willAnswer(invocation -> invocation.getArgument(0));
+
+		var response = authService.login(new LoginRequestDTO(user.getEmail(), "password1"));
+
+		assertThat(user.getPasswordCnt()).isZero();
+		assertThat(response.accessToken()).isEqualTo("access-token");
+		assertThat(response.refreshToken()).isEqualTo("refresh-token");
+	}
+
+	@Test
+	@DisplayName("login does not issue tokens for locked user")
+	void login_lockedUser_doesNotIssueToken() {
+		assertLoginBlocked(UserStatus.LOCK, ErrorCode.USER_ACCOUNT_LOCKED);
+	}
+
+	@Test
+	@DisplayName("login does not issue tokens for withdrawn user")
+	void login_withdrawnUser_doesNotIssueToken() {
+		assertLoginBlocked(UserStatus.WITHDRAWN, ErrorCode.USER_ACCOUNT_WITHDRAWN);
+	}
+
+	@Test
+	@DisplayName("sendAccountUnlockCode sends PASSWORD_VERIFICATION code for registered user")
+	void sendAccountUnlockCode_lockedUser_sendsCode() {
+		User user = user("test@example.com", UserStatus.LOCK);
+
+		given(userRepository.findByEmail(user.getEmail())).willReturn(Optional.of(user));
+
+		authService.sendAccountUnlockCode(new SendCodeRequestDTO(user.getEmail()));
+
+		verify(emailVerificationService).sendCode(user.getEmail(), VerificationPurpose.PASSWORD_VERIFICATION);
+	}
+
+	@Test
+	@DisplayName("sendAccountUnlockCode blocks withdrawn user")
+	void sendAccountUnlockCode_withdrawnUser_throwsException() {
+		User user = user("test@example.com", UserStatus.WITHDRAWN);
+
+		given(userRepository.findByEmail(user.getEmail())).willReturn(Optional.of(user));
+
+		assertThatThrownBy(() -> authService.sendAccountUnlockCode(new SendCodeRequestDTO(user.getEmail())))
+			.isInstanceOf(AppException.class)
+			.extracting("errorCode")
+			.isEqualTo(ErrorCode.USER_ACCOUNT_WITHDRAWN);
+
+		verify(emailVerificationService, never()).sendCode(any(), any());
+	}
+
+	@Test
+	@DisplayName("verifyAccountUnlockCode resets password count and activates user")
+	void verifyAccountUnlockCode_verifiedCode_activatesUser() {
+		User user = user("test@example.com", UserStatus.LOCK);
+		user.updatePasswordCnt(5);
+
+		given(userRepository.findByEmail(user.getEmail())).willReturn(Optional.of(user));
+
+		authService.verifyAccountUnlockCode(new VerifyCodeRequestDTO(user.getEmail(), "123456"));
+
+		verify(emailVerificationService)
+			.verifyCode(user.getEmail(), VerificationPurpose.PASSWORD_VERIFICATION, "123456");
+		assertThat(user.getPasswordCnt()).isZero();
+		assertThat(user.getUserStatus()).isEqualTo(UserStatus.ACTIVE);
+	}
+
+	@Test
+	@DisplayName("verifyAccountUnlockCode fails when email is not registered")
+	void verifyAccountUnlockCode_missingEmail_throwsException() {
+		String email = "missing@example.com";
+
+		given(userRepository.findByEmail(email)).willReturn(Optional.empty());
+
+		assertThatThrownBy(() -> authService.verifyAccountUnlockCode(new VerifyCodeRequestDTO(email, "123456")))
+			.isInstanceOf(AppException.class)
+			.extracting("errorCode")
+			.isEqualTo(ErrorCode.EMAIL_NOT_REGISTERED);
+
+		verify(emailVerificationService, never()).verifyCode(any(), any(), any());
+	}
+
+	@Test
+	@DisplayName("socialLogin does not issue tokens for existing locked user auth")
+	void socialLogin_existingLockedUser_doesNotIssueToken() {
+		assertSocialLoginBlocked(UserStatus.LOCK, ErrorCode.USER_ACCOUNT_LOCKED);
+	}
+
+	@Test
+	@DisplayName("socialLogin does not issue tokens for existing withdrawn user auth")
+	void socialLogin_existingWithdrawnUser_doesNotIssueToken() {
+		assertSocialLoginBlocked(UserStatus.WITHDRAWN, ErrorCode.USER_ACCOUNT_WITHDRAWN);
+	}
+
+	@Test
+	@DisplayName("socialLogin does not save user auth when same email user is locked")
+	void socialLogin_lockedEmailUser_doesNotSaveUserAuth() {
+		assertSocialEmailUserBlocked(UserStatus.LOCK, ErrorCode.USER_ACCOUNT_LOCKED);
+	}
+
+	@Test
+	@DisplayName("socialLogin does not save user auth when same email user is withdrawn")
+	void socialLogin_withdrawnEmailUser_doesNotSaveUserAuth() {
+		assertSocialEmailUserBlocked(UserStatus.WITHDRAWN, ErrorCode.USER_ACCOUNT_WITHDRAWN);
+	}
+
+	@Test
+	@DisplayName("tokenRefresh does not issue access token for locked user")
+	void tokenRefresh_lockedUser_doesNotIssueAccessToken() {
+		assertTokenRefreshBlocked(UserStatus.LOCK, ErrorCode.USER_ACCOUNT_LOCKED);
+	}
+
+	@Test
+	@DisplayName("tokenRefresh does not issue access token for withdrawn user")
+	void tokenRefresh_withdrawnUser_doesNotIssueAccessToken() {
+		assertTokenRefreshBlocked(UserStatus.WITHDRAWN, ErrorCode.USER_ACCOUNT_WITHDRAWN);
+	}
+
+	private void assertLoginBlocked(UserStatus userStatus, ErrorCode errorCode) {
+		User user = user("test@example.com", userStatus);
+		given(userRepository.findByEmail(user.getEmail())).willReturn(Optional.of(user));
+
+		assertThatThrownBy(() -> authService.login(new LoginRequestDTO(user.getEmail(), "password1")))
+			.isInstanceOf(AppException.class)
+			.extracting("errorCode")
+			.isEqualTo(errorCode);
+
+		verify(passwordEncoder, never()).matches(any(), any());
+		verify(jwtTokenProvider, never()).createAccessToken(any());
+	}
+
+	private void assertSocialLoginBlocked(UserStatus userStatus, ErrorCode errorCode) {
+		User user = user("test@example.com", userStatus);
+		UserAuth userAuth = UserAuth.builder()
+			.user(user)
+			.provider(Provider.KAKAO)
+			.providerUserId("social-id")
+			.build();
+
+		given(oAuthProvider.provider()).willReturn(Provider.KAKAO);
+		given(oAuthProvider.getAccessToken("code", "redirect-uri")).willReturn("oauth-access-token");
+		given(oAuthProvider.getUserInfo("oauth-access-token"))
+			.willReturn(new OAuthUserInfoDTO("social-id", user.getEmail()));
+		given(userAuthRepository.findByProviderAndProviderUserId(Provider.KAKAO, "social-id"))
+			.willReturn(Optional.of(userAuth));
+
+		assertThatThrownBy(() -> authService.socialLogin(Provider.KAKAO, "code", "redirect-uri"))
+			.isInstanceOf(AppException.class)
+			.extracting("errorCode")
+			.isEqualTo(errorCode);
+
+		verify(jwtTokenProvider, never()).createAccessToken(any());
+	}
+
+	private void assertSocialEmailUserBlocked(UserStatus userStatus, ErrorCode errorCode) {
+		User user = user("test@example.com", userStatus);
+
+		given(oAuthProvider.provider()).willReturn(Provider.KAKAO);
+		given(oAuthProvider.getAccessToken("code", "redirect-uri")).willReturn("oauth-access-token");
+		given(oAuthProvider.getUserInfo("oauth-access-token"))
+			.willReturn(new OAuthUserInfoDTO("social-id", user.getEmail()));
+		given(userAuthRepository.findByProviderAndProviderUserId(Provider.KAKAO, "social-id"))
+			.willReturn(Optional.empty());
+		given(userRepository.findByEmail(user.getEmail())).willReturn(Optional.of(user));
+
+		assertThatThrownBy(() -> authService.socialLogin(Provider.KAKAO, "code", "redirect-uri"))
+			.isInstanceOf(AppException.class)
+			.extracting("errorCode")
+			.isEqualTo(errorCode);
+
+		verify(userAuthRepository, never()).save(any(UserAuth.class));
+	}
+
+	private void assertTokenRefreshBlocked(UserStatus userStatus, ErrorCode errorCode) {
+		User user = user("test@example.com", userStatus);
+		UserSession userSession = UserSession.builder()
+			.user(user)
+			.refreshToken("refresh-token")
+			.expiresAt(LocalDateTime.now().plusDays(1))
+			.build();
+
+		given(jwtTokenProvider.validateToken("refresh-token", true)).willReturn(true);
+		given(jwtTokenProvider.getUserId("refresh-token", true)).willReturn(user.getUserId());
+		given(userSessionRepository.findByUser_UserId(user.getUserId())).willReturn(Optional.of(userSession));
+		given(userReader.readById(user.getUserId())).willReturn(user);
+
+		assertThatThrownBy(() -> authService.tokenRefresh(new TokenRefreshRequestDTO("refresh-token")))
+			.isInstanceOf(AppException.class)
+			.extracting("errorCode")
+			.isEqualTo(errorCode);
+
+		verify(jwtTokenProvider, never()).createAccessToken(any());
+	}
+
+	private User user(String email, UserStatus userStatus) {
+		return User.builder()
+			.userId(1L)
+			.email(email)
+			.password("encoded-password")
+			.nickname("nickname")
+			.userStatus(userStatus)
+			.lastAccessAt(LocalDateTime.now())
+			.build();
 	}
 }

--- a/src/test/java/com/cookeep/cookeep/domain/user/application/AuthServiceTest.java
+++ b/src/test/java/com/cookeep/cookeep/domain/user/application/AuthServiceTest.java
@@ -65,6 +65,9 @@ class AuthServiceTest {
 	private PasswordEncoder passwordEncoder;
 
 	@Mock
+	private LoginPasswordFailureService loginPasswordFailureService;
+
+	@Mock
 	private NicknameGenerator nicknameGenerator;
 
 	@Mock
@@ -90,6 +93,7 @@ class AuthServiceTest {
 			jwtTokenProvider,
 			userReader,
 			passwordEncoder,
+			loginPasswordFailureService,
 			nicknameGenerator,
 			emailVerificationService,
 			cookieService,
@@ -192,17 +196,17 @@ class AuthServiceTest {
 	@DisplayName("login increments password count when password does not match")
 	void login_passwordMismatch_incrementsPasswordCount() {
 		User user = user("test@example.com", UserStatus.ACTIVE);
-		user.updatePasswordCnt(2);
 
 		given(userRepository.findByEmail(user.getEmail())).willReturn(Optional.of(user));
 		given(passwordEncoder.matches("wrong-password", user.getPassword())).willReturn(false);
+		given(loginPasswordFailureService.increasePasswordFailCount(user.getUserId())).willReturn(3);
 
 		assertThatThrownBy(() -> authService.login(new LoginRequestDTO(user.getEmail(), "wrong-password")))
 			.isInstanceOf(AppException.class)
 			.extracting("errorCode")
 			.isEqualTo(ErrorCode.AUTH_PASSWORD_MISMATCH);
 
-		assertThat(user.getPasswordCnt()).isEqualTo(3);
+		verify(loginPasswordFailureService).increasePasswordFailCount(user.getUserId());
 		verify(jwtTokenProvider, never()).createAccessToken(any());
 	}
 
@@ -210,18 +214,17 @@ class AuthServiceTest {
 	@DisplayName("login locks user when password mismatch reaches max attempts")
 	void login_maxPasswordMismatch_locksUser() {
 		User user = user("test@example.com", UserStatus.ACTIVE);
-		user.updatePasswordCnt(4);
 
 		given(userRepository.findByEmail(user.getEmail())).willReturn(Optional.of(user));
 		given(passwordEncoder.matches("wrong-password", user.getPassword())).willReturn(false);
+		given(loginPasswordFailureService.increasePasswordFailCount(user.getUserId())).willReturn(5);
 
 		assertThatThrownBy(() -> authService.login(new LoginRequestDTO(user.getEmail(), "wrong-password")))
 			.isInstanceOf(AppException.class)
 			.extracting("errorCode")
 			.isEqualTo(ErrorCode.PASSWORD_VERIFICATION_LOCKED);
 
-		assertThat(user.getPasswordCnt()).isEqualTo(5);
-		assertThat(user.getUserStatus()).isEqualTo(UserStatus.LOCK);
+		verify(loginPasswordFailureService).increasePasswordFailCount(user.getUserId());
 		verify(jwtTokenProvider, never()).createAccessToken(any());
 	}
 
@@ -243,6 +246,7 @@ class AuthServiceTest {
 		assertThat(user.getPasswordCnt()).isZero();
 		assertThat(response.accessToken()).isEqualTo("access-token");
 		assertThat(response.refreshToken()).isEqualTo("refresh-token");
+		verify(loginPasswordFailureService, never()).increasePasswordFailCount(any());
 	}
 
 	@Test

--- a/src/test/java/com/cookeep/cookeep/domain/user/application/LoginPasswordFailureServiceTest.java
+++ b/src/test/java/com/cookeep/cookeep/domain/user/application/LoginPasswordFailureServiceTest.java
@@ -1,0 +1,93 @@
+package com.cookeep.cookeep.domain.user.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+import java.lang.reflect.Method;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.cookeep.cookeep.domain.user.entity.User;
+import com.cookeep.cookeep.domain.user.entity.UserStatus;
+
+@ExtendWith(MockitoExtension.class)
+class LoginPasswordFailureServiceTest {
+
+	@Mock
+	private UserReader userReader;
+
+	@Test
+	@DisplayName("increasePasswordFailCount starts a new transaction")
+	void increasePasswordFailCount_hasRequiresNewPropagation() throws NoSuchMethodException {
+		Method method = LoginPasswordFailureService.class
+			.getDeclaredMethod("increasePasswordFailCount", Long.class);
+
+		Transactional transactional = method.getAnnotation(Transactional.class);
+
+		assertThat(transactional).isNotNull();
+		assertThat(transactional.propagation()).isEqualTo(Propagation.REQUIRES_NEW);
+	}
+
+	@Test
+	@DisplayName("increasePasswordFailCount stores 1 when password count is null")
+	void increasePasswordFailCount_nullPasswordCount_storesOne() {
+		LoginPasswordFailureService service = new LoginPasswordFailureService(userReader);
+		User user = user(UserStatus.ACTIVE);
+
+		given(userReader.readById(user.getUserId())).willReturn(user);
+
+		int passwordCnt = service.increasePasswordFailCount(user.getUserId());
+
+		assertThat(passwordCnt).isEqualTo(1);
+		assertThat(user.getPasswordCnt()).isEqualTo(1);
+		assertThat(user.getUserStatus()).isEqualTo(UserStatus.ACTIVE);
+	}
+
+	@Test
+	@DisplayName("increasePasswordFailCount locks user when max attempts is reached")
+	void increasePasswordFailCount_maxAttempts_locksUser() {
+		LoginPasswordFailureService service = new LoginPasswordFailureService(userReader);
+		User user = user(UserStatus.ACTIVE);
+		user.updatePasswordCnt(4);
+
+		given(userReader.readById(user.getUserId())).willReturn(user);
+
+		int passwordCnt = service.increasePasswordFailCount(user.getUserId());
+
+		assertThat(passwordCnt).isEqualTo(5);
+		assertThat(user.getPasswordCnt()).isEqualTo(5);
+		assertThat(user.getUserStatus()).isEqualTo(UserStatus.LOCK);
+	}
+
+	@Test
+	@DisplayName("increasePasswordFailCount keeps max count and lock state when already over max attempts")
+	void increasePasswordFailCount_alreadyOverMax_keepsLocked() {
+		LoginPasswordFailureService service = new LoginPasswordFailureService(userReader);
+		User user = user(UserStatus.LOCK);
+		user.updatePasswordCnt(5);
+
+		given(userReader.readById(user.getUserId())).willReturn(user);
+
+		int passwordCnt = service.increasePasswordFailCount(user.getUserId());
+
+		assertThat(passwordCnt).isEqualTo(5);
+		assertThat(user.getPasswordCnt()).isEqualTo(5);
+		assertThat(user.getUserStatus()).isEqualTo(UserStatus.LOCK);
+	}
+
+	private User user(UserStatus userStatus) {
+		return User.builder()
+			.userId(1L)
+			.email("test@example.com")
+			.password("encoded-password")
+			.nickname("nickname")
+			.userStatus(userStatus)
+			.build();
+	}
+}


### PR DESCRIPTION
# Related Issue

#285

</br></br>

# Description

### 회원 상태별 인증 차단 처리

- `LOCK`, `WITHDRAWN` 상태의 회원은 토큰을 발급받을 수 없도록 제한
- 일반 로그인, 소셜 로그인, 토큰 재발급 과정에서 회원 상태 검증 추가
- 기존 이메일 계정이 `LOCK` 또는 `WITHDRAWN` 상태일 경우, 소셜 계정 연결도 차단하도록 처리

</br>

### 로그인 비밀번호 실패 횟수 기반 계정 잠금 처리

- 로그인 비밀번호 불일치 시 `passwordCnt`를 증가시키도록 구현
- 비밀번호 실패 횟수가 최대 5회에 도달하면 회원 상태를 `LOCK`으로 변경
- 로그인 실패 응답에 `failedCount`, `maxCount` 정보를 포함하도록 처리
- 로그인 성공 시 기존 비밀번호 실패 횟수를 `0`으로 초기화

</br>

### 로그인 실패 횟수 저장 트랜잭션 분리

- `LoginPasswordFailureService` 추가
- 비밀번호 실패 횟수 증가는 `REQUIRES_NEW` 트랜잭션으로 분리
- 로그인 실패 예외로 인해 기존 로그인 트랜잭션이 롤백되더라도 실패 횟수는 저장되도록 처리

</br>

### 계정 잠금 해제 이메일 인증 API 추가

- 기존 로그인된 사용자 기준 비밀번호 인증 API를 계정 잠금 해제 API로 변경
- 잠긴 계정도 인증 요청/확인이 가능하도록 `/auth/account-unlock/*` 경로로 분리
- 이메일 인증 완료 시 `passwordCnt`를 초기화하고 회원 상태를 `ACTIVE`로 변경
- 탈퇴 회원은 계정 잠금 해제 인증 요청/확인 모두 차단

</br>

### 에러코드 추가

- `USER_ACCOUNT_LOCKED`
- `USER_ACCOUNT_WITHDRAWN`

</br></br>

# Changes

### 추가
- `LoginPasswordFailureService` 추가
- `LoginPasswordFailureServiceTest` 추가
- 계정 잠금 해제 인증 API 추가
  - `POST /auth/account-unlock/send-code`
  - `POST /auth/account-unlock/verify-code`

### 변경
- `AuthService` 로그인 실패 횟수 증가 및 계정 잠금 처리 추가
- `AuthService` 토큰 발급 전 회원 상태 검증 로직 추가
- `AuthService` 소셜 로그인 시 잠금/탈퇴 회원 토큰 발급 및 계정 연결 차단
- `AuthService` 토큰 재발급 시 잠금/탈퇴 회원 차단
- `VerificationController` 비밀번호 인증 API를 계정 잠금 해제 API로 변경
- `ErrorCode`에 잠금/탈퇴 회원 관련 에러코드 추가
- `AuthServiceTest`에 로그인 실패, 계정 잠금, 잠금 해제, 토큰 발급 차단 테스트 추가

### 제거
- `UserInfoService`의 기존 비밀번호 검증 실패 이메일 인증 로직 제거
- 기존 `/users/me/password/send-code`, `/users/me/password/verify-code` API 제거

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새 기능**
  - 비밀번호 로그인 실패가 누적되면 계정이 자동으로 잠깁니다.
  - 잠긴 계정은 이메일 인증을 통해 잠금 해제할 수 있습니다.
  - 잠금 해제 인증 후 계정 상태가 활성화되고 로그인 실패 횟수가 초기화됩니다.

- **개선 사항**
  - 잠긴 계정과 탈퇴한 계정의 로그인, 소셜 로그인, 토큰 갱신을 제한합니다.
  - 계정 잠금 및 탈퇴 상태를 구분해 안내하는 오류 응답을 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->