### PR TITLE
feat: Refresh Token 전달 방식 HttpOnly Cookie로 변경

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -167,6 +167,6 @@ jobs:
               -e "VAPID_PRIVATE_KEY=${{ secrets.VAPID_PRIVATE_KEY }}" \
               -e "EMAIL_USERNAME=${{ secrets.EMAIL_USERNAME }}" \
               -e "EMAIL_PASSWORD=${{ secrets.EMAIL_PASSWORD }}" \
-              -e "REFRESH_COOKIE_SECURE=false" \
+              -e "REFRESH_COOKIE_SECURE=true" \
               ${{ secrets.DOCKER_USERNAME }}/cookeep:dev
             docker image prune -f

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -167,5 +167,6 @@ jobs:
               -e "VAPID_PRIVATE_KEY=${{ secrets.VAPID_PRIVATE_KEY }}" \
               -e "EMAIL_USERNAME=${{ secrets.EMAIL_USERNAME }}" \
               -e "EMAIL_PASSWORD=${{ secrets.EMAIL_PASSWORD }}" \
+              -e "REFRESH_COOKIE_SECURE=false" \
               ${{ secrets.DOCKER_USERNAME }}/cookeep:dev
             docker image prune -f

--- a/src/main/java/com/cookeep/cookeep/api/controller/AuthController.java
+++ b/src/main/java/com/cookeep/cookeep/api/controller/AuthController.java
@@ -1,8 +1,9 @@
 package com.cookeep.cookeep.api.controller;
 
-
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -15,14 +16,15 @@ import org.springframework.web.bind.annotation.RestController;
 import com.cookeep.cookeep.api.dto.request.LoginRequestDTO;
 import com.cookeep.cookeep.api.dto.request.ResetPasswordRequestDTO;
 import com.cookeep.cookeep.api.dto.request.SignupRequestDTO;
-import com.cookeep.cookeep.api.dto.request.TokenRefreshRequestDTO;
-import com.cookeep.cookeep.api.dto.response.SocialLoginResponseDTO;
 import com.cookeep.cookeep.api.dto.response.LoginResponseDTO;
 import com.cookeep.cookeep.api.dto.response.SignUpResponseDTO;
+import com.cookeep.cookeep.api.dto.response.SocialLoginResponseDTO;
 import com.cookeep.cookeep.api.dto.response.TokenRefreshResponseDTO;
 import com.cookeep.cookeep.common.dto.DataResponse;
 import com.cookeep.cookeep.domain.user.application.AuthService;
+import com.cookeep.cookeep.domain.user.dto.AuthResult;
 import com.cookeep.cookeep.domain.user.entity.Provider;
+import com.cookeep.cookeep.security.RefreshTokenCookieProvider;
 import com.cookeep.cookeep.security.UserPrincipal;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -37,16 +39,17 @@ import lombok.RequiredArgsConstructor;
 public class AuthController {
 
 	private final AuthService authService;
+	private final RefreshTokenCookieProvider refreshTokenCookieProvider;
 
 	@Operation(summary = "액세스 토큰 재발급 API")
 	@ApiResponses(value = {
 		@ApiResponse(responseCode = "200", description = "액세스 토큰 갱신 성공"),
-		@ApiResponse(responseCode = "401", description = "유효하지 않은 리프레쉬 토큰")
+		@ApiResponse(responseCode = "401", description = "유효하지 않은 리프레시 토큰")
 	})
 	@PostMapping("/refresh")
-	public ResponseEntity<DataResponse<TokenRefreshResponseDTO>> tokenRefresh(@RequestBody TokenRefreshRequestDTO tokenRefreshRequestDTO) {
-		return ResponseEntity.ok(DataResponse.from(authService.tokenRefresh(tokenRefreshRequestDTO)));
-
+	public ResponseEntity<DataResponse<TokenRefreshResponseDTO>> tokenRefresh(
+		@CookieValue(value = RefreshTokenCookieProvider.COOKIE_NAME, required = false) String refreshToken) {
+		return ResponseEntity.ok(DataResponse.from(authService.tokenRefresh(refreshToken)));
 	}
 
 	@Operation(summary = "카카오 로그인 API")
@@ -58,7 +61,7 @@ public class AuthController {
 	public ResponseEntity<DataResponse<SocialLoginResponseDTO>> kakaoLogin(
 		@RequestParam String code,
 		@RequestParam(value = "redirect_uri", required = false) String redirectUri) {
-		return ResponseEntity.ok(DataResponse.from(authService.socialLogin(Provider.KAKAO, code, redirectUri)));
+		return createAuthResponse(authService.socialLogin(Provider.KAKAO, code, redirectUri));
 	}
 
 	@Operation(summary = "구글 로그인 API")
@@ -70,7 +73,7 @@ public class AuthController {
 	public ResponseEntity<DataResponse<SocialLoginResponseDTO>> googleLogin(
 		@RequestParam String code,
 		@RequestParam(value = "redirect_uri", required = false) String redirectUri) {
-		return ResponseEntity.ok(DataResponse.from(authService.socialLogin(Provider.GOOGLE, code, redirectUri)));
+		return createAuthResponse(authService.socialLogin(Provider.GOOGLE, code, redirectUri));
 	}
 
 	@Operation(summary = "이메일 회원가입 API")
@@ -81,17 +84,17 @@ public class AuthController {
 	})
 	@PostMapping("/signup")
 	public ResponseEntity<DataResponse<SignUpResponseDTO>> signup(@Valid @RequestBody SignupRequestDTO signupRequestDTO) {
-		return ResponseEntity.ok(DataResponse.from(authService.signUp(signupRequestDTO)));
+		return createAuthResponse(authService.signUp(signupRequestDTO));
 	}
 
 	@Operation(summary = "이메일 로그인 API")
 	@PostMapping("/login")
 	@ApiResponses(value = {
-		@ApiResponse(responseCode = "200", description = "회원가입 성공"),
+		@ApiResponse(responseCode = "200", description = "로그인 성공"),
 		@ApiResponse(responseCode = "400", description = "요청 파라미터 오류")
 	})
 	public ResponseEntity<DataResponse<LoginResponseDTO>> login(@Valid @RequestBody LoginRequestDTO loginRequestDTO) {
-		return ResponseEntity.ok(DataResponse.from(authService.login(loginRequestDTO)));
+		return createAuthResponse(authService.login(loginRequestDTO));
 	}
 
 	@Operation(summary = "비밀번호 초기화 API")
@@ -107,7 +110,6 @@ public class AuthController {
 		return ResponseEntity.ok(DataResponse.ok());
 	}
 
-
 	@Operation(summary = "로그아웃 API")
 	@ApiResponses(value = {
 		@ApiResponse(responseCode = "200", description = "로그아웃 성공"),
@@ -119,7 +121,7 @@ public class AuthController {
 	) {
 		Long userId = principal.userId();
 		authService.logout(userId);
-		return ResponseEntity.ok(DataResponse.ok());
+		return createLogoutResponse();
 	}
 
 	@Operation(summary = "회원 탈퇴 API", description = "현재 로그인한 사용자를 탈퇴 처리합니다.")
@@ -134,6 +136,19 @@ public class AuthController {
 	) {
 		Long userId = principal.userId();
 		authService.withdraw(userId);
-		return ResponseEntity.ok(DataResponse.ok());
+		return createLogoutResponse();
+	}
+
+	private <T> ResponseEntity<DataResponse<T>> createAuthResponse(AuthResult<T> authResult) {
+		// refresh token은 응답 body에 노출하지 않고 브라우저의 HttpOnly cookie로만 전달한다.
+		return ResponseEntity.ok()
+			.header(HttpHeaders.SET_COOKIE, refreshTokenCookieProvider.create(authResult.refreshToken()).toString())
+			.body(DataResponse.from(authResult.response()));
+	}
+
+	private ResponseEntity<DataResponse<Void>> createLogoutResponse() {
+		return ResponseEntity.ok()
+			.header(HttpHeaders.SET_COOKIE, refreshTokenCookieProvider.delete().toString())
+			.body(DataResponse.ok());
 	}
 }

--- a/src/main/java/com/cookeep/cookeep/api/controller/AuthController.java
+++ b/src/main/java/com/cookeep/cookeep/api/controller/AuthController.java
@@ -28,6 +28,10 @@ import com.cookeep.cookeep.security.RefreshTokenCookieProvider;
 import com.cookeep.cookeep.security.UserPrincipal;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.headers.Header;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
@@ -38,23 +42,60 @@ import lombok.RequiredArgsConstructor;
 @RequestMapping("/api/auth")
 public class AuthController {
 
+	private static final String REFRESH_COOKIE_ISSUE_DESCRIPTION = """
+		refreshToken은 응답 body에 포함되지 않고 Set-Cookie 응답 헤더의 HttpOnly Cookie로 전달됨
+		""";
+
+	private static final String REFRESH_COOKIE_DELETE_DESCRIPTION = """
+		성공 시 refreshToken HttpOnly Cookie 만료됨
+		""";
+
+	private static final String REFRESH_COOKIE_SET_COOKIE_HEADER = """
+		refreshToken HttpOnly Cookie. Path=/api/auth/refresh
+		""";
+
+	private static final String REFRESH_COOKIE_DELETE_HEADER = """
+		refreshToken 만료 Cookie. Path=/api/auth/refresh
+		""";
+
 	private final AuthService authService;
 	private final RefreshTokenCookieProvider refreshTokenCookieProvider;
 
-	@Operation(summary = "액세스 토큰 재발급 API")
+	@Operation(
+		summary = "액세스 토큰 재발급 API",
+		description = """
+			request body 없이 refreshToken HttpOnly Cookie로 액세스 토큰 재발급됨
+			쿠키 누락, 빈 값, 위조, 만료, DB 불일치는 401 AUTH-002로 처리됨
+			"""
+	)
 	@ApiResponses(value = {
 		@ApiResponse(responseCode = "200", description = "액세스 토큰 갱신 성공"),
-		@ApiResponse(responseCode = "401", description = "유효하지 않은 리프레시 토큰")
+		@ApiResponse(responseCode = "401", description = "유효하지 않은 리프레시 토큰 (AUTH-002)")
 	})
 	@PostMapping("/refresh")
 	public ResponseEntity<DataResponse<TokenRefreshResponseDTO>> tokenRefresh(
+		@Parameter(
+			name = RefreshTokenCookieProvider.COOKIE_NAME,
+			in = ParameterIn.COOKIE,
+			required = true,
+			description = "로그인/회원가입/소셜 로그인 응답의 Set-Cookie 헤더로 저장된 refreshToken HttpOnly Cookie",
+			example = "eyJhbGciOiJIUzI1NiJ9..."
+		)
 		@CookieValue(value = RefreshTokenCookieProvider.COOKIE_NAME, required = false) String refreshToken) {
 		return ResponseEntity.ok(DataResponse.from(authService.tokenRefresh(refreshToken)));
 	}
 
-	@Operation(summary = "카카오 로그인 API")
+	@Operation(summary = "카카오 로그인 API", description = REFRESH_COOKIE_ISSUE_DESCRIPTION)
 	@ApiResponses(value = {
-		@ApiResponse(responseCode = "200", description = "카카오 로그인 성공"),
+		@ApiResponse(
+			responseCode = "200",
+			description = "카카오 로그인 성공",
+			headers = @Header(
+				name = "Set-Cookie",
+				description = REFRESH_COOKIE_SET_COOKIE_HEADER,
+				schema = @Schema(type = "string")
+			)
+		),
 		@ApiResponse(responseCode = "400", description = "요청 파라미터 오류")
 	})
 	@GetMapping("/login/kakao")
@@ -64,9 +105,17 @@ public class AuthController {
 		return createAuthResponse(authService.socialLogin(Provider.KAKAO, code, redirectUri));
 	}
 
-	@Operation(summary = "구글 로그인 API")
+	@Operation(summary = "구글 로그인 API", description = REFRESH_COOKIE_ISSUE_DESCRIPTION)
 	@ApiResponses(value = {
-		@ApiResponse(responseCode = "200", description = "구글 로그인 성공"),
+		@ApiResponse(
+			responseCode = "200",
+			description = "구글 로그인 성공",
+			headers = @Header(
+				name = "Set-Cookie",
+				description = REFRESH_COOKIE_SET_COOKIE_HEADER,
+				schema = @Schema(type = "string")
+			)
+		),
 		@ApiResponse(responseCode = "400", description = "요청 파라미터 오류")
 	})
 	@GetMapping("/login/google")
@@ -76,9 +125,17 @@ public class AuthController {
 		return createAuthResponse(authService.socialLogin(Provider.GOOGLE, code, redirectUri));
 	}
 
-	@Operation(summary = "이메일 회원가입 API")
+	@Operation(summary = "이메일 회원가입 API", description = REFRESH_COOKIE_ISSUE_DESCRIPTION)
 	@ApiResponses(value = {
-		@ApiResponse(responseCode = "200", description = "회원가입 성공"),
+		@ApiResponse(
+			responseCode = "200",
+			description = "회원가입 성공",
+			headers = @Header(
+				name = "Set-Cookie",
+				description = REFRESH_COOKIE_SET_COOKIE_HEADER,
+				schema = @Schema(type = "string")
+			)
+		),
 		@ApiResponse(responseCode = "400", description = "요청 파라미터 오류"),
 		@ApiResponse(responseCode = "409", description = "이미 사용중인 전화번호 또는 이메일")
 	})
@@ -87,10 +144,18 @@ public class AuthController {
 		return createAuthResponse(authService.signUp(signupRequestDTO));
 	}
 
-	@Operation(summary = "이메일 로그인 API")
+	@Operation(summary = "이메일 로그인 API", description = REFRESH_COOKIE_ISSUE_DESCRIPTION)
 	@PostMapping("/login")
 	@ApiResponses(value = {
-		@ApiResponse(responseCode = "200", description = "로그인 성공"),
+		@ApiResponse(
+			responseCode = "200",
+			description = "로그인 성공",
+			headers = @Header(
+				name = "Set-Cookie",
+				description = REFRESH_COOKIE_SET_COOKIE_HEADER,
+				schema = @Schema(type = "string")
+			)
+		),
 		@ApiResponse(responseCode = "400", description = "요청 파라미터 오류")
 	})
 	public ResponseEntity<DataResponse<LoginResponseDTO>> login(@Valid @RequestBody LoginRequestDTO loginRequestDTO) {
@@ -110,9 +175,17 @@ public class AuthController {
 		return ResponseEntity.ok(DataResponse.ok());
 	}
 
-	@Operation(summary = "로그아웃 API")
+	@Operation(summary = "로그아웃 API", description = REFRESH_COOKIE_DELETE_DESCRIPTION)
 	@ApiResponses(value = {
-		@ApiResponse(responseCode = "200", description = "로그아웃 성공"),
+		@ApiResponse(
+			responseCode = "200",
+			description = "로그아웃 성공",
+			headers = @Header(
+				name = "Set-Cookie",
+				description = REFRESH_COOKIE_DELETE_HEADER,
+				schema = @Schema(type = "string")
+			)
+		),
 		@ApiResponse(responseCode = "401", description = "회원 인증 실패, AccessToken이 없거나 유효하지 않음")
 	})
 	@PostMapping("/logout")
@@ -124,9 +197,17 @@ public class AuthController {
 		return createLogoutResponse();
 	}
 
-	@Operation(summary = "회원 탈퇴 API", description = "현재 로그인한 사용자를 탈퇴 처리합니다.")
+	@Operation(summary = "회원 탈퇴 API", description = "현재 로그인한 사용자를 탈퇴 처리함\n" + REFRESH_COOKIE_DELETE_DESCRIPTION)
 	@ApiResponses(value = {
-		@ApiResponse(responseCode = "200", description = "회원 탈퇴 성공"),
+		@ApiResponse(
+			responseCode = "200",
+			description = "회원 탈퇴 성공",
+			headers = @Header(
+				name = "Set-Cookie",
+				description = REFRESH_COOKIE_DELETE_HEADER,
+				schema = @Schema(type = "string")
+			)
+		),
 		@ApiResponse(responseCode = "401", description = "회원 인증 실패, AccessToken이 없거나 유효하지 않음"),
 		@ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음")
 	})

--- a/src/main/java/com/cookeep/cookeep/api/dto/request/TokenRefreshRequestDTO.java
+++ b/src/main/java/com/cookeep/cookeep/api/dto/request/TokenRefreshRequestDTO.java
@@ -1,6 +1,0 @@
-package com.cookeep.cookeep.api.dto.request;
-
-public record TokenRefreshRequestDTO(
-	String refreshToken
-) {
-}

--- a/src/main/java/com/cookeep/cookeep/api/dto/response/LoginResponseDTO.java
+++ b/src/main/java/com/cookeep/cookeep/api/dto/response/LoginResponseDTO.java
@@ -4,6 +4,6 @@ import com.cookeep.cookeep.domain.user.entity.UserStatus;
 
 public record LoginResponseDTO(
 	Long userId, String accessToken,
-	String refreshToken, UserStatus userStatus, boolean isRewarded // isRewarded - 14일 이상 미접속 후 접속 시 쿠키 보상, 해당 보상 지급 여부
+	UserStatus userStatus, boolean isRewarded // isRewarded - 14일 이상 미접속 후 접속 시 쿠키 보상, 해당 보상 지급 여부
 ) {
 }

--- a/src/main/java/com/cookeep/cookeep/api/dto/response/SignUpResponseDTO.java
+++ b/src/main/java/com/cookeep/cookeep/api/dto/response/SignUpResponseDTO.java
@@ -1,9 +1,6 @@
 package com.cookeep.cookeep.api.dto.response;
 
-import com.cookeep.cookeep.domain.user.entity.UserStatus;
-
 public record SignUpResponseDTO(
-	Long userId, String accessToken,
-	String refreshToken
+	Long userId, String accessToken
 ) {
 }

--- a/src/main/java/com/cookeep/cookeep/api/dto/response/SocialLoginResponseDTO.java
+++ b/src/main/java/com/cookeep/cookeep/api/dto/response/SocialLoginResponseDTO.java
@@ -8,7 +8,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record SocialLoginResponseDTO(
 	Long userId, String accessToken,
-	String refreshToken, UserStatus userStatus,
+	UserStatus userStatus,
 	NextStep nextStep, // nullable
 	boolean isRewarded // isRewarded - 14일 이상 미접속 후 접속 시 쿠키 보상, 해당 보상 지급 여부
 ) {

--- a/src/main/java/com/cookeep/cookeep/domain/user/application/AuthService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/user/application/AuthService.java
@@ -22,7 +22,6 @@ import com.cookeep.cookeep.api.dto.request.LoginRequestDTO;
 import com.cookeep.cookeep.api.dto.request.ResetPasswordRequestDTO;
 import com.cookeep.cookeep.api.dto.request.SendCodeRequestDTO;
 import com.cookeep.cookeep.api.dto.request.SignupRequestDTO;
-import com.cookeep.cookeep.api.dto.request.TokenRefreshRequestDTO;
 import com.cookeep.cookeep.api.dto.request.VerifyCodeRequestDTO;
 import com.cookeep.cookeep.api.dto.response.SocialLoginResponseDTO;
 import com.cookeep.cookeep.api.dto.response.LoginResponseDTO;
@@ -30,6 +29,7 @@ import com.cookeep.cookeep.api.dto.response.SignUpResponseDTO;
 import com.cookeep.cookeep.api.dto.response.TokenRefreshResponseDTO;
 import com.cookeep.cookeep.domain.cookie.application.CookieService;
 import com.cookeep.cookeep.domain.cookie.entity.CookieLog;
+import com.cookeep.cookeep.domain.user.dto.AuthResult;
 import com.cookeep.cookeep.domain.user.dto.OAuthUserInfoDTO;
 import com.cookeep.cookeep.domain.user.dto.TokenPair;
 import com.cookeep.cookeep.domain.user.entity.Provider;
@@ -69,9 +69,7 @@ public class AuthService {
 
 	// 액세스 토큰이 만료되었을 경우 리프레쉬 토큰으로 액세스 토큰 갱신
 	@Transactional
-	public TokenRefreshResponseDTO tokenRefresh(TokenRefreshRequestDTO tokenRefreshRequestDTO) {
-		String refreshToken = tokenRefreshRequestDTO.refreshToken();
-
+	public TokenRefreshResponseDTO tokenRefresh(String refreshToken) {
 		validateRefreshToken(refreshToken);
 
 		Long userId = extractUserIdFromRefreshToken(refreshToken);
@@ -99,6 +97,11 @@ public class AuthService {
 	}
 
 	private void validateRefreshToken(String refreshToken) {
+		// 쿠키가 없거나 빈 경우 JWT 검증기에 null을 전달하지 않고 기존 INVALID_REFRESH_TOKEN(401) 응답으로 통일
+		if (refreshToken == null || refreshToken.isBlank()) {
+			throw new AppException(ErrorCode.INVALID_REFRESH_TOKEN);
+		}
+
 		// 위조/서명오류/만료된 리프레쉬 토큰인지 검증
 		boolean valid = jwtTokenProvider.validateToken(refreshToken, true);
 
@@ -190,7 +193,7 @@ public class AuthService {
 
 	// 소셜 로그인
 	@Transactional
-	public SocialLoginResponseDTO socialLogin(Provider provider, String code, String redirectUri) {
+	public AuthResult<SocialLoginResponseDTO> socialLogin(Provider provider, String code, String redirectUri) {
 		// provider 타입에 따라 KakaoOAuthProvider 또는 GoogleOAuthProvider 반환
 		OAuthProvider oAuthProvider = getProvider(provider);
 		String accessToken = oAuthProvider.getAccessToken(code, redirectUri);
@@ -271,10 +274,12 @@ public class AuthService {
 				: NextStep.ONBOARDING;
 		}
 
-		return new SocialLoginResponseDTO(
-			user.getUserId(), tokenPair.accessToken(), tokenPair.refreshToken(),
+		SocialLoginResponseDTO response = new SocialLoginResponseDTO(
+			user.getUserId(), tokenPair.accessToken(),
 			userStatus, nextStep, tokenPair.isRewarded()
 		);
+
+		return new AuthResult<>(response, tokenPair.refreshToken());
 	}
 
 	private User createSocialUser(String email) {
@@ -374,7 +379,7 @@ public class AuthService {
 	}
 
 	@Transactional
-	public SignUpResponseDTO signUp(SignupRequestDTO signupRequestDTO) {
+	public AuthResult<SignUpResponseDTO> signUp(SignupRequestDTO signupRequestDTO) {
 		String email = signupRequestDTO.email();
 
 		// 이메일 중복 검증 진행
@@ -428,9 +433,11 @@ public class AuthService {
 				.provider(LOCAL)
 				.build());
 
-		return new SignUpResponseDTO(
-			user.getUserId(), tokenPair.accessToken(), tokenPair.refreshToken()
+		SignUpResponseDTO response = new SignUpResponseDTO(
+			user.getUserId(), tokenPair.accessToken()
 		);
+
+		return new AuthResult<>(response, tokenPair.refreshToken());
 	}
 
 	private boolean shouldRetryNickname(DataIntegrityViolationException e) {
@@ -481,7 +488,7 @@ public class AuthService {
 	}
 
 	@Transactional
-	public LoginResponseDTO login(LoginRequestDTO loginRequestDTO) {
+	public AuthResult<LoginResponseDTO> login(LoginRequestDTO loginRequestDTO) {
 		String email = loginRequestDTO.email();
 		String password = loginRequestDTO.password();
 
@@ -524,9 +531,11 @@ public class AuthService {
 
 		UserStatus userStatus = user.getUserStatus();
 
-		return new LoginResponseDTO(
-			user.getUserId(), tokenPair.accessToken(), tokenPair.refreshToken(), userStatus, tokenPair.isRewarded()
+		LoginResponseDTO response = new LoginResponseDTO(
+			user.getUserId(), tokenPair.accessToken(), userStatus, tokenPair.isRewarded()
 		);
+
+		return new AuthResult<>(response, tokenPair.refreshToken());
 	}
 
 	@Transactional

--- a/src/main/java/com/cookeep/cookeep/domain/user/dto/AuthResult.java
+++ b/src/main/java/com/cookeep/cookeep/domain/user/dto/AuthResult.java
@@ -1,0 +1,8 @@
+package com.cookeep.cookeep.domain.user.dto;
+
+// HTTP 응답에 노출할 데이터와 쿠키로만 전달할 refresh token을 분리한 인증 처리 결과
+public record AuthResult<T>(
+	T response,
+	String refreshToken
+) {
+}

--- a/src/main/java/com/cookeep/cookeep/security/RefreshTokenCookieProvider.java
+++ b/src/main/java/com/cookeep/cookeep/security/RefreshTokenCookieProvider.java
@@ -1,0 +1,52 @@
+package com.cookeep.cookeep.security;
+
+import java.time.Duration;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseCookie;
+import org.springframework.stereotype.Component;
+
+@Component
+public class RefreshTokenCookieProvider {
+
+	public static final String COOKIE_NAME = "refreshToken";
+	private static final String COOKIE_PATH = "/api/auth/refresh";
+	private static final Duration COOKIE_MAX_AGE = Duration.ofDays(14);
+
+	private final boolean secure;
+
+	public RefreshTokenCookieProvider(
+		@Value("${REFRESH_COOKIE_SECURE:true}") boolean secure
+	) {
+		this.secure = secure;
+	}
+
+	public ResponseCookie create(String refreshToken) {
+		return baseCookie(refreshToken)
+			// HttpOnly는 브라우저 JavaScript가 refresh token을 읽지 못하게 해 XSS 탈취 위험을 낮춘다.
+			.httpOnly(true)
+			// 운영에서는 HTTPS로만 전송한다. HTTP 기반 로컬 도구가 필요할 때만 환경변수로 비활성화한다.
+			.secure(secure)
+			// 프론트와 API가 같은 site(cookeep.kr)이므로 cross-site 요청에는 쿠키를 보내지 않는다.
+			.sameSite("Lax")
+			// refresh token이 인증 영역의 다른 API에 불필요하게 첨부되지 않도록 갱신 경로로 제한한다.
+			.path(COOKIE_PATH)
+			.maxAge(COOKIE_MAX_AGE)
+			.build();
+	}
+
+	public ResponseCookie delete() {
+		return baseCookie("")
+			.httpOnly(true)
+			.secure(secure)
+			.sameSite("Lax")
+			// 브라우저가 기존 쿠키를 찾아 삭제하려면 발급할 때와 이름 및 Path가 같아야 한다.
+			.path(COOKIE_PATH)
+			.maxAge(Duration.ZERO)
+			.build();
+	}
+
+	private ResponseCookie.ResponseCookieBuilder baseCookie(String value) {
+		return ResponseCookie.from(COOKIE_NAME, value);
+	}
+}

--- a/src/test/java/com/cookeep/cookeep/api/controller/AuthControllerTest.java
+++ b/src/test/java/com/cookeep/cookeep/api/controller/AuthControllerTest.java
@@ -1,0 +1,170 @@
+package com.cookeep.cookeep.api.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.mock.web.MockCookie;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import com.cookeep.cookeep.api.dto.request.LoginRequestDTO;
+import com.cookeep.cookeep.api.dto.request.SignupRequestDTO;
+import com.cookeep.cookeep.api.dto.response.LoginResponseDTO;
+import com.cookeep.cookeep.api.dto.response.SignUpResponseDTO;
+import com.cookeep.cookeep.api.dto.response.SocialLoginResponseDTO;
+import com.cookeep.cookeep.api.dto.response.TokenRefreshResponseDTO;
+import com.cookeep.cookeep.common.dto.DataResponse;
+import com.cookeep.cookeep.common.exception.AppException;
+import com.cookeep.cookeep.common.exception.ErrorCode;
+import com.cookeep.cookeep.common.exception.GlobalExceptionHandler;
+import com.cookeep.cookeep.domain.user.application.AuthService;
+import com.cookeep.cookeep.domain.user.dto.AuthResult;
+import com.cookeep.cookeep.domain.user.entity.Provider;
+import com.cookeep.cookeep.domain.user.entity.UserStatus;
+import com.cookeep.cookeep.security.RefreshTokenCookieProvider;
+import com.cookeep.cookeep.security.UserPrincipal;
+
+@ExtendWith(MockitoExtension.class)
+class AuthControllerTest {
+
+	@Mock
+	private AuthService authService;
+
+	private AuthController authController;
+	private MockMvc mockMvc;
+
+	@BeforeEach
+	void setUp() {
+		authController = new AuthController(authService, new RefreshTokenCookieProvider(true));
+		mockMvc = MockMvcBuilders.standaloneSetup(authController)
+			.setControllerAdvice(new GlobalExceptionHandler())
+			.build();
+	}
+
+	@Test
+	void login_setsRefreshTokenCookieWithoutExposingItInBody() throws Exception {
+		LoginResponseDTO response = new LoginResponseDTO(1L, "access-token", UserStatus.ACTIVE, false);
+		given(authService.login(any(LoginRequestDTO.class)))
+			.willReturn(new AuthResult<>(response, "refresh-token"));
+
+		mockMvc.perform(post("/api/auth/login")
+				.contentType("application/json")
+				.content("""
+					{"email":"test@example.com","password":"password1"}
+					"""))
+			.andExpect(status().isOk())
+			.andExpect(header().string(HttpHeaders.SET_COOKIE, containsString("refreshToken=refresh-token")))
+			.andExpect(header().string(HttpHeaders.SET_COOKIE, containsString("Path=/api/auth/refresh")))
+			.andExpect(header().string(HttpHeaders.SET_COOKIE, containsString("Secure")))
+			.andExpect(header().string(HttpHeaders.SET_COOKIE, containsString("HttpOnly")))
+			.andExpect(header().string(HttpHeaders.SET_COOKIE, containsString("SameSite=Lax")))
+			.andExpect(jsonPath("$.data.accessToken").value("access-token"))
+			.andExpect(jsonPath("$.data.refreshToken").doesNotExist());
+	}
+
+	@Test
+	void signup_setsRefreshTokenCookieWithoutExposingItInBody() throws Exception {
+		SignUpResponseDTO response = new SignUpResponseDTO(1L, "access-token");
+		given(authService.signUp(any(SignupRequestDTO.class)))
+			.willReturn(new AuthResult<>(response, "refresh-token"));
+
+		mockMvc.perform(post("/api/auth/signup")
+				.contentType("application/json")
+				.content("""
+					{
+					  "email":"test@example.com",
+					  "password":"password1",
+					  "passwordConfirm":"password1",
+					  "marketingConsent":true
+					}
+					"""))
+			.andExpect(status().isOk())
+			.andExpect(header().string(HttpHeaders.SET_COOKIE, containsString("refreshToken=refresh-token")))
+			.andExpect(jsonPath("$.data.accessToken").value("access-token"))
+			.andExpect(jsonPath("$.data.refreshToken").doesNotExist());
+	}
+
+	@Test
+	void socialLogin_setsRefreshTokenCookieWithoutExposingItInBody() throws Exception {
+		SocialLoginResponseDTO response = new SocialLoginResponseDTO(
+			1L, "access-token", UserStatus.ACTIVE, null, false
+		);
+		given(authService.socialLogin(Provider.KAKAO, "code", null))
+			.willReturn(new AuthResult<>(response, "refresh-token"));
+
+		mockMvc.perform(get("/api/auth/login/kakao").param("code", "code"))
+			.andExpect(status().isOk())
+			.andExpect(header().string(HttpHeaders.SET_COOKIE, containsString("refreshToken=refresh-token")))
+			.andExpect(jsonPath("$.data.accessToken").value("access-token"))
+			.andExpect(jsonPath("$.data.refreshToken").doesNotExist());
+	}
+
+	@Test
+	void tokenRefresh_readsRefreshTokenFromCookieWithoutRequestBody() throws Exception {
+		given(authService.tokenRefresh("refresh-token"))
+			.willReturn(new TokenRefreshResponseDTO("new-access-token", false));
+
+		mockMvc.perform(post("/api/auth/refresh")
+				.cookie(new MockCookie(RefreshTokenCookieProvider.COOKIE_NAME, "refresh-token")))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.accessToken").value("new-access-token"));
+
+		verify(authService).tokenRefresh("refresh-token");
+	}
+
+	@Test
+	void tokenRefresh_returnsUnauthorizedWhenCookieIsMissingOrInvalid() throws Exception {
+		given(authService.tokenRefresh(null))
+			.willThrow(new AppException(ErrorCode.INVALID_REFRESH_TOKEN));
+		given(authService.tokenRefresh("invalid-token"))
+			.willThrow(new AppException(ErrorCode.INVALID_REFRESH_TOKEN));
+
+		mockMvc.perform(post("/api/auth/refresh"))
+			.andExpect(status().isUnauthorized())
+			.andExpect(jsonPath("$.code").value(ErrorCode.INVALID_REFRESH_TOKEN.getCode()));
+
+		mockMvc.perform(post("/api/auth/refresh")
+				.cookie(new MockCookie(RefreshTokenCookieProvider.COOKIE_NAME, "invalid-token")))
+			.andExpect(status().isUnauthorized())
+			.andExpect(jsonPath("$.code").value(ErrorCode.INVALID_REFRESH_TOKEN.getCode()));
+	}
+
+	@Test
+	void logout_andWithdrawExpireRefreshTokenCookie() {
+		UserPrincipal principal = new UserPrincipal(1L);
+
+		ResponseEntity<DataResponse<Void>> logoutResponse = authController.logout(principal);
+		ResponseEntity<DataResponse<Void>> withdrawResponse = authController.withdraw(principal);
+
+		assertExpiredRefreshTokenCookie(logoutResponse);
+		assertExpiredRefreshTokenCookie(withdrawResponse);
+		verify(authService).logout(1L);
+		verify(authService).withdraw(1L);
+	}
+
+	private void assertExpiredRefreshTokenCookie(ResponseEntity<DataResponse<Void>> response) {
+		String setCookie = response.getHeaders().getFirst(HttpHeaders.SET_COOKIE);
+
+		assertThat(setCookie)
+			.contains("refreshToken=")
+			.contains("Path=/api/auth/refresh")
+			.contains("Max-Age=0")
+			.contains("HttpOnly")
+			.contains("SameSite=Lax");
+	}
+}

--- a/src/test/java/com/cookeep/cookeep/domain/user/application/AuthServiceTest.java
+++ b/src/test/java/com/cookeep/cookeep/domain/user/application/AuthServiceTest.java
@@ -23,7 +23,6 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import com.cookeep.cookeep.api.dto.request.LoginRequestDTO;
 import com.cookeep.cookeep.api.dto.request.SendCodeRequestDTO;
 import com.cookeep.cookeep.api.dto.request.SignupRequestDTO;
-import com.cookeep.cookeep.api.dto.request.TokenRefreshRequestDTO;
 import com.cookeep.cookeep.api.dto.request.VerifyCodeRequestDTO;
 import com.cookeep.cookeep.api.dto.response.SignUpResponseDTO;
 import com.cookeep.cookeep.common.exception.AppException;
@@ -126,11 +125,12 @@ class AuthServiceTest {
 		given(userSessionRepository.save(any(UserSession.class))).willAnswer(invocation -> invocation.getArgument(0));
 		given(userAuthRepository.save(any(UserAuth.class))).willAnswer(invocation -> invocation.getArgument(0));
 
-		SignUpResponseDTO response = authService.signUp(request);
+		var authResult = authService.signUp(request);
+		SignUpResponseDTO response = authResult.response();
 
 		assertThat(response.userId()).isEqualTo(1L);
 		assertThat(response.accessToken()).isEqualTo("access-token");
-		assertThat(response.refreshToken()).isEqualTo("refresh-token");
+		assertThat(authResult.refreshToken()).isEqualTo("refresh-token");
 		verify(emailVerificationService).assertVerified(email, VerificationPurpose.SIGNUP);
 		verify(userRepository).saveAndFlush(any(User.class));
 	}
@@ -241,11 +241,12 @@ class AuthServiceTest {
 		given(userSessionRepository.findByUser(user)).willReturn(Optional.empty());
 		given(userSessionRepository.save(any(UserSession.class))).willAnswer(invocation -> invocation.getArgument(0));
 
-		var response = authService.login(new LoginRequestDTO(user.getEmail(), "password1"));
+		var authResult = authService.login(new LoginRequestDTO(user.getEmail(), "password1"));
+		var response = authResult.response();
 
 		assertThat(user.getPasswordCnt()).isZero();
 		assertThat(response.accessToken()).isEqualTo("access-token");
-		assertThat(response.refreshToken()).isEqualTo("refresh-token");
+		assertThat(authResult.refreshToken()).isEqualTo("refresh-token");
 		verify(loginPasswordFailureService, never()).increasePasswordFailCount(any());
 	}
 
@@ -355,6 +356,21 @@ class AuthServiceTest {
 		assertTokenRefreshBlocked(UserStatus.WITHDRAWN, ErrorCode.USER_ACCOUNT_WITHDRAWN);
 	}
 
+	@Test
+	@DisplayName("tokenRefresh rejects a missing or blank refresh token")
+	void tokenRefresh_missingOrBlankToken_throwsInvalidRefreshToken() {
+		assertThatThrownBy(() -> authService.tokenRefresh(null))
+			.isInstanceOf(AppException.class)
+			.extracting("errorCode")
+			.isEqualTo(ErrorCode.INVALID_REFRESH_TOKEN);
+
+		assertThatThrownBy(() -> authService.tokenRefresh(" "))
+			.isInstanceOf(AppException.class)
+			.extracting("errorCode")
+			.isEqualTo(ErrorCode.INVALID_REFRESH_TOKEN);
+	}
+
+
 	private void assertLoginBlocked(UserStatus userStatus, ErrorCode errorCode) {
 		User user = user("test@example.com", userStatus);
 		given(userRepository.findByEmail(user.getEmail())).willReturn(Optional.of(user));
@@ -423,7 +439,7 @@ class AuthServiceTest {
 		given(userSessionRepository.findByUser_UserId(user.getUserId())).willReturn(Optional.of(userSession));
 		given(userReader.readById(user.getUserId())).willReturn(user);
 
-		assertThatThrownBy(() -> authService.tokenRefresh(new TokenRefreshRequestDTO("refresh-token")))
+		assertThatThrownBy(() -> authService.tokenRefresh("refresh-token"))
 			.isInstanceOf(AppException.class)
 			.extracting("errorCode")
 			.isEqualTo(errorCode);

--- a/src/test/java/com/cookeep/cookeep/security/RefreshTokenCookieProviderTest.java
+++ b/src/test/java/com/cookeep/cookeep/security/RefreshTokenCookieProviderTest.java
@@ -1,0 +1,53 @@
+package com.cookeep.cookeep.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.http.ResponseCookie;
+
+class RefreshTokenCookieProviderTest {
+
+	@Test
+	void create_buildsSecureHttpOnlyRefreshTokenCookie() {
+		RefreshTokenCookieProvider provider = new RefreshTokenCookieProvider(true);
+
+		ResponseCookie cookie = provider.create("refresh-token");
+
+		assertThat(cookie.getName()).isEqualTo(RefreshTokenCookieProvider.COOKIE_NAME);
+		assertThat(cookie.getValue()).isEqualTo("refresh-token");
+		assertThat(cookie.isHttpOnly()).isTrue();
+		assertThat(cookie.isSecure()).isTrue();
+		assertThat(cookie.getSameSite()).isEqualTo("Lax");
+		assertThat(cookie.getPath()).isEqualTo("/api/auth/refresh");
+		assertThat(cookie.getMaxAge()).isEqualTo(Duration.ofDays(14));
+		assertThat(cookie.getDomain()).isNull();
+	}
+
+	@Test
+	void create_canDisableSecureForLocalHttpTools() {
+		RefreshTokenCookieProvider provider = new RefreshTokenCookieProvider(false);
+
+		ResponseCookie cookie = provider.create("refresh-token");
+
+		assertThat(cookie.isSecure()).isFalse();
+		assertThat(cookie.isHttpOnly()).isTrue();
+	}
+
+	@Test
+	void delete_expiresCookieWithSameScope() {
+		RefreshTokenCookieProvider provider = new RefreshTokenCookieProvider(true);
+
+		ResponseCookie cookie = provider.delete();
+
+		assertThat(cookie.getName()).isEqualTo(RefreshTokenCookieProvider.COOKIE_NAME);
+		assertThat(cookie.getValue()).isEmpty();
+		assertThat(cookie.getPath()).isEqualTo("/api/auth/refresh");
+		assertThat(cookie.getSameSite()).isEqualTo("Lax");
+		assertThat(cookie.isHttpOnly()).isTrue();
+		assertThat(cookie.isSecure()).isTrue();
+		assertThat(cookie.getMaxAge()).isEqualTo(Duration.ZERO);
+		assertThat(cookie.getDomain()).isNull();
+	}
+}


### PR DESCRIPTION
# Related Issue

#294

</br></br>

# Description

## Refresh Token 전달 방식 변경

- 기존 - 회원가입, 로그인 성공 시 Access Token과 Refresh Token을 모두 response body로 반환
- Access Token은 기존과 동일하게 응답 body로 반환하고, **Refresh Token은 `Set-Cookie` 응답 헤더의 HttpOnly Cookie로 전달하도록 변경**

</br>

### 변경 전 - 기존 방식의 문제점

- 응답 body로 전달된 Refresh Token은 프론트엔드 JavaScript에서 직접 접근 가능
- Refresh Token을 `localStorage`, `sessionStorage` 등에 저장할 경우 XSS 공격으로 토큰이 탈취될 가능성 有
- 프론트엔드에서 Refresh Token의 저장·조회·요청 첨부를 직접 관리해야 했음
- Access Token보다 유효기간이 긴 Refresh Token이 클라이언트 코드에 노출되는 구조

</br>

### 변경 후 - HttpOnly Cookie 기반으로 변경

- Refresh Token을 응답 body에서 제거하고 `Set-Cookie` 응답 헤더로 전달
- `HttpOnly`를 적용하여 브라우저 JavaScript에서 Refresh Token에 접근할 수 없도록 처리
- 브라우저가 Refresh Token을 저장하고 `/api/auth/refresh` 요청 시 자동으로 전송하도록 변경
- Cookie 적용 속성
  - 이름: `refreshToken` 
  - `HttpOnly=true` - JavaScript에서 Refresh Token에 직접 접근할 수 없도록 제한
  - `SameSite=Lax` - 다른 사이트에서 발생한 요청의 Cookie 전송을 제한하여 CSRF 위험 완화
  - `Path=/api/auth/refresh` 
  - `Max-Age=14일` 
  - `Domain` 미지정 - Cookie를 발급한 호스트에서만 사용되도록 제한
  - `Secure=${REFRESH_COOKIE_SECURE:true}`
- Cookie의 Path를 `/api/auth/refresh`로 제한하여 Refresh Token이 불필요한 API 요청에 포함되지 않도록 처리
- 로컬 개발 환경에서는 HTTP 테스트를 위해 `REFRESH_COOKIE_SECURE=false` 사용해야 함

> `HttpOnly`를 적용하여 JavaScript에서 Refresh Token에 직접 접근할 수 없도록 처리함. 추가로 `SameSite=Lax`, 제한된 Path, 운영 환경의 `Secure` 설정을 적용하여 Cookie가 전송되는 출처·경로·통신 환경을 제한함.

</br>

### 로그아웃 및 회원 탈퇴 시 Cookie 만료 처리

다음 API가 성공하면 DB의 Refresh Token 세션을 삭제하고 브라우저의 Refresh Token Cookie도 함께 만료하도록 변경

- `POST /api/auth/logout`
- `DELETE /api/auth/withdraw`

발급 시 사용한 것과 동일한 이름 및 Path로 `Max-Age=0`인 `Set-Cookie` 응답 헤더를 내려 기존 Cookie를 삭제함

</br>

### 서비스 반환 구조 분리

- 서비스 계층이 HTTP Cookie를 직접 처리하지 않도록 응답 DTO와 Refresh Token을 분리한 `AuthResult<T>` 추가
- `AuthService`는 응답 데이터와 Refresh Token을 분리하여 반환
- `AuthController`에서 응답 body 생성과 `Set-Cookie` 헤더 설정을 담당하도록 구성
- 사용하지 않게 된 `TokenRefreshRequestDTO` 제거

</br>

### Swagger 명세 반영

- 회원가입·로그인·소셜 로그인 응답에 `Set-Cookie` 헤더 명세 추가
- 응답 body에 Refresh Token이 포함되지 않음을 명시
- `POST /api/auth/refresh`의 request body를 제거하고 `refreshToken` Cookie parameter 명세 추가
- 로그아웃·회원 탈퇴 성공 시 Refresh Token Cookie가 만료됨을 명시

</br></br>

# API Changes

| API | 변경 내용 |
| --- | --- |
| `POST /api/auth/signup` | 응답 body에서 `refreshToken` 제거, `Set-Cookie`로 전달 |
| `POST /api/auth/login` | 응답 body에서 `refreshToken` 제거, `Set-Cookie`로 전달 |
| `GET /api/auth/login/kakao` | 응답 body에서 `refreshToken` 제거, `Set-Cookie`로 전달 |
| `GET /api/auth/login/google` | 응답 body에서 `refreshToken` 제거, `Set-Cookie`로 전달 |
| `POST /api/auth/refresh` | request body 제거, `refreshToken` Cookie로 Access Token 재발급 |
| `POST /api/auth/logout` | 성공 시 DB 세션 삭제 및 Refresh Token Cookie 만료 |
| `DELETE /api/auth/withdraw` | 성공 시 DB 세션 삭제 및 Refresh Token Cookie 만료 |

</br></br>

# Changes

### 추가

- `RefreshTokenCookieProvider` 추가
- 응답 DTO와 Refresh Token을 분리하는 `AuthResult<T>` 추가
- Refresh Token HttpOnly Cookie 발급·삭제 테스트 추가
- 인증 Controller의 Cookie 기반 동작 테스트 추가
- Swagger `Set-Cookie` 응답 헤더 및 Cookie parameter 명세 추가

### 변경

- 회원가입·일반 로그인·소셜 로그인 응답을 HttpOnly Cookie 기반으로 변경
- `POST /api/auth/refresh`를 request body 방식에서 Cookie 방식으로 변경
- 로그아웃·회원 탈퇴 성공 시 Refresh Token Cookie 만료 처리
- 개발 배포 환경에 `REFRESH_COOKIE_SECURE=false` 설정 추가
- `LoginResponseDTO`, `SignUpResponseDTO`, `SocialLoginResponseDTO`에서 `refreshToken` 제거

### 제거

- `TokenRefreshRequestDTO` 제거

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - 로그인, 회원가입, 소셜 로그인 시 리프레시 토큰을 응답 본문 대신 보안 쿠키로 제공합니다.
  - 리프레시 토큰 쿠키에 HttpOnly, SameSite 및 만료 기간이 적용됩니다.
  - 토큰 재발급 시 요청 본문 없이 쿠키를 사용하도록 변경되었습니다.

- **버그 수정**
  - 리프레시 토큰이 없거나 유효하지 않을 때 일관된 인증 오류를 반환합니다.
  - 로그아웃 및 회원 탈퇴 시 리프레시 토큰 쿠키가 즉시 삭제됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->