### PR TITLE
fix: 비밀번호 검증 규칙 불일치 수정

### DIFF
--- a/src/main/java/com/cookeep/cookeep/api/dto/request/ResetPasswordRequestDTO.java
+++ b/src/main/java/com/cookeep/cookeep/api/dto/request/ResetPasswordRequestDTO.java
@@ -1,10 +1,10 @@
 package com.cookeep.cookeep.api.dto.request;
 
 import com.cookeep.cookeep.api.dto.validator.PasswordMatch;
+import com.cookeep.cookeep.api.dto.validator.ValidPassword;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Pattern;
 
 @PasswordMatch
 public record ResetPasswordRequestDTO(
@@ -14,10 +14,7 @@ public record ResetPasswordRequestDTO(
 
 	// 영문, 숫자 포함 8자 이상 값
 	@NotBlank(message = "비밀번호는 필수 입력 값입니다.")
-	@Pattern(
-		regexp = "^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d]{8,}$",
-		message = "영문, 숫자 포함 8자 이상의 비밀번호를 사용해주세요"
-	)
+	@ValidPassword
 	String password,
 
 	@NotBlank(message = "비밀번호 확인은 필수 입력 값입니다.")

--- a/src/main/java/com/cookeep/cookeep/api/dto/request/SignupRequestDTO.java
+++ b/src/main/java/com/cookeep/cookeep/api/dto/request/SignupRequestDTO.java
@@ -1,10 +1,10 @@
 package com.cookeep.cookeep.api.dto.request;
 
 import com.cookeep.cookeep.api.dto.validator.PasswordMatch;
+import com.cookeep.cookeep.api.dto.validator.ValidPassword;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Pattern;
 
 @PasswordMatch // password와 passwordConfirm 일치 여부를 확인하는 커스텀 어노테이션
 public record SignupRequestDTO(
@@ -14,10 +14,7 @@ public record SignupRequestDTO(
 
 	// 영문, 숫자 포함 8자 이상 값, 특수문자는 선택사항
 	@NotBlank(message = "비밀번호는 필수 입력 값입니다.")
-	@Pattern(
-		regexp = "^(?=.*[A-Za-z])(?=.*\\d).{8,}$",
-		message = "영문, 숫자 포함 8자 이상의 비밀번호를 사용해주세요"
-	)
+	@ValidPassword
 	String password,
 
 	@NotBlank(message = "비밀번호 확인은 필수 입력 값입니다.")

--- a/src/main/java/com/cookeep/cookeep/api/dto/request/UpdatePasswordRequestDTO.java
+++ b/src/main/java/com/cookeep/cookeep/api/dto/request/UpdatePasswordRequestDTO.java
@@ -1,18 +1,15 @@
 package com.cookeep.cookeep.api.dto.request;
 
 import com.cookeep.cookeep.api.dto.validator.PasswordMatch;
+import com.cookeep.cookeep.api.dto.validator.ValidPassword;
 
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Pattern;
 
 @PasswordMatch
 public record UpdatePasswordRequestDTO(
 	// 영문, 숫자 포함 8자 이상 값
 	@NotBlank(message = "비밀번호는 필수 입력 값입니다.")
-	@Pattern(
-		regexp = "^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d]{8,}$",
-		message = "영문, 숫자 포함 8자 이상의 비밀번호를 사용해주세요"
-	)
+	@ValidPassword
 	String password,
 
 	@NotBlank(message = "비밀번호 확인은 필수 입력 값입니다.")

--- a/src/main/java/com/cookeep/cookeep/api/dto/request/VerifyPasswordRequestDTO.java
+++ b/src/main/java/com/cookeep/cookeep/api/dto/request/VerifyPasswordRequestDTO.java
@@ -1,15 +1,10 @@
 package com.cookeep.cookeep.api.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Pattern;
 
 public record VerifyPasswordRequestDTO(
 	// 현재 비밀번호
 	@NotBlank(message = "비밀번호는 필수 입력 값입니다.")
-	@Pattern(
-		regexp = "^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d]{8,}$",
-		message = "영문, 숫자 포함 8자 이상의 비밀번호를 사용해주세요"
-	)
 	String password
 ) {
 }

--- a/src/main/java/com/cookeep/cookeep/api/dto/validator/ValidPassword.java
+++ b/src/main/java/com/cookeep/cookeep/api/dto/validator/ValidPassword.java
@@ -1,0 +1,30 @@
+package com.cookeep.cookeep.api.dto.validator;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+@Documented
+@Target({
+	ElementType.FIELD,
+	ElementType.METHOD,
+	ElementType.PARAMETER,
+	ElementType.ANNOTATION_TYPE,
+	ElementType.TYPE_USE,
+	ElementType.RECORD_COMPONENT
+})
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = ValidPasswordValidator.class)
+public @interface ValidPassword {
+
+	String message() default "영문, 숫자 포함 8자 이상의 비밀번호를 사용해주세요";
+
+	Class<?>[] groups() default {};
+
+	Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/com/cookeep/cookeep/api/dto/validator/ValidPasswordValidator.java
+++ b/src/main/java/com/cookeep/cookeep/api/dto/validator/ValidPasswordValidator.java
@@ -1,0 +1,20 @@
+package com.cookeep.cookeep.api.dto.validator;
+
+import java.util.regex.Pattern;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+public class ValidPasswordValidator implements ConstraintValidator<ValidPassword, String> {
+
+	private static final Pattern PASSWORD_PATTERN = Pattern.compile("^(?=.*[A-Za-z])(?=.*\\d).{8,}$");
+
+	@Override
+	public boolean isValid(String value, ConstraintValidatorContext context) {
+		if (value == null || value.isBlank()) {
+			return true;
+		}
+
+		return PASSWORD_PATTERN.matcher(value).matches();
+	}
+}

--- a/src/test/java/com/cookeep/cookeep/api/dto/validator/ValidPasswordTest.java
+++ b/src/test/java/com/cookeep/cookeep/api/dto/validator/ValidPasswordTest.java
@@ -1,0 +1,111 @@
+package com.cookeep.cookeep.api.dto.validator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Set;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import com.cookeep.cookeep.api.dto.request.ResetPasswordRequestDTO;
+import com.cookeep.cookeep.api.dto.request.SignupRequestDTO;
+import com.cookeep.cookeep.api.dto.request.UpdatePasswordRequestDTO;
+import com.cookeep.cookeep.api.dto.request.VerifyPasswordRequestDTO;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import jakarta.validation.constraints.NotBlank;
+
+class ValidPasswordTest {
+
+	private static ValidatorFactory validatorFactory;
+	private static Validator validator;
+
+	@BeforeAll
+	static void setUpValidator() {
+		validatorFactory = Validation.buildDefaultValidatorFactory();
+		validator = validatorFactory.getValidator();
+	}
+
+	@AfterAll
+	static void closeValidatorFactory() {
+		validatorFactory.close();
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = {"password1", "password1!", "pass word1", "password1??"})
+	@DisplayName("new password requests accept passwords with optional special characters")
+	void newPasswordRequests_validPassword_passValidation(String password) {
+		newPasswordRequests(password, password)
+			.forEach(request -> assertThat(validator.validate(request)).isEmpty());
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = {"12345678", "password", "pass1"})
+	@DisplayName("new password requests reject passwords that do not meet the shared policy")
+	void newPasswordRequests_invalidPassword_failValidation(String password) {
+		newPasswordRequests(password, password).forEach(request -> {
+			Set<ConstraintViolation<Object>> violations = validator.validate(request);
+
+			assertThat(violations).anySatisfy(violation -> {
+				assertThat(violation.getPropertyPath().toString()).isEqualTo("password");
+				assertThat(violation.getConstraintDescriptor().getAnnotation().annotationType())
+					.isEqualTo(ValidPassword.class);
+			});
+		});
+	}
+
+	@Test
+	@DisplayName("blank new passwords are rejected by NotBlank")
+	void newPasswordRequests_blankPassword_failNotBlankValidation() {
+		newPasswordRequests("", "").forEach(request -> {
+			Set<ConstraintViolation<Object>> violations = validator.validate(request);
+
+			assertThat(violations).anySatisfy(violation -> {
+				assertThat(violation.getPropertyPath().toString()).isEqualTo("password");
+				assertThat(violation.getConstraintDescriptor().getAnnotation().annotationType())
+					.isEqualTo(NotBlank.class);
+			});
+			assertThat(violations).noneSatisfy(violation ->
+				assertThat(violation.getConstraintDescriptor().getAnnotation().annotationType())
+					.isEqualTo(ValidPassword.class));
+		});
+	}
+
+	@Test
+	@DisplayName("password confirmation must still match")
+	void newPasswordRequests_mismatchedConfirmation_failPasswordMatchValidation() {
+		newPasswordRequests("password1!", "different1!").forEach(request ->
+			assertThat(validator.validate(request)).anySatisfy(violation ->
+				assertThat(violation.getConstraintDescriptor().getAnnotation().annotationType())
+					.isEqualTo(PasswordMatch.class)));
+	}
+
+	@Test
+	@DisplayName("current password verification accepts any non-blank password format")
+	void verifyPassword_nonBlankLegacyFormat_passValidation() {
+		assertThat(validator.validate(new VerifyPasswordRequestDTO("legacy!"))).isEmpty();
+	}
+	@Test
+	@DisplayName("current password verification rejects a blank password")
+	void verifyPassword_blankPassword_failValidation() {
+		assertThat(validator.validate(new VerifyPasswordRequestDTO(" "))).anySatisfy(violation ->
+			assertThat(violation.getConstraintDescriptor().getAnnotation().annotationType())
+				.isEqualTo(NotBlank.class));
+	}
+
+	private List<Object> newPasswordRequests(String password, String passwordConfirm) {
+		return List.of(
+			new SignupRequestDTO("user@example.com", password, passwordConfirm, false),
+			new ResetPasswordRequestDTO("user@example.com", password, passwordConfirm),
+			new UpdatePasswordRequestDTO(password, passwordConfirm)
+		);
+	}
+}


### PR DESCRIPTION
# Related Issue

#297

</br></br>

# Description

## 비밀번호 검증 규칙 통일

회원가입, 비밀번호 재설정, 비밀번호 변경 API마다 다르게 적용되던 비밀번호 검증 규칙을 회원가입 정책을 기준으로 통일했습니다.

공통 비밀번호 정책은 다음과 같습니다.

- 영문과 숫자를 각각 1개 이상 포함
- 최소 8자 이상
- 특수문자 사용 가능
- 특수문자는 필수가 아닌 선택 사항

</br>

### 공통 비밀번호 검증 추가

- 공통 Bean Validation 애노테이션 `@ValidPassword` 추가
- 회원가입, 비밀번호 재설정, 비밀번호 변경 DTO에서 동일한 검증 규칙 사용
- 검증 정규식
  - `^(?=.*[A-Za-z])(?=.*\d).{8,}$`
- 검증 실패 메시지
  - `영문, 숫자 포함 8자 이상의 비밀번호를 사용해주세요`
- 빈 값 검증은 기존과 동일하게 `@NotBlank`에서 처리

</br>

### 비밀번호 재설정 및 변경 시 특수문자 허용

기존 비밀번호 재설정 및 변경 요청에서는 영문과 숫자만 입력할 수 있어, 회원가입 시 특수문자를 포함해 생성한 비밀번호와 정책이 일치하지 않았습니다.

다음 요청 DTO에 공통 비밀번호 검증을 적용하여 특수문자를 사용할 수 있도록 변경했습니다.

- `ResetPasswordRequestDTO`
- `UpdatePasswordRequestDTO`

`password1`, `password1!`과 같이 공통 정책을 만족하는 비밀번호를 모두 사용할 수 있습니다.

</br>

### 현재 비밀번호 확인의 형식 제한 제거

현재 비밀번호 확인은 새로운 비밀번호를 등록하는 과정이 아니므로 별도의 비밀번호 형식 검증을 제거했습니다.

- `VerifyPasswordRequestDTO`의 `@Pattern` 제거
- 빈 값 방지를 위한 `@NotBlank`는 유지
- 실제 비밀번호 일치 여부는 기존과 동일하게 BCrypt 비교를 통해 확인

이를 통해 특수문자가 포함된 비밀번호나 과거 정책으로 생성된 비밀번호도 정상적으로 확인할 수 있습니다.

</br>

### 기존 검증 및 API 구조 유지

- `passwordConfirm` 일치 여부를 검사하는 `@PasswordMatch` 유지
- 기존 비밀번호 중복 검사 및 암호화 로직 유지
- API 요청·응답 형식 유지
- 인증 방식 및 DB 스키마 변경 없음

</br></br>

# API Changes

| API | 변경 내용 |
| --- | --- |
| `POST /api/auth/signup` | 기존 정책은 유지하면서 공통 `@ValidPassword` 검증을 사용하도록 리팩터링 |
| `PATCH /api/auth/password/reset` | 새 비밀번호에 특수문자 사용 가능 |
| `POST /api/users/me/password/verify` | 현재 비밀번호의 형식 검증 제거, 빈 값 및 실제 비밀번호 일치 여부만 검사 |
| `PATCH /api/users/me/password` | 새 비밀번호에 특수문자 사용 가능 |

</br></br>

# Changes

### 추가

- 공통 비밀번호 검증 애노테이션 `ValidPassword`
- 공통 비밀번호 검증 구현체 `ValidPasswordValidator`
- 비밀번호 검증 정책 테스트

### 변경

- `SignupRequestDTO`의 개별 정규식을 공통 검증으로 변경
- `ResetPasswordRequestDTO`의 비밀번호 검증을 공통 규칙으로 변경
- `UpdatePasswordRequestDTO`의 비밀번호 검증을 공통 규칙으로 변경
- `VerifyPasswordRequestDTO`에서 현재 비밀번호 형식 제한 제거

</br></br>

# Test

- 영문과 숫자를 포함한 8자 이상 비밀번호 검증
- 특수문자가 포함된 비밀번호 허용 검증
- 영문 누락, 숫자 누락, 8자 미만 비밀번호 거부 검증
- 빈 비밀번호의 `@NotBlank` 검증
- 비밀번호 확인 값 불일치 시 `@PasswordMatch` 검증
- 현재 비밀번호 확인 요청에서 특수문자 및 과거 형식 허용 검증
- `ValidPasswordTest` 통과
- `compileJava` 통과

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **개선 사항**
  - 회원가입, 비밀번호 재설정 및 변경 시 비밀번호 검증 기준을 공통 정책으로 통일했습니다.
  - 영문과 숫자를 포함한 8자 이상의 비밀번호인지 일관되게 확인합니다.
  - 비밀번호 검증 오류 메시지를 보다 명확하게 안내합니다.
  - 비밀번호 확인 및 필수 입력 검증은 기존과 동일하게 유지됩니다.
  - 비밀번호 확인 요청에서는 형식 검증 대신 필수 입력 여부를 확인하도록 변경했습니다.

- **테스트**
  - 유효·무효 비밀번호, 빈 값, 비밀번호 불일치 상황에 대한 검증을 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->