### PR TITLE
[COOKEEP-85] 재료 등록 시 '직접 입력' 선택 가능하도록 수정

### DIFF
--- a/src/main/java/com/cookeep/cookeep/api/controller/MyPlantController.java
+++ b/src/main/java/com/cookeep/cookeep/api/controller/MyPlantController.java
@@ -59,19 +59,19 @@ public class MyPlantController {
         return ResponseEntity.ok(DataResponse.from(response));
     }
 
-    @Operation(summary = "프로필 식물 지정", description = "내 보유 식물 ID를 경로에 전달하여 대표 프로필로 설정합니다.")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "지정 성공"),
-            @ApiResponse(responseCode = "403", description = "본인의 식물이 아님"),
-            @ApiResponse(responseCode = "404", description = "유저 또는 식물을 찾을 수 없음")
-    })
-    @PatchMapping("/{userPlantId}/profile") // /api/my-plants/{userPlantId}/profile
-    public ResponseEntity<DataResponse<Void>> updateProfilePlant(
-            @AuthenticationPrincipal(expression = "userId") Long userId,
-            @Parameter(description = "유저 보유 식물 ID (user_plant_id)") @PathVariable long userPlantId) {
-        userPlantService.updateProfilePlant(userId, userPlantId);
-        return ResponseEntity.ok(DataResponse.from(null));
-    }
+//    @Operation(summary = "프로필 식물 지정", description = "내 보유 식물 ID를 경로에 전달하여 대표 프로필로 설정합니다.")
+//    @ApiResponses(value = {
+//            @ApiResponse(responseCode = "200", description = "지정 성공"),
+//            @ApiResponse(responseCode = "403", description = "본인의 식물이 아님"),
+//            @ApiResponse(responseCode = "404", description = "유저 또는 식물을 찾을 수 없음")
+//    })
+//    @PatchMapping("/{userPlantId}/profile") // /api/my-plants/{userPlantId}/profile
+//    public ResponseEntity<DataResponse<Void>> updateProfilePlant(
+//            @AuthenticationPrincipal(expression = "userId") Long userId,
+//            @Parameter(description = "유저 보유 식물 ID (user_plant_id)") @PathVariable long userPlantId) {
+//        userPlantService.updateProfilePlant(userId, userPlantId);
+//        return ResponseEntity.ok(DataResponse.from(null));
+//    }
 
     @Operation(summary = "식물 키우기 포기", description = "성장이 정지된 식물을 포기하고 삭제합니다.")
     @ApiResponses(value = {

--- a/src/main/java/com/cookeep/cookeep/api/controller/ProfileImageController.java
+++ b/src/main/java/com/cookeep/cookeep/api/controller/ProfileImageController.java
@@ -37,8 +37,7 @@ public class ProfileImageController {
             ErrorCode.INTERNAL_SERVER_ERROR
     })
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "조회 성공",
-                    content = @Content(schema = @Schema(implementation = ProfileImageListResponseDto.class))),
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
             @ApiResponse(responseCode = "401", description = """
             인증 실패입니다.
             - UNAUTHORIZED: 인증에 실패했습니다.

--- a/src/main/java/com/cookeep/cookeep/api/controller/ProfileImageController.java
+++ b/src/main/java/com/cookeep/cookeep/api/controller/ProfileImageController.java
@@ -9,6 +9,10 @@ import com.cookeep.cookeep.domain.user.application.ProfileImageService;
 import com.cookeep.cookeep.domain.user.application.UserInfoService;
 import com.cookeep.cookeep.security.UserPrincipal;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -26,11 +30,27 @@ public class ProfileImageController {
     private final UserInfoService userInfoService;
     private final ProfileImageService profileImageService;
 
-    @Operation(summary = "프로필 이미지 목록 조회", description = "선택 가능한 프리셋 프로필 이미지 6종을 조회합니다.")
+    @Operation(summary = "프로필 이미지 목록 조회", description = "선택 가능한 프로필 이미지 12종을 S3에서 조회합니다.")
     @ApiErrorCodeExamples({
             ErrorCode.UNAUTHORIZED,
             ErrorCode.USER_NOT_FOUND,
             ErrorCode.INTERNAL_SERVER_ERROR
+    })
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공",
+                    content = @Content(schema = @Schema(implementation = ProfileImageListResponseDto.class))),
+            @ApiResponse(responseCode = "401", description = """
+            인증 실패입니다.
+            - UNAUTHORIZED: 인증에 실패했습니다.
+            """, content = @Content),
+            @ApiResponse(responseCode = "404", description = """
+            리소스를 찾을 수 없습니다.
+            - USER_NOT_FOUND: 존재하지 않는 사용자입니다.
+            """, content = @Content),
+            @ApiResponse(responseCode = "500", description = """
+            서버 오류입니다.
+            - INTERNAL_SERVER_ERROR: 서버 내부에서 에러가 발생하였습니다.
+            """, content = @Content)
     })
     @GetMapping("/profile-images")
     public ResponseEntity<DataResponse<ProfileImageListResponseDto>> getProfileImages(

--- a/src/main/java/com/cookeep/cookeep/api/controller/UserInfoController.java
+++ b/src/main/java/com/cookeep/cookeep/api/controller/UserInfoController.java
@@ -171,12 +171,31 @@ public class UserInfoController {
         return ResponseEntity.ok(DataResponse.ok());
     }
 
-    @Operation(summary = "프로필 이미지 수정", description = "프리셋 프로필 이미지 6종 중 하나로 프로필 이미지를 변경합니다.")
+    @Operation(summary = "프로필 이미지 수정", description = "프리셋 프로필 이미지 12종 중 하나로 프로필 이미지를 변경합니다.")
     @ApiErrorCodeExamples({
             ErrorCode.UNAUTHORIZED,
             ErrorCode.USER_NOT_FOUND,
             ErrorCode.INVALID_PROFILE_IMAGE_ID,
             ErrorCode.INTERNAL_SERVER_ERROR
+    })
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "프로필 이미지 수정 성공"),
+            @ApiResponse(responseCode = "400", description = """
+            요청이 잘못되었습니다.
+            - INVALID_PROFILE_IMAGE_ID: 유효하지 않은 프로필 이미지 ID입니다.
+            """, content = @Content),
+            @ApiResponse(responseCode = "401", description = """
+            인증 실패입니다.
+            - UNAUTHORIZED: 인증에 실패했습니다.
+            """, content = @Content),
+            @ApiResponse(responseCode = "404", description = """
+            리소스를 찾을 수 없습니다.
+            - USER_NOT_FOUND: 존재하지 않는 사용자입니다.
+            """, content = @Content),
+            @ApiResponse(responseCode = "500", description = """
+            서버 오류입니다.
+            - INTERNAL_SERVER_ERROR: 서버 내부에서 에러가 발생하였습니다.
+            """, content = @Content)
     })
     @PatchMapping("/profile-images")
     public ResponseEntity<DataResponse<Void>> updateProfileImage(

--- a/src/main/java/com/cookeep/cookeep/api/controller/UserIngredientController.java
+++ b/src/main/java/com/cookeep/cookeep/api/controller/UserIngredientController.java
@@ -76,13 +76,19 @@ public class UserIngredientController {
             ErrorCode.USER_NOT_FOUND,
             ErrorCode.INGREDIENT_REFERENCE_NOT_FOUND,
             ErrorCode.INTERNAL_SERVER_ERROR,
-            ErrorCode.INVALID_INGREDIENT_REQUEST
+            ErrorCode.INVALID_INGREDIENT_REQUEST,
+            ErrorCode.CUSTOM_UNIT_NAME_REQUIRED,
+            ErrorCode.CUSTOM_UNIT_NAME_NOT_ALLOWED,
+            ErrorCode.CUSTOM_UNIT_NAME_TOO_LONG
     })
     @ApiResponses(value = {
             @ApiResponse(responseCode = "201", description = "식재료 등록 성공"),
             @ApiResponse(responseCode = "400", description = """
                     잘못된 요청입니다.
                     - INVALID_INGREDIENT_REQUEST: 필수값 누락 또는 ENUM 값 오류
+                    - CUSTOM_UNIT_NAME_REQUIRED: "직접입력" 시 사용할 custom_unit_name 입력 필요
+                    - CUSTOM_UNIT_NAME_NOT_ALLOWED: "직접입력"이 아닌 기본 단위 사용 시 custom_unit_name 입력 불가
+                    - CUSTOM_UNIT_NAME_TOO_LONG: custom_unit_name 길이 초과 (VARCHAR(500)
                     """, content = @Content),
             @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content),
             @ApiResponse(responseCode = "404", description = """

--- a/src/main/java/com/cookeep/cookeep/api/dto/request/UserIngredientCreateRequestDto.java
+++ b/src/main/java/com/cookeep/cookeep/api/dto/request/UserIngredientCreateRequestDto.java
@@ -22,7 +22,7 @@ public class UserIngredientCreateRequestDto {
     @NotNull(message = "식재료 타입은 필수입니다.")
     @Schema(
             description = "식재료 타입 (DEFAULT / CUSTOM)",
-            example = "CUSTOM",
+            example = "DEFAULT",
             requiredMode = Schema.RequiredMode.REQUIRED
     )
     private Type type;

--- a/src/main/java/com/cookeep/cookeep/api/dto/request/UserIngredientCreateRequestDto.java
+++ b/src/main/java/com/cookeep/cookeep/api/dto/request/UserIngredientCreateRequestDto.java
@@ -42,7 +42,7 @@ public class UserIngredientCreateRequestDto {
     @Schema(
             description = "수량 단위 (미입력 시 DEFAULT=db값, CUSTOM=PIECE)",
             example = "PIECE",
-            allowableValues = {"PIECE", "PACK", "BAG", "BOTTLE", "BUNDLE", "CAN", "GRAM", "MILLILITER"},
+            allowableValues = {"PIECE", "PACK", "BAG", "BOTTLE", "BUNDLE", "CAN", "GRAM", "MILLILITER", "CUSTOM"},
             requiredMode = Schema.RequiredMode.NOT_REQUIRED
     )
     private Unit unit;
@@ -70,4 +70,11 @@ public class UserIngredientCreateRequestDto {
             requiredMode = Schema.RequiredMode.NOT_REQUIRED
     )
     private String memo;
+
+    @Schema(
+            description = "직접 입력한 단위명. unit == CUSTOM일 때만 사용, 필수",
+            example = "상자",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    private String customUnitName;
 }

--- a/src/main/java/com/cookeep/cookeep/api/dto/response/MyPlantResponseDto.java
+++ b/src/main/java/com/cookeep/cookeep/api/dto/response/MyPlantResponseDto.java
@@ -14,13 +14,13 @@ public class MyPlantResponseDto {
     private Integer level;         // 성장 단계 (1~4)
     private Boolean isHarvested;   // 수확 여부 (false면 '키우는 중', true면 '수확 완료')
     private Boolean isFrozen;      // 성장 정지 여부 (14일 미접속 시 true)
-    private Boolean isProfile;     // 현재 이 식물이 유저의 프로필 식물인지 여부
+    //private Boolean isProfile;     // 현재 이 식물이 유저의 프로필 식물인지 여부
     private String createdAt;      // 언제부터 키웠는지 (BaseEntity 활용)
 
     public static MyPlantResponseDto from(UserPlant userPlant, User user) {
-        // 유저의 profile_plant_id와 현재 식물의 ID가 같으면 true
-        boolean isProfile = user.getProfilePlant() != null &&
-                user.getProfilePlant().getUserPlantId().equals(userPlant.getUserPlantId());
+//        // 유저의 profile_plant_id와 현재 식물의 ID가 같으면 true
+//        boolean isProfile = user.getProfilePlant() != null &&
+//                user.getProfilePlant().getUserPlantId().equals(userPlant.getUserPlantId());
 
         return MyPlantResponseDto.builder()
                 .userPlantId(userPlant.getUserPlantId())
@@ -29,7 +29,7 @@ public class MyPlantResponseDto {
                 .level(userPlant.getLevel())
                 .isHarvested(userPlant.getIsHarvested())
                 .isFrozen(userPlant.getIsFrozen())
-                .isProfile(isProfile)
+                //.isProfile(isProfile)
                 .createdAt(userPlant.getCreatedAt().toLocalDate().toString())
                 .build();
     }

--- a/src/main/java/com/cookeep/cookeep/api/dto/response/RefrigeratorSearchResponseDto.java
+++ b/src/main/java/com/cookeep/cookeep/api/dto/response/RefrigeratorSearchResponseDto.java
@@ -105,5 +105,12 @@ public class RefrigeratorSearchResponseDto {
                 requiredMode = Schema.RequiredMode.REQUIRED
         )
         private Unit unit;
+
+        @Schema(
+                description = "직접 입력한 단위명 (unit이 CUSTOM일 때만 값 존재)",
+                example = "상자",
+                requiredMode = Schema.RequiredMode.NOT_REQUIRED
+        )
+        private String customUnitName;
     }
 }

--- a/src/main/java/com/cookeep/cookeep/api/dto/response/UserIngredientCreateResponseDto.java
+++ b/src/main/java/com/cookeep/cookeep/api/dto/response/UserIngredientCreateResponseDto.java
@@ -33,6 +33,9 @@ public class UserIngredientCreateResponseDto {
     @Schema(description = "단위", example = "PIECE")
     private String unit;
 
+    @Schema(description = "직접 입력한 단위명 (unit이 CUSTOM일 때만 값 존재)", example = "상자")
+    private String customUnitName;
+
     @Schema(description = "보관 장소", example = "FRIDGE")
     private String storage;
 
@@ -63,6 +66,7 @@ public class UserIngredientCreateResponseDto {
                 ingredientName,
                 userIngredient.getQuantity(),
                 userIngredient.getUnit().name(),
+                userIngredient.getCustomUnitName(),
                 userIngredient.getStorage().name(),
                 userIngredient.getExpirationDate(),
                 userIngredient.getLeftDays(),

--- a/src/main/java/com/cookeep/cookeep/api/dto/response/UserIngredientDetailResponseDto.java
+++ b/src/main/java/com/cookeep/cookeep/api/dto/response/UserIngredientDetailResponseDto.java
@@ -70,6 +70,13 @@ public class UserIngredientDetailResponseDto {
     private Unit unit;
 
     @Schema(
+            description = "직접 입력한 단위명 (unit이 CUSTOM일 때만 값 존재)",
+            example = "상자",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    private String customUnitName;
+
+    @Schema(
             description = "메모",
             example = "샐러드용",
             requiredMode = Schema.RequiredMode.NOT_REQUIRED

--- a/src/main/java/com/cookeep/cookeep/common/exception/ErrorCode.java
+++ b/src/main/java/com/cookeep/cookeep/common/exception/ErrorCode.java
@@ -34,6 +34,7 @@ public enum ErrorCode {
 	INVALID_INGREDIENT_REQUEST(HttpStatus.BAD_REQUEST, "type과 referenceId는 필수 입력입니다.", "INGREDIENT-011"),
 	CUSTOM_UNIT_NAME_REQUIRED(HttpStatus.BAD_REQUEST, "직접입력 시 사용할 단위명을 입력하세요.", "INGREDIENT-012"),
 	CUSTOM_UNIT_NAME_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "CUSTOM unit 사용 시에만 단위명을 입력하세요.", "INGREDIENT-013"),
+	CUSTOM_UNIT_NAME_TOO_LONG(HttpStatus.BAD_REQUEST, "직접 입력 단위명은 최대 255자까지 입력 가능합니다.", "INGREDIENT-014"),
 
 	// COOKIE
 	NOT_ENOUGH_COOKIES(HttpStatus.BAD_REQUEST, "보유한 쿠키가 부족합니다.", "COOKIE-001"),

--- a/src/main/java/com/cookeep/cookeep/common/exception/ErrorCode.java
+++ b/src/main/java/com/cookeep/cookeep/common/exception/ErrorCode.java
@@ -32,6 +32,7 @@ public enum ErrorCode {
 	MEMO_TOO_LONG(HttpStatus.BAD_REQUEST, "식재료 메모는 최대 100자까지 입력 가능합니다.", "INGREDIENT_009"),
 	INVALID_DELETE_REQUEST(HttpStatus.BAD_REQUEST, "삭제할 식재료를 입력해주세요.", "INGREDIENT_010"),
 	INVALID_INGREDIENT_REQUEST(HttpStatus.BAD_REQUEST, "type과 referenceId는 필수 입력입니다.", "INGREDIENT-011"),
+	CUSTOM_UNIT_NAME_REQUIRED(HttpStatus.BAD_REQUEST, "직접입력 시 사용할 단위명을 입력하세요.", "INGREDIENT-012"),
 
 	// COOKIE
 	NOT_ENOUGH_COOKIES(HttpStatus.BAD_REQUEST, "보유한 쿠키가 부족합니다.", "COOKIE-001"),

--- a/src/main/java/com/cookeep/cookeep/common/exception/ErrorCode.java
+++ b/src/main/java/com/cookeep/cookeep/common/exception/ErrorCode.java
@@ -33,6 +33,7 @@ public enum ErrorCode {
 	INVALID_DELETE_REQUEST(HttpStatus.BAD_REQUEST, "삭제할 식재료를 입력해주세요.", "INGREDIENT_010"),
 	INVALID_INGREDIENT_REQUEST(HttpStatus.BAD_REQUEST, "type과 referenceId는 필수 입력입니다.", "INGREDIENT-011"),
 	CUSTOM_UNIT_NAME_REQUIRED(HttpStatus.BAD_REQUEST, "직접입력 시 사용할 단위명을 입력하세요.", "INGREDIENT-012"),
+	CUSTOM_UNIT_NAME_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "CUSTOM unit 사용 시에만 단위명을 입력하세요.", "INGREDIENT-013"),
 
 	// COOKIE
 	NOT_ENOUGH_COOKIES(HttpStatus.BAD_REQUEST, "보유한 쿠키가 부족합니다.", "COOKIE-001"),

--- a/src/main/java/com/cookeep/cookeep/domain/ingredient/common/domain/Unit.java
+++ b/src/main/java/com/cookeep/cookeep/domain/ingredient/common/domain/Unit.java
@@ -9,7 +9,8 @@ public enum Unit {
     BUNDLE("묶음"),
     CAN("캔"),
     GRAM("g"),
-    MILLILITER("ml");
+    MILLILITER("ml"),
+    CUSTOM("직접입력");
 
     private final String displayName;
 

--- a/src/main/java/com/cookeep/cookeep/domain/ingredient/useringredient/application/UserIngredientServiceImpl.java
+++ b/src/main/java/com/cookeep/cookeep/domain/ingredient/useringredient/application/UserIngredientServiceImpl.java
@@ -36,6 +36,7 @@ public class UserIngredientServiceImpl implements UserIngredientService {
 
     private static final int DEFAULT_QUANTITY = 1;
     private static final Unit DEFAULT_CUSTOM_UNIT = Unit.PIECE;
+    private static final int CUSTOM_UNIT_NAME_MAX_LENGTH = 255;
 
     private final UserIngredientRepository userIngredientRepository;
     private final DefaultIngredientRepository defaultIngredientRepository;
@@ -210,7 +211,13 @@ public class UserIngredientServiceImpl implements UserIngredientService {
             if (customUnitName == null || customUnitName.isBlank()) {
                 throw new AppException(ErrorCode.CUSTOM_UNIT_NAME_REQUIRED);
             }
-            return customUnitName.trim();
+            String trimmed = customUnitName.trim();
+
+            if (trimmed.length() > CUSTOM_UNIT_NAME_MAX_LENGTH) {
+                throw new AppException(ErrorCode.CUSTOM_UNIT_NAME_TOO_LONG);
+            }
+
+            return trimmed;
         }
 
         // CUSTOM이 아닌데 값이 들어온 경우 명시적으로 거부

--- a/src/main/java/com/cookeep/cookeep/domain/ingredient/useringredient/application/UserIngredientServiceImpl.java
+++ b/src/main/java/com/cookeep/cookeep/domain/ingredient/useringredient/application/UserIngredientServiceImpl.java
@@ -125,6 +125,7 @@ public class UserIngredientServiceImpl implements UserIngredientService {
 
         int quantity = req.getQuantity()!= null ? req.getQuantity():DEFAULT_QUANTITY;
         Unit unit = req.getUnit()!= null ? req.getUnit():ref.getUnit();
+        String customUnitName = resolveCustomUnitName(unit, req.getCustomUnitName());
         Storage storage = req.getStorage()!= null ? req.getStorage():ref.getDefaultStorage();
         LocalDate expiration = req.getExpirationDate()!= null ? req.getExpirationDate():calcExpiration(ref.getDefaultExpirationDays());
         String memo = req.getMemo();
@@ -135,6 +136,7 @@ public class UserIngredientServiceImpl implements UserIngredientService {
                 .referenceId(ref.getId())
                 .quantity(quantity)
                 .unit(unit)
+                .customUnitName(customUnitName)
                 .storage(storage)
                 .expirationDate(expiration)
                 .memo(memo)
@@ -161,6 +163,7 @@ public class UserIngredientServiceImpl implements UserIngredientService {
 
         int quantity = req.getQuantity()!= null ? req.getQuantity():DEFAULT_QUANTITY;
         Unit unit = req.getUnit()!= null ? req.getUnit():DEFAULT_CUSTOM_UNIT;
+        String customUnitName = resolveCustomUnitName(unit, req.getCustomUnitName());
         Storage storage = req.getStorage()!= null ? req.getStorage():ref.getStorage();
         LocalDate expiration = req.getExpirationDate() != null ? req.getExpirationDate():calcExpiration(ref.getExpirationDays());
         String memo = req.getMemo();
@@ -171,6 +174,7 @@ public class UserIngredientServiceImpl implements UserIngredientService {
                 .referenceId(ref.getId())
                 .quantity(quantity)
                 .unit(unit)
+                .customUnitName(customUnitName)
                 .storage(storage)
                 .expirationDate(expiration)
                 .memo(memo)
@@ -200,4 +204,14 @@ public class UserIngredientServiceImpl implements UserIngredientService {
         return false;
     }
 
+    // [직접입력] 선택 시 단위 입력
+    private String resolveCustomUnitName(Unit unit, String customUnitName) {
+        if (unit == Unit.CUSTOM) {
+            if (customUnitName == null || customUnitName.isBlank()) {
+                throw new AppException(ErrorCode.CUSTOM_UNIT_NAME_REQUIRED);
+            }
+            return customUnitName.trim();
+        }
+        return null; // CUSTOM이 아니면 항상 null
+    }
 }

--- a/src/main/java/com/cookeep/cookeep/domain/ingredient/useringredient/application/UserIngredientServiceImpl.java
+++ b/src/main/java/com/cookeep/cookeep/domain/ingredient/useringredient/application/UserIngredientServiceImpl.java
@@ -212,6 +212,12 @@ public class UserIngredientServiceImpl implements UserIngredientService {
             }
             return customUnitName.trim();
         }
+
+        // CUSTOM이 아닌데 값이 들어온 경우 명시적으로 거부
+        if (customUnitName != null && !customUnitName.isBlank()) {
+            throw new AppException(ErrorCode.CUSTOM_UNIT_NAME_NOT_ALLOWED);
+        }
+
         return null; // CUSTOM이 아니면 항상 null
     }
 }

--- a/src/main/java/com/cookeep/cookeep/domain/ingredient/useringredient/entity/UserIngredient.java
+++ b/src/main/java/com/cookeep/cookeep/domain/ingredient/useringredient/entity/UserIngredient.java
@@ -59,12 +59,16 @@ public class UserIngredient extends BaseEntity {
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
+    @Column(name = "custom_unit_name", nullable = true)
+    private String customUnitName;
+
     @Builder
     public UserIngredient(
             Type type,
             Long referenceId,
             Integer quantity,
             Unit unit, Storage storage,
+            String customUnitName,
             LocalDate expirationDate,
             String memo,
             User user,
@@ -75,6 +79,7 @@ public class UserIngredient extends BaseEntity {
         this.quantity = quantity;
         this.unit = unit;
         this.storage = storage;
+        this.customUnitName = customUnitName;
         this.expirationDate = expirationDate;
         this.memo = memo;
         this.user = user;

--- a/src/main/java/com/cookeep/cookeep/domain/plant/application/UserPlantService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/plant/application/UserPlantService.java
@@ -95,24 +95,24 @@ public class UserPlantService {
     }
 
     // 프로필 식물 지정
-    @Transactional
-    public void updateProfilePlant(Long userId, Long userPlantId) {
-        // 1. 유저 조회
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new AppException(ErrorCode.NOT_FOUND));
-
-        // 2. 변경할 식물 조회
-        UserPlant userPlant = userPlantRepository.findById(userPlantId)
-                .orElseThrow(() -> new AppException(ErrorCode.PLANT_NOT_FOUND));
-
-        // 3. 보안 체크: 이 식물의 주인이 현재 로그인한 유저가 맞는지 검증
-        if (!userPlant.getUser().getUserId().equals(userId)) {
-            throw new AppException(ErrorCode.NOT_MY_PLANT); // 본인 식물이 아닐 경우 예외 발생
-        }
-
-        // 4. 프로필 식물 업데이트 (더티 체킹에 의해 자동 반영)
-        user.updateProfilePlant(userPlant);
-    }
+//    @Transactional
+//    public void updateProfilePlant(Long userId, Long userPlantId) {
+//        // 1. 유저 조회
+//        User user = userRepository.findById(userId)
+//                .orElseThrow(() -> new AppException(ErrorCode.NOT_FOUND));
+//
+//        // 2. 변경할 식물 조회
+//        UserPlant userPlant = userPlantRepository.findById(userPlantId)
+//                .orElseThrow(() -> new AppException(ErrorCode.PLANT_NOT_FOUND));
+//
+//        // 3. 보안 체크: 이 식물의 주인이 현재 로그인한 유저가 맞는지 검증
+//        if (!userPlant.getUser().getUserId().equals(userId)) {
+//            throw new AppException(ErrorCode.NOT_MY_PLANT); // 본인 식물이 아닐 경우 예외 발생
+//        }
+//
+//        // 4. 프로필 식물 업데이트 (더티 체킹에 의해 자동 반영)
+//        user.updateProfilePlant(userPlant);
+//    }
 
     // 현재 키우는 식물 등록 (첫 식물 등록 여부 + userPlantId 반환)
     @Transactional
@@ -140,8 +140,8 @@ public class UserPlantService {
 
         userPlantRepository.save(newUserPlant);
 
-        // 5. 자동 모드(isProfileAutoUpdate=true)일 때만 프로필 갱신
-        user.setProfilePlantAuto(newUserPlant);
+//        // 5. 자동 모드(isProfileAutoUpdate=true)일 때만 프로필 갱신
+//        user.setProfilePlantAuto(newUserPlant);
 
         // 6. 새 식물 등록 시 plantStatus를 NORMAL로 초기화
         // (키우는 식물 없이 14일+ 미접속 후 로그인하면 FROZEN이 설정될 수 있으므로)
@@ -168,11 +168,11 @@ public class UserPlantService {
             throw new AppException(ErrorCode.PLANT_NOT_FROZEN);
         }
 
-        // 4. 삭제한 식물이 현재 프로필 식물이라면 연관 관계 해제
-        User user = userPlant.getUser();
-        if (user.getProfilePlant() != null && user.getProfilePlant().getUserPlantId().equals(userPlantId)) {
-            user.updateProfilePlant(null);
-        }
+//        // 4. 삭제한 식물이 현재 프로필 식물이라면 연관 관계 해제
+//        User user = userPlant.getUser();
+//        if (user.getProfilePlant() != null && user.getProfilePlant().getUserPlantId().equals(userPlantId)) {
+//            user.updateProfilePlant(null);
+//        }
 
         // 5. 식물 삭제
         userPlantRepository.delete(userPlant);

--- a/src/main/java/com/cookeep/cookeep/domain/refrigerator/application/RefrigeratorService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/refrigerator/application/RefrigeratorService.java
@@ -130,6 +130,7 @@ public class RefrigeratorService {
                 .expirationDate(userIngredient.getExpirationDate())
                 .quantity(userIngredient.getQuantity())
                 .unit(userIngredient.getUnit())
+                .customUnitName(userIngredient.getCustomUnitName())
                 .leftDays(userIngredient.getLeftDays())
                 .memo(userIngredient.getMemo())
                 .aiTip(aiTip)
@@ -196,6 +197,7 @@ public class RefrigeratorService {
                             .expirationDate(ui.getExpirationDate())
                             .quantity(ui.getQuantity())
                             .unit(ui.getUnit())
+                            .customUnitName(ui.getCustomUnitName())
                             .build();
                 })
                 .collect(Collectors.toList());

--- a/src/main/java/com/cookeep/cookeep/domain/user/application/UserInfoService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/user/application/UserInfoService.java
@@ -228,7 +228,7 @@ public class UserInfoService {
     public void updateProfileImage(Long userId, ProfileImageUpdateRequestDto request) {
         User user = userReader.readById(userId);
 
-        // 유효한 imageId인지 검증 (1~6 범위 밖이면 예외)
+        // 유효한 imageId인지 검증 (1~12 범위 밖이면 예외)
         ProfileImages.fromId(request.imageId());
 
         user.updateProfileImage(request.imageId());

--- a/src/main/java/com/cookeep/cookeep/domain/user/entity/ProfileImages.java
+++ b/src/main/java/com/cookeep/cookeep/domain/user/entity/ProfileImages.java
@@ -14,7 +14,13 @@ public enum ProfileImages {
     IMAGE_3(3, "3.png"),
     IMAGE_4(4, "4.png"),
     IMAGE_5(5, "5.png"),
-    IMAGE_6(6, "6.png");
+    IMAGE_6(6, "6.png"),
+    IMAGE_7(7, "7.png"),
+    IMAGE_8(8, "8.png"),
+    IMAGE_9(9, "9.png"),
+    IMAGE_10(10, "10.png"),
+    IMAGE_11(11, "11.png"),
+    IMAGE_12(12, "12.png");
 
     private final int imageId;
     private final String fileName;

--- a/src/main/java/com/cookeep/cookeep/domain/user/entity/User.java
+++ b/src/main/java/com/cookeep/cookeep/domain/user/entity/User.java
@@ -94,13 +94,13 @@ public class User extends BaseEntity {
 	@Enumerated(EnumType.STRING)
 	private PlantStatus plantStatus = PlantStatus.NORMAL;
 
-	@OneToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "profile_plant_id")
-	private UserPlant profilePlant;
-
-	@Builder.Default
-	@Column(nullable = false)
-	private boolean isProfileAutoUpdate = true; // 프로필 식물 변경을 자동 or 수동 모드 관리
+//	@OneToOne(fetch = FetchType.LAZY)
+//	@JoinColumn(name = "profile_plant_id")
+//	private UserPlant profilePlant;
+//
+//	@Builder.Default
+//	@Column(nullable = false)
+//	private boolean isProfileAutoUpdate = true; // 프로필 식물 변경을 자동 or 수동 모드 관리
 
 	@Builder.Default
 	@Column(nullable = false)
@@ -124,18 +124,18 @@ public class User extends BaseEntity {
 	@Column(name = "profile_image_id", nullable = false)
 	private int profileImageId = 1; // 프로필 이미지 프리셋 ID (기본값 1)
 
-	// 유저가 API를 통해 직접 프로필을 변경할 때 호출
-	public void updateProfilePlant(UserPlant nesUserPlant) {
-		this.profilePlant = nesUserPlant;
-		this.isProfileAutoUpdate = false; // 수동으로 변경하면 자동 갱신 모드 해제
-	}
-
-	// 새로운 식물 등록 시 시스템에 의해 호출
-	public void setProfilePlantAuto(UserPlant userPlant) {
-		if (this.isProfileAutoUpdate) {
-			this.profilePlant = userPlant;
-		}
-	}
+//	// 유저가 API를 통해 직접 프로필을 변경할 때 호출
+//	public void updateProfilePlant(UserPlant nesUserPlant) {
+//		this.profilePlant = nesUserPlant;
+//		this.isProfileAutoUpdate = false; // 수동으로 변경하면 자동 갱신 모드 해제
+//	}
+//
+//	// 새로운 식물 등록 시 시스템에 의해 호출
+//	public void setProfilePlantAuto(UserPlant userPlant) {
+//		if (this.isProfileAutoUpdate) {
+//			this.profilePlant = userPlant;
+//		}
+//	}
 
 	public void updateCookieCnt(int amount) {
 		this.cookieCnt += amount;

--- a/src/main/resources/db/migration/V10__drop_profile_plant_columns_from_users.sql
+++ b/src/main/resources/db/migration/V10__drop_profile_plant_columns_from_users.sql
@@ -1,14 +1,10 @@
 -- src/main/resources/db/migration/V10__drop_profile_plant_columns_from_users.sql
 
 -- FK 제약조건 먼저 제거 (컬럼/인덱스보다 선행되어야 함)
-ALTER TABLE users
-DROP FOREIGN KEY FK2rjifh48h13w869flwypbuup8;
-
 -- UNIQUE 인덱스 제거
-ALTER TABLE users
-DROP INDEX UK5f54qvapcu07iindngrju7rwl;
-
 -- 컬럼 제거
 ALTER TABLE users
-DROP COLUMN profile_plant_id,
+    DROP FOREIGN KEY FK2rjifh48h13w869flwypbuup8,
+    DROP INDEX UK5f54qvapcu07iindngrju7rwl,
+    DROP COLUMN profile_plant_id,
     DROP COLUMN is_profile_auto_update;

--- a/src/main/resources/db/migration/V10__drop_profile_plant_columns_from_users.sql
+++ b/src/main/resources/db/migration/V10__drop_profile_plant_columns_from_users.sql
@@ -1,0 +1,14 @@
+-- src/main/resources/db/migration/V10__drop_profile_plant_columns_from_users.sql
+
+-- FK 제약조건 먼저 제거 (컬럼/인덱스보다 선행되어야 함)
+ALTER TABLE users
+DROP FOREIGN KEY FK2rjifh48h13w869flwypbuup8;
+
+-- UNIQUE 인덱스 제거
+ALTER TABLE users
+DROP INDEX UK5f54qvapcu07iindngrju7rwl;
+
+-- 컬럼 제거
+ALTER TABLE users
+DROP COLUMN profile_plant_id,
+    DROP COLUMN is_profile_auto_update;

--- a/src/main/resources/db/migration/V11__add_custom_unit_name_to_user_ingredient.sql
+++ b/src/main/resources/db/migration/V11__add_custom_unit_name_to_user_ingredient.sql
@@ -1,0 +1,9 @@
+-- src/main/resources/db/migration/V11__drop_add_custom_unit_name_to_user_ingredient.sql
+
+-- Unit ENUM에 CUSTOM 추가
+ALTER TABLE user_ingredients
+    MODIFY COLUMN unit ENUM('PIECE','PACK','BAG','BOTTLE','BUNDLE','CAN','GRAM','MILLILITER','CUSTOM') NOT NULL;
+
+
+-- user_ingredients에 custom_unit_name 컬럼 추가
+ALTER TABLE user_ingredients ADD COLUMN custom_unit_name VARCHAR(255) NULL;


### PR DESCRIPTION
# Issue
#302 

# Description
식재료 등록 시 목록에 없는 단위를 입력하기 위해 "직접입력" 선택 시 INVALID_UNIT_TYPE 에러가 발생하던 문제를 해결했습니다.
Unit enum에 CUSTOM 값을 추가하고, 사용자가 "직접입력"을 선택했을 때 실제로 입력한 단위 텍스트를 별도 컬럼(customUnitName)에 저장 및 조회할 수 있도록 등록/조회 전체 흐름을 수정했습니다.

# Changes
### Entity
`Unit.java`
- CUSTOM("직접입력") 값 추가
`UserIngredient.java`
- customUnitName (String, nullable) 필드 추가
- @Builder 생성자에 customUnitName 파라미터 추가

### Dto
`UserIngredientCreateRequestDto.java`
- customUnitName 필드 추가
- unit의 allowableValues에 "CUSTOM" 추가

`UserIngredientCreateResponseDto.java`
- customUnitName 필드 추가, of() 생성 로직 반영

`UserIngredientDetailResponseDto.java`, `RefrigeratorSearchResponseDto`
- customUnitName 필드 추가

### Service
`UserIngredientServiceImpl.java`
- createFromDefault, createFromCustom 공통으로 사용하는 resolveCustomUnitName(Unit unit, String customUnitName) 검증 메서드 추가
- unit == CUSTOM이면서 customUnitName이 비어있으면 CUSTOM_UNIT_NAME_REQUIRED 에러
- unit != CUSTOM인데 customUnitName이 전달되면 CUSTOM_UNIT_NAME_NOT_ALLOWED 에러
- UserIngredient 저장 시 customUnitName 값 반영

`RefrigeratorService.java`
- getIngredientDetail()에서 UserIngredientDetailResponseDto 빌드 시 customUnitName(userIngredient.getCustomUnitName()) 추가
- searchIngredients()에 customUnitName(userIngredient.getCustomUnitName()) 추가

### ErrorCode
- CUSTOM_UNIT_NAME_REQUIRED (INGREDIENT-012) 추가
- CUSTOM_UNIT_NAME_NOT_ALLOWED (INGREDIENT-013) 추가

### DB Migration
- ENUM에 CUSTOM 추가
- user_ingredients 테이블에 custom_unit_name 컬럼 추가

# Test Checklist
- CUSTOM 단위 사용 시 custom_unit_name 미입력 에러 정상 처리 확인
- 기본 단위 사용 시 custom_unit_name에 값 입력 시도 시 에러 정상 처리 확인
- CUSTOM unit으로 재료 저장 후 상세 조회 시 직접 입력한 단위 정상 노출 확인
- CUSTOM unit으로 재료 저장 후 냉장고 내 재료 검색 시 직접 입력한 단위 정상 노출 확인
- 커스텀 식재료 등록 후 냉장고 등록 시 CUSTOM unit 사용 정상 처리 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 식재료 등록 시 `CUSTOM` 단위와 직접 입력한 단위명을 지원합니다.
  * 식재료 상세·검색·등록 결과에 사용자 지정 단위명이 표시됩니다.
  * 선택 가능한 프로필 이미지가 6종에서 12종으로 확대되었습니다.

* **변경 사항**
  * 대표 프로필 식물 지정 및 자동 갱신 기능이 비활성화되었습니다.
  * 식물 목록 응답에서 대표 식물 여부 정보가 제외됩니다.

* **오류 개선**
  * `CUSTOM` 단위명 누락 또는 부적절한 입력 시 명확한 오류를 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->