### PR TITLE
Refactor/cookeep 84 recipes

### DIFF
--- a/src/main/java/com/cookeep/cookeep/api/controller/AiRecipeController.java
+++ b/src/main/java/com/cookeep/cookeep/api/controller/AiRecipeController.java
@@ -42,7 +42,7 @@ public class AiRecipeController {
     )
     @ApiErrorCodeExamples({
             ErrorCode.RECIPE_INGREDIENTS_REQUIRED,
-            ErrorCode.INVALID_DIFFICULTY,
+            ErrorCode.INVALID_FEATURE,
             ErrorCode.INVALID_INGREDIENT_TYPE,
             ErrorCode.INGREDIENT_NOT_FOUND,
             ErrorCode.AI_SEARCH_FAILED,
@@ -57,7 +57,7 @@ public class AiRecipeController {
             @ApiResponse(responseCode = "400", description = """
                     잘못된 요청입니다. 다음 오류가 발생할 수 있습니다:
                     - RECIPE_INGREDIENTS_REQUIRED: 레시피 생성을 위한 재료가 필요합니다.
-                    - INVALID_DIFFICULTY: 유효하지 않은 난이도입니다.
+                    - INVALID_FEATURE: 유효하지 않은 요리 종류입니다.
                     - INVALID_INGREDIENT_TYPE: 유효하지 않은 재료 타입입니다.
                     """, content = @Content),
             @ApiResponse(responseCode = "401", description = """

--- a/src/main/java/com/cookeep/cookeep/api/dto/request/UserIngredientCreateRequestDto.java
+++ b/src/main/java/com/cookeep/cookeep/api/dto/request/UserIngredientCreateRequestDto.java
@@ -57,7 +57,7 @@ public class UserIngredientCreateRequestDto {
 
     @Schema(
             description = "소비/만료 날짜 (yyyy-MM-dd). 미입력 시 db expirationDays 기준 계산",
-            example = "2026-07-20",
+            example = "2026-08-20",
             type = "string",
             format = "date",
             requiredMode = Schema.RequiredMode.NOT_REQUIRED

--- a/src/main/java/com/cookeep/cookeep/api/dto/response/AiRecipeResponseDto.java
+++ b/src/main/java/com/cookeep/cookeep/api/dto/response/AiRecipeResponseDto.java
@@ -46,4 +46,7 @@ public class AiRecipeResponseDto {
 
     @Schema(description = "요리 종류", example = "RICE_BOWL")
     private Feature feature;
+
+    @Schema(description = "보유 재료 중 실제로 레시피에 사용된 재료 개수", example = "3")
+    private Integer usedIngredientCount;
 }

--- a/src/main/java/com/cookeep/cookeep/api/dto/response/AiSessionDetailResponseDto.java
+++ b/src/main/java/com/cookeep/cookeep/api/dto/response/AiSessionDetailResponseDto.java
@@ -1,6 +1,7 @@
 package com.cookeep.cookeep.api.dto.response;
 
 import com.cookeep.cookeep.domain.recipe.entity.AiMessage;
+import com.cookeep.cookeep.domain.recipe.entity.Feature;
 import com.cookeep.cookeep.domain.recipe.entity.MessageType;
 import com.cookeep.cookeep.domain.recipe.entity.Role;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -35,6 +36,11 @@ public class AiSessionDetailResponseDto {
             requiredMode = Schema.RequiredMode.REQUIRED
     )
     private List<MessageItem> messages;
+
+    @Schema(
+            description = "요리 종류 (일반 레시피 - 선택한 feature, 랜덤 레시피 - ANY)",
+            example = "RICE_BOWL")
+    private Feature feature;
 
     @Getter
     @Builder

--- a/src/main/java/com/cookeep/cookeep/domain/recipe/application/AiRateLimitService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/recipe/application/AiRateLimitService.java
@@ -24,7 +24,7 @@ public class AiRateLimitService {
     private final Map<Long, List<Long>> requestLogs = new ConcurrentHashMap<>();
 
     // 제한 설정
-    private static final int LIMIT = 3;         // 3회/m
+    private static final int LIMIT = 5;         // 5회/m
     private static final Duration WINDOW = Duration.ofMinutes(1); // 1분
     private static final String KEY_PREFIX = "rate:limit:ai:";
 

--- a/src/main/java/com/cookeep/cookeep/domain/recipe/application/AiRecipeService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/recipe/application/AiRecipeService.java
@@ -36,10 +36,9 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
-import java.util.LinkedHashMap;
-import java.util.List;
+import java.util.*;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 
 @Slf4j
@@ -170,7 +169,7 @@ public class AiRecipeService {
                 .feature(request.getFeature())
                 .recipe(aiResponse)
                 .youtubeReferences(youtubeReferences)
-                .usedIngredientCount(countActuallyUsedIngredients(aiResponse))
+                .usedIngredientCount(countActuallyUsedIngredients(aiResponse, request.getIngredientIds()))
                 .build();
     }
 
@@ -245,7 +244,7 @@ public class AiRecipeService {
                 .feature(session.getFeature())
                 .recipe(aiResponse)
                 .youtubeReferences(youtubeReferences)
-                .usedIngredientCount(countActuallyUsedIngredients(aiResponse))
+                .usedIngredientCount(countActuallyUsedIngredients(aiResponse, ingredients.stream().map(IngredientDetailDto::getIngredientId).toList()))
                 .build();
     }
 
@@ -296,9 +295,8 @@ public class AiRecipeService {
         }
 
         // 요청했던 재료 중 실제 steps에서 사용된 것만 남김 (엣지케이스 방지)
-        java.util.Set<Long> actuallyUsedIds = extractActuallyUsedIngredientIds(parsedRecipe);
-        List<Long> ingredientIds = requestedIngredientIds.stream()
-                .filter(actuallyUsedIds::contains)
+        List<Long> ingredientIds = resolveValidatedUsedIngredientIds(parsedRecipe, requestedIngredientIds)
+                .stream()
                 .toList();
 
         // 8. 임박 재료(leftDays=0) 포함 세션이면 쿠키 지급 (하루 1회)
@@ -521,7 +519,7 @@ public class AiRecipeService {
                 .feature(Feature.ANY)
                 .recipe(aiResponse)
                 .youtubeReferences(youtubeReferences)
-                .usedIngredientCount(countActuallyUsedIngredients(aiResponse))
+                .usedIngredientCount(countActuallyUsedIngredients(aiResponse, selectedIds))
                 .build();
     }
 
@@ -586,7 +584,7 @@ public class AiRecipeService {
                 .feature(Feature.ANY)
                 .recipe(aiResponse)
                 .youtubeReferences(youtubeReferences)
-                .usedIngredientCount(countActuallyUsedIngredients(aiResponse))
+                .usedIngredientCount(countActuallyUsedIngredients(aiResponse, selectedIds))
                 .build();
     }
 
@@ -1126,28 +1124,47 @@ public class AiRecipeService {
         throw new AppException(ErrorCode.AI_RANDOM_SELECTION_INSUFFICIENT);
     }
 
-    // 레시피의 steps에서 실제로 언급된 ingredientId 집합 추출
-    private java.util.Set<Long> extractActuallyUsedIngredientIds(GeminiRecipeResponseDto aiResponse) {
-        if (aiResponse.getSteps() == null) return java.util.Set.of();
+    // 레시피의 steps에서 실제로 언급된 ingredientId 집합 추출 후 카운트
+    private int countActuallyUsedIngredients(GeminiRecipeResponseDto aiResponse, List<Long> requestedIngredientIds) {
+        return resolveValidatedUsedIngredientIds(aiResponse, requestedIngredientIds).size();
+    }
+
+    // 세 집합(steps 참조 id ∩ 응답 userIngredients ∩ 요청 재료 id)의 교집합 계산
+    // requestedIngredientIds가 null이면(요청 시점 검증이 필요 없는 컨텍스트) 요청 id 제약 없이 계산
+    private Set<Long> extractStepReferencedIngredientIds(GeminiRecipeResponseDto aiResponse) {
+        if (aiResponse.getSteps() == null) return Set.of();
         return aiResponse.getSteps().stream()
-                .filter(java.util.Objects::nonNull)
+                .filter(Objects::nonNull)
                 .flatMap(step -> step.getUsedIngredientIds() == null
-                        ? java.util.stream.Stream.<Long>empty()
+                        ? Stream.<Long>empty()
                         : step.getUsedIngredientIds().stream())
                 .collect(Collectors.toSet());
     }
+    private Set<Long> resolveValidatedUsedIngredientIds(
+            GeminiRecipeResponseDto aiResponse,
+            List<Long> requestedIngredientIds
+    ) {
+        Set<Long> stepIds = extractStepReferencedIngredientIds(aiResponse);
 
-    // "보유 재료 중 n개 사용" 카운트 (표시용)
-    private int countActuallyUsedIngredients(GeminiRecipeResponseDto aiResponse) {
-        if (aiResponse.getIngredients() == null || aiResponse.getIngredients().getUserIngredients() == null) {
-            return 0;
+        Set<Long> responseUserIngredientIds =
+                (aiResponse.getIngredients() == null || aiResponse.getIngredients().getUserIngredients() == null)
+                        ? Set.of()
+                        : aiResponse.getIngredients().getUserIngredients().stream()
+                        .map(GeminiRecipeResponseDto.UserIngredient::getIngredientId)
+                        .collect(Collectors.toSet());
+
+        Set<Long> validated = stepIds.stream()
+                .filter(responseUserIngredientIds::contains)
+                .collect(Collectors.toSet());
+
+        if (requestedIngredientIds != null) {
+            Set<Long> requestedSet = new HashSet<>(requestedIngredientIds);
+            validated = validated.stream()
+                    .filter(requestedSet::contains)
+                    .collect(Collectors.toSet());
         }
-        java.util.Set<Long> usedIds = extractActuallyUsedIngredientIds(aiResponse);
-        return (int) aiResponse.getIngredients().getUserIngredients().stream()
-                .map(GeminiRecipeResponseDto.UserIngredient::getIngredientId)
-                .filter(usedIds::contains)
-                .count();
-    }
 
+        return validated;
+    }
 
 }

--- a/src/main/java/com/cookeep/cookeep/domain/recipe/application/AiRecipeService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/recipe/application/AiRecipeService.java
@@ -1144,7 +1144,8 @@ public class AiRecipeService {
             GeminiRecipeResponseDto aiResponse,
             List<Long> requestedIngredientIds
     ) {
-        Set<Long> stepIds = extractStepReferencedIngredientIds(aiResponse);
+
+        List<GeminiRecipeResponseDto.Step> steps = aiResponse.getSteps();
 
         Set<Long> responseUserIngredientIds =
                 (aiResponse.getIngredients() == null || aiResponse.getIngredients().getUserIngredients() == null)
@@ -1153,9 +1154,21 @@ public class AiRecipeService {
                         .map(GeminiRecipeResponseDto.UserIngredient::getIngredientId)
                         .collect(Collectors.toSet());
 
-        Set<Long> validated = stepIds.stream()
-                .filter(responseUserIngredientIds::contains)
-                .collect(Collectors.toSet());
+        // 레거시 판별: steps가 비어있지 않은데 모든 step이 usedIngredientIds 정보가 null인 경우
+        boolean isLegacyRecipe = steps != null && !steps.isEmpty()
+                && steps.stream().allMatch(GeminiRecipeResponseDto.Step::isLegacyFormat);
+
+        Set<Long> validated;
+        if (isLegacyRecipe) {
+            // 레거시 fallback: step 단위 검증 불가 → 요청 재료 + 응답 userIngredients로 판단
+            log.info("레거시 포맷 steps 감지, requestedIngredientIds 기반 fallback 적용");
+            validated = responseUserIngredientIds;
+        } else {
+            Set<Long> stepIds = extractStepReferencedIngredientIds(aiResponse);
+            validated = stepIds.stream()
+                    .filter(responseUserIngredientIds::contains)
+                    .collect(Collectors.toSet());
+        }
 
         if (requestedIngredientIds != null) {
             Set<Long> requestedSet = new HashSet<>(requestedIngredientIds);

--- a/src/main/java/com/cookeep/cookeep/domain/recipe/application/AiRecipeService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/recipe/application/AiRecipeService.java
@@ -364,6 +364,7 @@ public class AiRecipeService {
 
         return AiSessionDetailResponseDto.builder()
                 .sessionId(session.getId())
+                .feature(session.getFeature())
                 .isCompleted(Boolean.TRUE.equals(session.getIsCompleted()))
                 .messages(messages.stream()
                         .map(AiSessionDetailResponseDto.MessageItem::from)

--- a/src/main/java/com/cookeep/cookeep/domain/recipe/application/AiRecipeService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/recipe/application/AiRecipeService.java
@@ -170,6 +170,7 @@ public class AiRecipeService {
                 .feature(request.getFeature())
                 .recipe(aiResponse)
                 .youtubeReferences(youtubeReferences)
+                .usedIngredientCount(countActuallyUsedIngredients(aiResponse))
                 .build();
     }
 
@@ -244,6 +245,7 @@ public class AiRecipeService {
                 .feature(session.getFeature())
                 .recipe(aiResponse)
                 .youtubeReferences(youtubeReferences)
+                .usedIngredientCount(countActuallyUsedIngredients(aiResponse))
                 .build();
     }
 
@@ -274,9 +276,9 @@ public class AiRecipeService {
         boolean rewardGranted = grantFirstRecipeRewardIfEligible(userId);
 
         // 7. 세션의 ingredientIds 조회
-        List<Long> ingredientIds;
+        List<Long> requestedIngredientIds;
         try {
-            ingredientIds = objectMapper.readValue(
+            requestedIngredientIds = objectMapper.readValue(
                     session.getIngredientIdsJson(),
                     new TypeReference<List<Long>>() {}
             );
@@ -284,6 +286,20 @@ public class AiRecipeService {
             log.error("❌ingredientIdsJson 파싱 실패", e);
             throw new AppException(ErrorCode.INTERNAL_SERVER_ERROR);
         }
+
+        GeminiRecipeResponseDto parsedRecipe;
+        try {
+            parsedRecipe = objectMapper.readValue(rawContent, GeminiRecipeResponseDto.class);
+        } catch (Exception e) {
+            log.error("❌ 채택 시 레시피 파싱 실패", e);
+            throw new AppException(ErrorCode.AI_RESPONSE_PARSE_FAILED);
+        }
+
+        // 요청했던 재료 중 실제 steps에서 사용된 것만 남김 (엣지케이스 방지)
+        java.util.Set<Long> actuallyUsedIds = extractActuallyUsedIngredientIds(parsedRecipe);
+        List<Long> ingredientIds = requestedIngredientIds.stream()
+                .filter(actuallyUsedIds::contains)
+                .toList();
 
         // 8. 임박 재료(leftDays=0) 포함 세션이면 쿠키 지급 (하루 1회)
         boolean urgentRewardGranted = grantUrgentCookieRewardIfEligible(userId, ingredientIds);
@@ -505,6 +521,7 @@ public class AiRecipeService {
                 .feature(Feature.ANY)
                 .recipe(aiResponse)
                 .youtubeReferences(youtubeReferences)
+                .usedIngredientCount(countActuallyUsedIngredients(aiResponse))
                 .build();
     }
 
@@ -569,6 +586,7 @@ public class AiRecipeService {
                 .feature(Feature.ANY)
                 .recipe(aiResponse)
                 .youtubeReferences(youtubeReferences)
+                .usedIngredientCount(countActuallyUsedIngredients(aiResponse))
                 .build();
     }
 
@@ -1107,5 +1125,29 @@ public class AiRecipeService {
                 RANDOM_SELECTION_MAX_ATTEMPTS, RANDOM_MIN_SELECT_COUNT);
         throw new AppException(ErrorCode.AI_RANDOM_SELECTION_INSUFFICIENT);
     }
+
+    // 레시피의 steps에서 실제로 언급된 ingredientId 집합 추출
+    private java.util.Set<Long> extractActuallyUsedIngredientIds(GeminiRecipeResponseDto aiResponse) {
+        if (aiResponse.getSteps() == null) return java.util.Set.of();
+        return aiResponse.getSteps().stream()
+                .filter(java.util.Objects::nonNull)
+                .flatMap(step -> step.getUsedIngredientIds() == null
+                        ? java.util.stream.Stream.<Long>empty()
+                        : step.getUsedIngredientIds().stream())
+                .collect(Collectors.toSet());
+    }
+
+    // "보유 재료 중 n개 사용" 카운트 (표시용)
+    private int countActuallyUsedIngredients(GeminiRecipeResponseDto aiResponse) {
+        if (aiResponse.getIngredients() == null || aiResponse.getIngredients().getUserIngredients() == null) {
+            return 0;
+        }
+        java.util.Set<Long> usedIds = extractActuallyUsedIngredientIds(aiResponse);
+        return (int) aiResponse.getIngredients().getUserIngredients().stream()
+                .map(GeminiRecipeResponseDto.UserIngredient::getIngredientId)
+                .filter(usedIds::contains)
+                .count();
+    }
+
 
 }

--- a/src/main/java/com/cookeep/cookeep/domain/recipe/application/GeminiService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/recipe/application/GeminiService.java
@@ -255,7 +255,9 @@ public class GeminiService {
                 "additional_ingredients에 없는 새로운 재료를 이 목록에 추가하는 것은 절대 금지합니다. " +
                 "description은 \"이 재료는 [대체재료]로 대체 가능합니다\" 또는 \"이 재료는 생략 가능합니다\" 중 하나로만 작성하세요.\n" +
                 "4. youtube_search_queries는 한국어 검색어 1~3개를 작성하세요.\n" +
-                "5. steps는 단계별 조리 방법을 작성하세요.\n\n" +
+                "5. steps는 각 단계를 {\"content\": \"조리 설명\", \"usedIngredientIds\": [...]} 형식으로 작성하세요. " +
+                "usedIngredientIds에는 해당 단계에서 실제로 사용하는 user_ingredients의 ingredientId만 포함하세요. " +
+                "레시피에서 전혀 쓰이지 않는 user_ingredients가 있다면 어떤 step의 usedIngredientIds에도 포함하지 마세요.\n\n" +
                 "[user_ingredients]\n" +
                 ingredientsJson + "\n";
     }
@@ -294,7 +296,9 @@ public class GeminiService {
                 "additional_ingredients에 없는 새로운 재료를 이 목록에 추가하는 것은 절대 금지합니다. " +
                 "description은 \"이 재료는 [대체재료]로 대체 가능합니다\" 또는 \"이 재료는 생략 가능합니다\" 중 하나로만 작성하세요.\n" +
                 "5. youtube_search_queries는 한국어 검색어 1~3개를 작성하세요.\n" +
-                "6. steps는 단계별 조리 방법을 작성하세요.\n\n" +
+                "6. steps는 각 단계를 {\"content\": \"조리 설명\", \"usedIngredientIds\": [...]} 형식으로 작성하세요. " +
+                "usedIngredientIds에는 해당 단계에서 실제로 사용하는 user_ingredients의 ingredientId만 포함하세요. " +
+                "레시피에서 전혀 쓰이지 않는 user_ingredients가 있다면 어떤 step의 usedIngredientIds에도 포함하지 마세요.\n\n" +
                 "[user_ingredients]\n" +
                 ingredientsJson + "\n";
 

--- a/src/main/java/com/cookeep/cookeep/domain/recipe/application/YoutubeSearchService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/recipe/application/YoutubeSearchService.java
@@ -8,12 +8,16 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientRequestException;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+import reactor.util.retry.Retry;
 
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.TimeoutException;
 
 @Slf4j
 @Service
@@ -28,6 +32,18 @@ public class YoutubeSearchService {
 
     private static final int MAX_RESULTS_PER_QUERY = 1;
     private static final Duration YOUTUBE_TIMEOUT = Duration.ofSeconds(20);
+
+    // API 호출 자체가 실패(타임아웃/5xx/네트워크 오류)한 경우에만 재시도
+    private static final int MAX_API_RETRY_ATTEMPTS = 2;
+    private static final Duration RETRY_BACKOFF = Duration.ofMillis(500);
+
+    private static final String NOT_FOUND_TITLE = "관련 유튜브 영상 없음";
+
+    // 대체 쿼리 생성 시 제거할 수식어 (실제 운영 로그 기반으로 계속 보강 필요)
+    private static final List<String> BROADENING_STOPWORDS = List.of(
+            "만드는 법", "만드는법", "만들기", "황금레시피", "레시피",
+            "초간단", "초스피드", "간단한", "쉬운", "집에서", "완벽", "정석", "요리"
+    );
 
     /**
      * [검색 방법]
@@ -56,8 +72,32 @@ public class YoutubeSearchService {
 
     // --- 내부 메서드 ---
 
-    // 유튜브 영상 1개 검색 수행
-    private Mono<YoutubeReferenceDto> searchSingleVideo(String query) {
+    // 유튜브 영상 1개 검색 수행 (1차 검색 → 결과 없으면 대체 쿼리로 2차 검색 → 그래도 없으면 not-found)
+    private Mono<YoutubeReferenceDto> searchSingleVideo(String originalQuery) {
+        return callYoutubeApi(originalQuery)
+                .flatMap(responseBody -> Mono.justOrEmpty(parseSearchResult(responseBody, originalQuery)))
+                .switchIfEmpty(Mono.defer(() -> retryWithFallbackQuery(originalQuery)));
+    }
+
+    // 1차 검색 결과가 없을 때 대체 쿼리로 재검색
+    private Mono<YoutubeReferenceDto> retryWithFallbackQuery(String originalQuery) {
+        String fallbackQuery = buildFallbackQuery(originalQuery);
+
+        if (fallbackQuery == null) {
+            log.info("대체 쿼리 생성 불가 - 결과 없음 처리 (검색어: '{}')", originalQuery);
+            return Mono.just(buildNotFoundReference(originalQuery));
+        }
+
+        log.info("1차 검색 결과 없음. 대체 쿼리로 재검색 - 원본: '{}', 대체: '{}'", originalQuery, fallbackQuery);
+
+        return callYoutubeApi(fallbackQuery)
+                // 최종 응답에 노출되는 searchQuery는 항상 '원본 검색어' 기준으로 유지 (프론트 일관성)
+                .flatMap(responseBody -> Mono.justOrEmpty(parseSearchResult(responseBody, originalQuery)))
+                .switchIfEmpty(Mono.just(buildNotFoundReference(originalQuery)));
+    }
+
+    // 실제 YouTube API 호출 (타임아웃/5xx/네트워크 오류에 한해서만 재시도)
+    private Mono<String> callYoutubeApi(String query) {
         return webClient.get()
                 .uri(uriBuilder -> uriBuilder
                         .scheme("https")
@@ -75,8 +115,48 @@ public class YoutubeSearchService {
                 .retrieve()
                 .bodyToMono(String.class)
                 .timeout(YOUTUBE_TIMEOUT)
-                .mapNotNull(responseBody -> parseSearchResult(responseBody, query))
-                .doOnError(e -> log.error("YouTube API 호출 실패 (검색어: '{}')", query, e));
+                .retryWhen(Retry.backoff(MAX_API_RETRY_ATTEMPTS, RETRY_BACKOFF)
+                        .filter(this::isRetriableApiError)
+                        .doBeforeRetry(signal -> log.warn("유튜브 API 재시도 (검색어: '{}', 시도: {})",
+                                query, signal.totalRetries() + 1)))
+                .doOnError(e -> log.error("YouTube API 호출 최종 실패 (검색어: '{}')", query, e));
+    }
+
+    // 재시도 대상 판별: 타임아웃 / 5xx / 네트워크 오류만 재시도, 4xx나 파싱 오류는 재시도하지 않음
+    private boolean isRetriableApiError(Throwable e) {
+        if (e instanceof WebClientResponseException wcre) {
+            return wcre.getStatusCode().is5xxServerError();
+        }
+        return e instanceof TimeoutException || e instanceof WebClientRequestException;
+    }
+
+    // 검색어에서 흔한 수식어를 제거해 더 넓은 대체 쿼리를 생성
+    private String buildFallbackQuery(String originalQuery) {
+        if (originalQuery == null || originalQuery.isBlank()) {
+            return null;
+        }
+
+        String simplified = originalQuery;
+        for (String stopword : BROADENING_STOPWORDS) {
+            simplified = simplified.replace(stopword, "");
+        }
+        simplified = simplified.replaceAll("\\s+", " ").trim();
+
+        if (simplified.isBlank() || simplified.equals(originalQuery.trim())) {
+            return null; // 제거해도 원본과 동일하거나 빈 값이면 null
+        }
+
+        return simplified;
+    }
+
+    // 검색 결과 없음 placeholder 생성
+    private YoutubeReferenceDto buildNotFoundReference(String originalQuery) {
+        return YoutubeReferenceDto.builder()
+                .title(NOT_FOUND_TITLE)
+                .url(null)
+                .thumbnail(null)
+                .searchQuery(originalQuery)
+                .build();
     }
 
     // YouTube API 응답 dto로 파싱
@@ -97,7 +177,7 @@ public class YoutubeSearchService {
             if (videoId.isMissingNode() || videoId.isNull()) {
                 log.warn("videoId 없음 (검색어: '{}')", searchQuery);
                 return null;
-            }
+            } // 검색 결과 없음 → null 반환, 예외 아님
 
             String id = videoId.asText();
             String title = snippet.path("title").asText(searchQuery);
@@ -112,6 +192,7 @@ public class YoutubeSearchService {
                     .title(title)
                     .url("https://www.youtube.com/watch?v=" + id)
                     .thumbnail(thumbnail)
+                    .searchQuery(searchQuery)
                     .build();
 
         } catch (Exception e) {

--- a/src/main/java/com/cookeep/cookeep/domain/recipe/application/YoutubeSearchService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/recipe/application/YoutubeSearchService.java
@@ -62,7 +62,7 @@ public class YoutubeSearchService {
                 .flatMap(query ->
                         searchSingleVideo(query)
                                 .onErrorResume(e -> {
-                                    log.warn("유튜브 검색 실패 (검색어: '{}'): {}", query, e.getMessage());
+                                    log.warn("유튜브 검색 실패 (검색어: '{}', 원인: {})", query, describeError(e));
                                     return Mono.empty();
                                 })
                 )
@@ -119,7 +119,7 @@ public class YoutubeSearchService {
                         .filter(this::isRetriableApiError)
                         .doBeforeRetry(signal -> log.warn("유튜브 API 재시도 (검색어: '{}', 시도: {})",
                                 query, signal.totalRetries() + 1)))
-                .doOnError(e -> log.error("YouTube API 호출 최종 실패 (검색어: '{}')", query, e));
+                .doOnError(e -> log.error("YouTube API 호출 최종 실패 (검색어: '{}', 원인: {})", query, describeError(e)));
     }
 
     // 재시도 대상 판별: 타임아웃 / 5xx / 네트워크 오류만 재시도, 4xx나 파싱 오류는 재시도하지 않음
@@ -199,5 +199,14 @@ public class YoutubeSearchService {
             log.error("유튜브 응답 파싱 실패 (검색어: '{}')", searchQuery, e);
             return null;
         }
+    }
+
+    // 예외 객체 전체(toString/스택트레이스)를 로그에 남기지 않기 위한 안전한 요약 정보 추출
+    // URI 쿼리 파라미터(API 키 등) 노출 방지 목적 - 예외 타입과 HTTP 상태코드만 기록
+    private String describeError(Throwable e) {
+        if (e instanceof WebClientResponseException wcre) {
+            return e.getClass().getSimpleName() + " status=" + wcre.getStatusCode().value();
+        }
+        return e.getClass().getSimpleName();
     }
 }

--- a/src/main/java/com/cookeep/cookeep/domain/recipe/dto/GeminiRecipeRequestDto.java
+++ b/src/main/java/com/cookeep/cookeep/domain/recipe/dto/GeminiRecipeRequestDto.java
@@ -94,13 +94,23 @@ public class GeminiRecipeRequestDto {
                 "required", List.of("user_ingredients")
         );
 
+        // step
+        Map<String, Object> stepItem = Map.of(
+                "type", "object",
+                "properties", Map.of(
+                        "content", Map.of("type", "string"),
+                        "usedIngredientIds", Map.of("type", "array", "items", Map.of("type", "integer"))
+                ),
+                "required", List.of("content", "usedIngredientIds")
+        );
+
         // 최상위 schema
         Map<String, Object> schema = Map.of(
                 "type", "object",
                 "properties", Map.of(
                         "title",       Map.of("type", "string"),
                         "ingredients", ingredients,
-                        "steps",       Map.of("type", "array", "items", Map.of("type", "string")),
+                        "steps",       Map.of("type", "array", "items", stepItem),
                         "youtube_search_queries", Map.of(
                                 "type", "array",
                                 "items", Map.of("type", "string")
@@ -183,13 +193,26 @@ public class GeminiRecipeRequestDto {
                 "required", List.of("user_ingredients")
         );
 
+        // step
+        Map<String, Object> stepItem = Map.of(
+                "type", "object",
+                "properties", Map.of(
+                        "content", Map.of("type", "string"),
+                        "usedIngredientIds", Map.of(
+                                "type", "array",
+                                "items", Map.of("type", "integer")
+                        )
+                ),
+                "required", List.of("content", "usedIngredientIds")
+        );
+
         // 최상위 schema
         Map<String, Object> schema = Map.of(
                 "type", "object",
                 "properties", Map.of(
                         "title",       Map.of("type", "string"),
                         "ingredients", ingredients,
-                        "steps",       Map.of("type", "array", "items", Map.of("type", "string")),
+                        "steps",       Map.of("type", "array", "items", stepItem),
                         "youtube_search_queries", Map.of(
                                 "type", "array",
                                 "items", Map.of("type", "string")

--- a/src/main/java/com/cookeep/cookeep/domain/recipe/dto/GeminiRecipeResponseDto.java
+++ b/src/main/java/com/cookeep/cookeep/domain/recipe/dto/GeminiRecipeResponseDto.java
@@ -105,9 +105,9 @@ public class GeminiRecipeResponseDto {
                 String content = node.get("content").asText();
                 List<Long> usedIds = new ArrayList<>();
                 for (JsonNode idNode : node.get("usedIngredientIds")) {
-                    if (!idNode.isIntegralNumber()) {
+                    if (!idNode.isIntegralNumber() || !idNode.canConvertToLong()) {
                         throw com.fasterxml.jackson.databind.JsonMappingException.from(
-                                p, "usedIngredientIds must contain integers"
+                                p, "usedIngredientIds must contain 64-bit integers"
                         );
                     }
                     usedIds.add(idNode.asLong());

--- a/src/main/java/com/cookeep/cookeep/domain/recipe/dto/GeminiRecipeResponseDto.java
+++ b/src/main/java/com/cookeep/cookeep/domain/recipe/dto/GeminiRecipeResponseDto.java
@@ -2,11 +2,17 @@ package com.cookeep.cookeep.domain.recipe.dto;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Schema(
@@ -41,11 +47,43 @@ public class GeminiRecipeResponseDto {
 
     @Getter
     @NoArgsConstructor
+    @JsonDeserialize(using = Step.StepDeserializer.class)
     public static class Step {
+
         private String content;
 
         @JsonProperty("usedIngredientIds")
         private List<Long> usedIngredientIds;
+
+        Step(String content, List<Long> usedIngredientIds) {
+            this.content = content;
+            this.usedIngredientIds = usedIngredientIds;
+        }
+
+        // 레거시 문자열 포맷인지 여부 (usedIngredientIds 정보 자체가 없음)
+        public boolean isLegacyFormat() {
+            return usedIngredientIds == null;
+        }
+
+        static class StepDeserializer extends JsonDeserializer<Step> {
+            @Override
+            public Step deserialize(JsonParser p, DeserializationContext ctxt) throws java.io.IOException {
+                JsonNode node = p.getCodec().readTree(p);
+
+                // 레거시 포맷: 순수 문자열 → usedIngredientIds는 null(정보 없음)로 표시
+                if (node.isTextual()) {
+                    return new Step(node.asText(), null);
+                }
+
+                // 신규 포맷: {content, usedIngredientIds}
+                String content = node.hasNonNull("content") ? node.get("content").asText() : null;
+                List<Long> usedIds = new ArrayList<>();
+                if (node.has("usedIngredientIds") && node.get("usedIngredientIds").isArray()) {
+                    node.get("usedIngredientIds").forEach(idNode -> usedIds.add(idNode.asLong()));
+                }
+                return new Step(content, usedIds);
+            }
+        }
     }
 
     @Schema(

--- a/src/main/java/com/cookeep/cookeep/domain/recipe/dto/GeminiRecipeResponseDto.java
+++ b/src/main/java/com/cookeep/cookeep/domain/recipe/dto/GeminiRecipeResponseDto.java
@@ -39,19 +39,35 @@ public class GeminiRecipeResponseDto {
     private Ingredients ingredients;
 
     @Schema(
-            description = "조리 단계 목록",
-            example = "[\"1. 팬에 기름을 두른다\", \"2. 재료를 볶는다\", \"3. 밥을 넣고 섞는다\"]",
+            description = "조리 단계 목록. content + usedIngredientIds 조합으로 작성됨.",
+            example = "[{\"content\": \"팬에 기름을 두른다\", \"usedIngredientIds\": []}, "
+                    + "{\"content\": \"양파와 김치를 볶는다\", \"usedIngredientIds\": [3, 7]}, "
+                    + "{\"content\": \"밥을 넣고 섞는다\", \"usedIngredientIds\": [12]}]",
             requiredMode = Schema.RequiredMode.REQUIRED
     )
     private List<Step> steps;
 
+    @Schema(
+            name = "GeminiRecipeStep",
+            description = "조리 단계 DTO"
+    )
     @Getter
     @NoArgsConstructor
     @JsonDeserialize(using = Step.StepDeserializer.class)
     public static class Step {
 
+        @Schema(
+                description = "조리 단계 설명",
+                example = "양파와 김치를 볶는다",
+                requiredMode = Schema.RequiredMode.REQUIRED
+        )
         private String content;
 
+        @Schema(
+                description = "해당 단계에서 사용된 재료 ID 목록 (레거시 포맷인 경우 null)",
+                example = "[3, 7]",
+                requiredMode = Schema.RequiredMode.NOT_REQUIRED
+        )
         @JsonProperty("usedIngredientIds")
         private List<Long> usedIngredientIds;
 

--- a/src/main/java/com/cookeep/cookeep/domain/recipe/dto/GeminiRecipeResponseDto.java
+++ b/src/main/java/com/cookeep/cookeep/domain/recipe/dto/GeminiRecipeResponseDto.java
@@ -37,7 +37,16 @@ public class GeminiRecipeResponseDto {
             example = "[\"1. 팬에 기름을 두른다\", \"2. 재료를 볶는다\", \"3. 밥을 넣고 섞는다\"]",
             requiredMode = Schema.RequiredMode.REQUIRED
     )
-    private List<String> steps;
+    private List<Step> steps;
+
+    @Getter
+    @NoArgsConstructor
+    public static class Step {
+        private String content;
+
+        @JsonProperty("usedIngredientIds")
+        private List<Long> usedIngredientIds;
+    }
 
     @Schema(
             description = "참고용 유튜브 영상 목록",

--- a/src/main/java/com/cookeep/cookeep/domain/recipe/dto/GeminiRecipeResponseDto.java
+++ b/src/main/java/com/cookeep/cookeep/domain/recipe/dto/GeminiRecipeResponseDto.java
@@ -75,11 +75,26 @@ public class GeminiRecipeResponseDto {
                     return new Step(node.asText(), null);
                 }
 
-                // 신규 포맷: {content, usedIngredientIds}
-                String content = node.hasNonNull("content") ? node.get("content").asText() : null;
+                // 신규 포맷: content(문자열)와 usedIngredientIds(배열)를 모두 필수로 검증
+                if (!node.isObject()
+                        || !node.hasNonNull("content")
+                        || !node.get("content").isTextual()
+                        || !node.has("usedIngredientIds")
+                        || !node.get("usedIngredientIds").isArray()) {
+                    throw com.fasterxml.jackson.databind.JsonMappingException.from(
+                            p, "step must contain textual content and array usedIngredientIds"
+                    );
+                }
+
+                String content = node.get("content").asText();
                 List<Long> usedIds = new ArrayList<>();
-                if (node.has("usedIngredientIds") && node.get("usedIngredientIds").isArray()) {
-                    node.get("usedIngredientIds").forEach(idNode -> usedIds.add(idNode.asLong()));
+                for (JsonNode idNode : node.get("usedIngredientIds")) {
+                    if (!idNode.isIntegralNumber()) {
+                        throw com.fasterxml.jackson.databind.JsonMappingException.from(
+                                p, "usedIngredientIds must contain integers"
+                        );
+                    }
+                    usedIds.add(idNode.asLong());
                 }
                 return new Step(content, usedIds);
             }

--- a/src/main/java/com/cookeep/cookeep/domain/recipe/dto/YoutubeReferenceDto.java
+++ b/src/main/java/com/cookeep/cookeep/domain/recipe/dto/YoutubeReferenceDto.java
@@ -17,23 +17,30 @@ import lombok.NoArgsConstructor;
 public class YoutubeReferenceDto {
 
     @Schema(
-            description = "유튜브 영상 제목",
+            description = "유튜브 영상 제목 (검색 결과가 없는 경우 안내 문구가 들어감)",
             example = "김치볶음밥 황금레시피",
             requiredMode = Schema.RequiredMode.REQUIRED
     )
     private String title;
 
     @Schema(
-            description = "유튜브 영상 URL",
+            description = "유튜브 영상 URL (검색 결과가 없는 경우 null)",
             example = "https://www.youtube.com/watch?v=abcdef",
-            requiredMode = Schema.RequiredMode.REQUIRED
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
     )
     private String url;
 
     @Schema(
-            description = "유튜브 영상 썸네일 URL",
+            description = "유튜브 영상 썸네일 URL (검색 결과가 없는 경우 null)",
             example = "https://img.youtube.com/vi/abcdef/0.jpg",
             requiredMode = Schema.RequiredMode.NOT_REQUIRED
     )
     private String thumbnail;
+
+    @Schema(
+            description = "실제 검색에 사용된 원본 검색어 (검색 결과 없어도 검색어는 존재함)",
+            example = "김치볶음밥 만들기",
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
+    private String searchQuery;
 }


### PR DESCRIPTION
# Issue
#295 

# Description
1. RateLimit 수정 (1분 당 3회 -> 5회로 수정)
  일부 레시피의 경우 생성 속도가 빨라 1분 내 재생성을 3회 이상 시도하는 케이스가 발생했습니다. 이와 관련하여 사용자 입장에서 기능 오류로 느껴질 수 있다는 점이 우려되어 레시피 재생성 제한 횟수인 5회로 수정하였습니다.
2. 세션 조회 시 feature 정보 같이 조회되도록 수정
  GET /api/users/me/ai/recipes/sessions/{sessionId} 응답에서 세션의 feature 정보가 누락되어 있었습니다. 세션 상세 조회 시 해당 세션의 feature 값(일반 레시피는 선택된 feature, 랜덤 레시피는 ANY로 고정)을 응답에 포함하도록 수정했습니다.
3. 유튜브 링크 검색 누락 문제 해결
  AI 랜덤 레시피 생성 시 youtubeReferences 필드가 응답에서 통째로 누락되거나, 검색 실패/결과 없음 상황에 대한 처리가 없어 유튜브 참고 영상 정보가 비정상적으로 빠지는 문제를 발견했습니다. 기존 YoutubeSearchService는 YouTube API 호출 실패(타임아웃/5xx/네트워크 오류)와 정상 호출인데 검색 결과가 0건인 경우를 구분하지 않고 동일하게 처리(로그만 남기고 해당 쿼리를 결과에서 누락)하고 있었습니다.
  - API 호출 자체의 일시적 오류는 재시도(backoff)하도록 하고
  - 정상 응답인데 결과가 없는 경우는 수식어를 제거한 대체 쿼리로 1회 재검색하도록 하고
  - 그래도 결과가 없으면 전체 레시피 생성을 실패시키지 않고 "결과 없음" placeholder를 채워 반환하도록 수정했습니다 (검색어는 유지되어 프론트에서 표시 가능)
4. 일반 레시피 최초 생성 에러메시지 수정
  이전 변경에서 레시피 생성 시 난이도 입력하던 기능을 feature 입력으로 수정하면서 AiRecipeController 내 에러 메시지 수정이 누락되었던 부분을 수정했습니다.
5. 레시피 응답에 [사용한 재료 개수] 필드 추가
  기존 방식에서 재료 채택 시 레시피 steps에서 실제로 사용되지 않은 재료가 차감되는 현상이 있었습니다. 이를 해결하기 위해 steps를 문자열 배열이 아닌 {content, usedIngredientIds} 객체 배열로 스키마를 변경하여, 각 조리 단계가 실제로 사용한 재료 id를 명시하도록 했습니다. 이 정보를 기반으로 "사용한 재료 개수" 표시와 "채택 시 재고 차감" 로직을 실제 사용 여부에 맞게 재계산하도록 수정했습니다.

+) 테스트 시 편리함을 위해 UserIngredientCreateRequestDto 내 expirationDate example 수정 (2026-07-20 -> 2026-08-20)

---

# Changes
### 1. RateLimit 수정
- AiRateLimitService: LIMIT 변수 5로 수정
### 2. 세션에 feature 정보 추가
- AiSessionDetailResponseDto.java
  - sessionId 하위에 최상위 feature 필드 추가 (Swagger @Schema 설명 포함)
- AiRecipeService.java
  - `getSessionDetail(Long userId, Long sessionId)` 응답 빌더에 .feature(session.getFeature()) 추가하여 세션의 feature 값을 최상위 필드로 매핑
### 3. 유튜브 링크 검색 누락 문제 해결
- YoutubeReferenceDto.java
  - 신규 필드 추가: searchQuery — 결과 항목별로 실제 사용된 원본 검색어를 담는 필드 (성공/실패 무관 항상 반환)
  - 필드 수정: url, thumbnail의 requiredMode를 REQUIRED → NOT_REQUIRED로 변경 (결과 없음 케이스에서 null이 정상 상태이므로 문서와 실제 동작 일치시킴)
 - YoutubeSearchService.java
   - `retryWithFallbackQuery()` — 1차 검색 결과가 없을 때 대체 쿼리로 재검색 수행, 실패 시 not-found placeholder 반환
  - `callYoutubeApi()` — 기존 searchSingleVideo의 HTTP 호출 부분을 분리, retryWhen으로 API 호출 자체의 일시적 오류(타임아웃/5xx/네트워크)에 한해 최대 2회 backoff 재시도 적용
  - `isRetriableApiError()` — 재시도 대상 예외 판별 (5xx/타임아웃/네트워크 오류만 true, 4xx나 파싱 오류는 재시도 대상 아님)
  - `buildFallbackQuery()` — 검색어에서 흔한 수식어(만들기, 레시피, 간단한 등)를 제거해 더 넓은 대체 쿼리 생성. 더 단순화할 수 없으면 null 반환
  - `buildNotFoundReference()` — 재시도/대체쿼리까지 모두 실패한 경우 "관련 유튜브 영상 없음" placeholder 생성 (검색어는 원본 유지)
  - `searchVideos()` — 최상위 onErrorResume에서 Mono.empty() 대신 Mono.just(buildNotFoundReference(query)) 반환하도록 변경. 이에 따라 입력 검색어 개수 == 출력 리스트 크기가 항상 보장됨
  - `searchSingleVideo()` — 기존에는 HTTP 호출 + 파싱을 한 번에 처리했으나, callYoutubeApi 호출 후 결과가 없으면(switchIfEmpty) retryWithFallbackQuery로 넘어가도록 흐름 변경
  - `parseSearchResult()` — 버그 수정: 성공 케이스 반환 시 builder 체인에 .searchQuery(searchQuery)가 누락되어 있어 응답에는 null로 나가던 문제 수정 (로그에는 정상 출력되어 발견이 늦어졌던 부분)
### 4. 일반 레시피 최초 생성 에러메시지 수정
- AiRecipeController
  - `generateRecipe` 의 @ApiErrorCodeExamples, @ApiResponse 에서 INVALID_DIFFICULTY 를 INVALID_FEATURE 로 수정
### 5. 레시피 응답에 [사용한 재료 개수] 필드 추가
- GeminiRecipeRequestDto.java
  - `buildGenerationConfig()` - steps 응답 스키마를 string[] → {content, usedIngredientIds}[] 객체 스키마로 변경
  - `buildGenerationConfig(Integer minUserIngredients)` - 랜덤 레시피 생성 스키마도 동일하게 steps 정의 변경 (기존에 이 부분만 누락되어 랜덤 레시피 생성 시 파싱 오류 발생하던 버그 포함 수정)
- GeminiRecipeResponseDto.java
  - steps 타입을 List<String> → List<Step>으로 변경
  - 신규 이너 클래스: Step -> content(조리 설명), usedIngredientIds(해당 단계에서 실제 사용된 재료 id 목록) 필드 포함
- GeminiService.java
  - `buildPrompt()` - steps 작성 규칙에 "각 단계는 실제 사용 재료의 ingredientId를 usedIngredientIds에 명시하고, 사용하지 않은 재료는 어떤 step에도 포함하지 말 것" 규칙 추가
  - `buildRandomPrompt()` - 동일한 규칙을 랜덤 레시피 프롬프트에도 추가
- AiRecipeResponseDto.java
  - `usedIngredientCount `- 보유 재료 중 실제 레시피에 사용된 재료 개수 (프론트 "n개를 사용했어요" 문구 표시용)
- AiRecipeService.java
  - `extractActuallyUsedIngredientIds(GeminiRecipeResponseDto)` - steps 전체를 순회하여 실제로 참조된 ingredientId 집합 추출
  - `countActuallyUsedIngredients(GeminiRecipeResponseDto)` - user_ingredients 중 extractActuallyUsedIngredientIds 결과에 포함된 것만 카운트
  - `generateInitialRecipe, regenerateRecipe, generateRandomRecipe, regenerateRandomRecipe` - 응답 빌드 시 usedIngredientCount(countActuallyUsedIngredients(aiResponse)) 추가
  - `adoptRecipe` - rawContent를 GeminiRecipeResponseDto로 재파싱하여 extractActuallyUsedIngredientIds로 실사용 id 집합을 구하고, 요청 재료 id 중 이 집합에 포함된 것만 필터링하여 ingredientIds로 사용 → 이 값이 grantUrgentCookieRewardIfEligible, consumeIngredientsAndTrackExpiringGoal에 전달되어 실사용 재료만 보상/차감 대상이 됨

# Test Checklist
- 1분 내 3번 이상 재생성 시 정상적으로 재시도 되는 것 확인 완료
- 세션 상세 정보 호출 시 (GET /api/users/me/ai/recipes/sessions/{sessionId}) feature 정보 반환 확인
- 유튜브 검색 실패 시 쿼리 수정 후 재검색 확인 (로그 통해 재검색 시도 확인 완료)
- 스웨거 통해 feature 관련 에러 메시지 문구 수정 확인
- 유효하지 않은 feature 입력 후 레시치 생성 시도 시 INVALID_FEATURE 에러 정상적으로 노출되는 것 확인
- 레시피 응답에 사용된 재료 개수 카운팅 확인
- 레시피 내 step 에서 {content, usedIngredientIds} 조합으로 스키마 생성 확인
- 재료 채택 시 실제 step에서 사용된 재료만 채택 후 개수 차감되는 것 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 새 기능
* AI 레시피에 실제 사용된 보유 재료 수가 표시됩니다.
* 세션 상세에서 요리 종류를 확인할 수 있습니다.
* 레시피 단계별 사용 재료 정보와 YouTube 검색어가 제공됩니다.

## 개선
* AI 요청 한도가 분당 5회로 상향됩니다.
* 레시피 채택 시 실제 사용된 재료만 차감 및 보상에 반영됩니다.
* YouTube 검색 결과가 없으면 대체 검색을 시도하고, 실패 시 안내 정보를 제공합니다.

## 문서
* API 오류 예시, 필드 설명 및 샘플 값이 갱신됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->