### PR TITLE
refactor: 비밀번호 변경 전 Redis 기반 일회용 재인증 토큰 도입

### DIFF
--- a/src/main/java/com/cookeep/cookeep/api/controller/UserInfoController.java
+++ b/src/main/java/com/cookeep/cookeep/api/controller/UserInfoController.java
@@ -3,20 +3,26 @@ package com.cookeep.cookeep.api.controller;
 import com.cookeep.cookeep.api.dto.request.*;
 import com.cookeep.cookeep.api.dto.response.DislikeIngredientResponseDto;
 import com.cookeep.cookeep.api.dto.response.ProfileImageListResponseDto;
+import com.cookeep.cookeep.api.dto.response.ReauthenticationResponseDTO;
 import com.cookeep.cookeep.api.dto.response.UserProfileResponseDTO;
 import com.cookeep.cookeep.common.dto.DataResponse;
 import com.cookeep.cookeep.common.exception.ErrorCode;
 import com.cookeep.cookeep.config.ApiErrorCodeExamples;
 import com.cookeep.cookeep.domain.user.application.UserInfoService;
+import com.cookeep.cookeep.security.RefreshTokenCookieProvider;
 import com.cookeep.cookeep.security.UserPrincipal;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.headers.Header;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -28,6 +34,7 @@ import org.springframework.web.bind.annotation.*;
 public class UserInfoController {
 
     private final UserInfoService userInfoService;
+    private final RefreshTokenCookieProvider refreshTokenCookieProvider;
 
     // 회원정보 조회
     @Operation(summary = "회원정보 조회 API")
@@ -86,39 +93,57 @@ public class UserInfoController {
     // 비밀번호 확인
     @Operation(summary =  "비밀번호 확인 API")
     @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = "요청 성공"),
+        @ApiResponse(
+            responseCode = "200",
+            description = "재인증 토큰 발급 성공",
+            content = @Content(schema = @Schema(implementation = ReauthenticationResponseDTO.class))
+        ),
         @ApiResponse(responseCode = "400", description = "요청 파라미터 오류(@Valid 검증 실패, 비밀번호 불일치)"),
         @ApiResponse(responseCode = "401", description = "회원 인증 실패, AccessToken이 없거나 유효하지 않음"),
-        @ApiResponse(responseCode = "403", description = "접근 권한 없음"),
-        @ApiResponse(responseCode = "423", description = "비밀번호 검증 시도 가능 횟수 초과")
+        @ApiResponse(responseCode = "403", description = "소셜 회원은 비밀번호 확인 불가"),
+        @ApiResponse(responseCode = "423", description = "비밀번호 검증 시도 가능 횟수 초과"),
+        @ApiResponse(responseCode = "503", description = "Redis 재인증 서비스 사용 불가")
     })
     @PostMapping("/password/verify")
-    public ResponseEntity<DataResponse<Void>> verifyMyPassword(
+    public ResponseEntity<DataResponse<ReauthenticationResponseDTO>> verifyMyPassword(
         @AuthenticationPrincipal UserPrincipal principal,
         @Valid @RequestBody VerifyPasswordRequestDTO verifyPasswordRequestDTO
     ) {
         Long userId = principal.userId();
-        userInfoService.verifyMyPassword(userId, verifyPasswordRequestDTO);
-        return ResponseEntity.ok(DataResponse.ok());
+        return ResponseEntity.ok(DataResponse.from(
+            userInfoService.verifyMyPassword(userId, verifyPasswordRequestDTO)));
     }
 
 
     // 비밀번호 변경
     @Operation(summary = "비밀번호 변경 API")
     @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = "요청 성공"),
+        @ApiResponse(
+            responseCode = "200",
+            description = "비밀번호 변경 및 Refresh Cookie 만료 성공",
+            headers = @Header(
+                name = HttpHeaders.SET_COOKIE,
+                description = "만료된 Refresh Token Cookie",
+                schema = @Schema(type = "string")
+            )
+        ),
         @ApiResponse(responseCode = "400", description = "요청 파라미터 오류(@Valid 검증 실패, 기존 비밀번호와 동일 등)"),
-        @ApiResponse(responseCode = "401", description = "회원 인증 실패, AccessToken이 없거나 유효하지 않음"),
-        @ApiResponse(responseCode = "403", description = "접근 권한 없음(소셜 로그인 유저는 비밀번호 변경 불가 등)")
+        @ApiResponse(responseCode = "401", description = "Access Token 또는 Reauth Token 누락·무효"),
+        @ApiResponse(responseCode = "403", description = "소셜 회원은 비밀번호 변경 불가"),
+        @ApiResponse(responseCode = "503", description = "Redis 재인증 서비스 사용 불가")
     })
     @PatchMapping("/password")
     public ResponseEntity<DataResponse<Void>> updateMyPassword(
         @AuthenticationPrincipal UserPrincipal principal,
+        @Parameter(description = "비밀번호 확인 API에서 발급한 일회용 토큰", required = true)
+        @RequestHeader(value = "X-Reauth-Token", required = false) String reauthToken,
         @Valid @RequestBody UpdatePasswordRequestDTO updatePasswordRequestDTO
     ) {
         Long userId = principal.userId();
-        userInfoService.updateMyPassword(userId, updatePasswordRequestDTO);
-        return ResponseEntity.ok(DataResponse.ok());
+        userInfoService.updateMyPassword(userId, reauthToken, updatePasswordRequestDTO);
+        return ResponseEntity.ok()
+            .header(HttpHeaders.SET_COOKIE, refreshTokenCookieProvider.delete().toString())
+            .body(DataResponse.ok());
     }
 
     // 알림설정 변경

--- a/src/main/java/com/cookeep/cookeep/api/dto/response/ReauthenticationResponseDTO.java
+++ b/src/main/java/com/cookeep/cookeep/api/dto/response/ReauthenticationResponseDTO.java
@@ -1,0 +1,7 @@
+package com.cookeep.cookeep.api.dto.response;
+
+public record ReauthenticationResponseDTO(
+	String reauthToken,
+	long expiresInSeconds
+) {
+}

--- a/src/main/java/com/cookeep/cookeep/common/exception/ErrorCode.java
+++ b/src/main/java/com/cookeep/cookeep/common/exception/ErrorCode.java
@@ -105,6 +105,8 @@ public enum ErrorCode {
 	UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증에 실패했습니다.", "AUTH-001"),
 	INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 리프레쉬 토큰입니다.", "AUTH-002"),
 	AUTH_PASSWORD_MISMATCH (HttpStatus.UNAUTHORIZED, "비밀번호가 올바르지 않습니다.", "AUTH-003"),
+	REAUTH_TOKEN_REQUIRED(HttpStatus.UNAUTHORIZED, "비밀번호 변경을 위한 재인증 토큰이 필요합니다.", "AUTH-011"),
+	INVALID_REAUTH_TOKEN(HttpStatus.UNAUTHORIZED, "재인증 토큰이 유효하지 않거나 만료되었습니다.", "AUTH-012"),
 
 	// ==============================
 	// 403 FORBIDDEN
@@ -128,6 +130,7 @@ public enum ErrorCode {
 	// USER
 	USER_ACCOUNT_WITHDRAWN(HttpStatus.FORBIDDEN, "탈퇴한 회원입니다.", "USER-010"),
 	SOCIAL_USER_EMAIL_CHANGE_NOT_ALLOWED(HttpStatus.FORBIDDEN, "소셜 로그인 사용자는 이메일을 변경할 수 없습니다.", "USER-009"),
+	SOCIAL_USER_PASSWORD_CHANGE_NOT_ALLOWED(HttpStatus.FORBIDDEN, "소셜 회원은 비밀번호 확인 및 변경을 사용할 수 없습니다.", "AUTH-013"),
 
 	// ==============================
 	// 404 NOT FOUND
@@ -239,6 +242,7 @@ public enum ErrorCode {
 
 	// RECIPE
 	AI_SERVER_FAILED(HttpStatus.SERVICE_UNAVAILABLE, "AI 서비스가 일시적으로 불안정합니다. 잠시 후 다시 시도해주세요.", "RECIPE-028"),
+	REAUTHENTICATION_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE, "재인증 서비스를 일시적으로 사용할 수 없습니다.", "AUTH-014"),
 	;
 
 	private final HttpStatus httpStatus;

--- a/src/main/java/com/cookeep/cookeep/domain/user/application/ReauthenticationPolicy.java
+++ b/src/main/java/com/cookeep/cookeep/domain/user/application/ReauthenticationPolicy.java
@@ -1,0 +1,12 @@
+package com.cookeep.cookeep.domain.user.application;
+
+import java.time.Duration;
+
+public final class ReauthenticationPolicy {
+
+	public static final Duration TOKEN_TTL = Duration.ofMinutes(5);
+	public static final long EXPIRES_IN_SECONDS = TOKEN_TTL.toSeconds();
+
+	private ReauthenticationPolicy() {
+	}
+}

--- a/src/main/java/com/cookeep/cookeep/domain/user/application/ReauthenticationService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/user/application/ReauthenticationService.java
@@ -1,0 +1,41 @@
+package com.cookeep.cookeep.domain.user.application;
+
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+import com.cookeep.cookeep.api.dto.response.ReauthenticationResponseDTO;
+import com.cookeep.cookeep.common.exception.AppException;
+import com.cookeep.cookeep.common.exception.ErrorCode;
+import com.cookeep.cookeep.domain.user.entity.ReauthenticationPurpose;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class ReauthenticationService {
+
+	private final ReauthenticationStore reauthenticationStore;
+
+	public ReauthenticationResponseDTO issueForPasswordChange(Long userId) {
+		String rawToken = reauthenticationStore.issue(
+			userId,
+			ReauthenticationPurpose.CHANGE_PASSWORD
+		);
+		return new ReauthenticationResponseDTO(rawToken, ReauthenticationPolicy.EXPIRES_IN_SECONDS);
+	}
+
+	public void assertTokenPresent(String rawToken) {
+		if (!StringUtils.hasText(rawToken)) {
+			throw new AppException(ErrorCode.REAUTH_TOKEN_REQUIRED);
+		}
+	}
+
+	public void consumeForPasswordChange(Long userId, String rawToken) {
+		assertTokenPresent(rawToken);
+		reauthenticationStore.consume(
+			userId,
+			ReauthenticationPurpose.CHANGE_PASSWORD,
+			rawToken
+		);
+	}
+}

--- a/src/main/java/com/cookeep/cookeep/domain/user/application/ReauthenticationStore.java
+++ b/src/main/java/com/cookeep/cookeep/domain/user/application/ReauthenticationStore.java
@@ -1,0 +1,10 @@
+package com.cookeep.cookeep.domain.user.application;
+
+import com.cookeep.cookeep.domain.user.entity.ReauthenticationPurpose;
+
+public interface ReauthenticationStore {
+
+	String issue(Long userId, ReauthenticationPurpose purpose);
+
+	void consume(Long userId, ReauthenticationPurpose purpose, String rawToken);
+}

--- a/src/main/java/com/cookeep/cookeep/domain/user/application/RedisReauthenticationStore.java
+++ b/src/main/java/com/cookeep/cookeep/domain/user/application/RedisReauthenticationStore.java
@@ -1,0 +1,93 @@
+package com.cookeep.cookeep.domain.user.application;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.time.Duration;
+import java.util.Base64;
+import java.util.HexFormat;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DataAccessException;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+import com.cookeep.cookeep.common.exception.AppException;
+import com.cookeep.cookeep.common.exception.ErrorCode;
+import com.cookeep.cookeep.domain.user.entity.ReauthenticationPurpose;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+public class RedisReauthenticationStore implements ReauthenticationStore {
+
+	static final String KEY_PREFIX = "auth:reauth:";
+	private static final String STORED_VALUE = "1";
+	private static final int TOKEN_BYTES = 32;
+
+	private final StringRedisTemplate redisTemplate;
+	private final SecureRandom secureRandom;
+	private final Duration tokenTtl;
+
+	@Autowired
+	public RedisReauthenticationStore(StringRedisTemplate redisTemplate) {
+		this(redisTemplate, new SecureRandom(), ReauthenticationPolicy.TOKEN_TTL);
+	}
+
+	RedisReauthenticationStore(
+		StringRedisTemplate redisTemplate,
+		SecureRandom secureRandom,
+		Duration tokenTtl
+	) {
+		this.redisTemplate = redisTemplate;
+		this.secureRandom = secureRandom;
+		this.tokenTtl = tokenTtl;
+	}
+
+	@Override
+	public String issue(Long userId, ReauthenticationPurpose purpose) {
+		byte[] tokenBytes = new byte[TOKEN_BYTES];
+		secureRandom.nextBytes(tokenBytes);
+		String rawToken = Base64.getUrlEncoder().withoutPadding().encodeToString(tokenBytes);
+		String key = buildKey(userId, purpose, rawToken);
+
+		try {
+			redisTemplate.opsForValue().set(key, STORED_VALUE, tokenTtl);
+			return rawToken;
+		} catch (DataAccessException e) {
+			log.error("Failed to issue reauthentication token. userId={}, purpose={}", userId, purpose, e);
+			throw new AppException(ErrorCode.REAUTHENTICATION_UNAVAILABLE);
+		}
+	}
+
+	@Override
+	public void consume(Long userId, ReauthenticationPurpose purpose, String rawToken) {
+		String key = buildKey(userId, purpose, rawToken);
+
+		try {
+			String value = redisTemplate.opsForValue().getAndDelete(key);
+			if (value == null) {
+				throw new AppException(ErrorCode.INVALID_REAUTH_TOKEN);
+			}
+		} catch (DataAccessException e) {
+			log.error("Failed to consume reauthentication token. userId={}, purpose={}", userId, purpose, e);
+			throw new AppException(ErrorCode.REAUTHENTICATION_UNAVAILABLE);
+		}
+	}
+
+	static String buildKey(Long userId, ReauthenticationPurpose purpose, String rawToken) {
+		return KEY_PREFIX + userId + ":" + purpose.name() + ":" + digest(rawToken);
+	}
+
+	private static String digest(String rawToken) {
+		try {
+			byte[] digest = MessageDigest.getInstance("SHA-256").digest(rawToken.getBytes(UTF_8));
+			return HexFormat.of().formatHex(digest);
+		} catch (NoSuchAlgorithmException e) {
+			throw new IllegalStateException("SHA-256 is not available", e);
+		}
+	}
+}

--- a/src/main/java/com/cookeep/cookeep/domain/user/application/UserInfoService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/user/application/UserInfoService.java
@@ -9,11 +9,13 @@ import com.cookeep.cookeep.api.dto.request.*;
 import com.cookeep.cookeep.api.dto.response.DislikeIngredientResponseDto;
 import com.cookeep.cookeep.api.dto.response.ProfileImageListResponseDto;
 import com.cookeep.cookeep.api.dto.response.ProfileImageResponseDto;
+import com.cookeep.cookeep.api.dto.response.ReauthenticationResponseDTO;
 import com.cookeep.cookeep.api.dto.response.UserProfileResponseDTO;
 import com.cookeep.cookeep.common.exception.AppException;
 import com.cookeep.cookeep.common.exception.ErrorCode;
 import com.cookeep.cookeep.domain.user.dao.UserAuthRepository;
 import com.cookeep.cookeep.domain.user.dao.UserRepository;
+import com.cookeep.cookeep.domain.user.dao.UserSessionRepository;
 import com.cookeep.cookeep.domain.user.entity.ProfileImages;
 import com.cookeep.cookeep.domain.user.entity.Provider;
 import com.cookeep.cookeep.domain.user.entity.User;
@@ -39,6 +41,8 @@ public class UserInfoService {
     private final UserAuthRepository userAuthRepository;
     private final PasswordEncoder passwordEncoder;
     private final ProfileImageService profileImageService;
+    private final UserSessionRepository userSessionRepository;
+    private final ReauthenticationService reauthenticationService;
 
     // 비밀번호 입력 최대 시도 횟수
     private static final int MAX_ATTEMPTS = 5;
@@ -143,13 +147,20 @@ public class UserInfoService {
     // 비밀번호 확인
     // 비밀번호 검증 실패 횟수를 예외 발생 시에도 누적시키기 위해 rollback 제외하였음
     @Transactional(noRollbackFor = AppException.class)
-    public void verifyMyPassword(Long userId, VerifyPasswordRequestDTO verifyPasswordRequestDTO) {
+    public ReauthenticationResponseDTO verifyMyPassword(
+        Long userId,
+        VerifyPasswordRequestDTO verifyPasswordRequestDTO
+    ) {
         User user = userReader.readById(userId);
+        assertLocalPasswordUser(userId);
 
         if (passwordEncoder.matches(verifyPasswordRequestDTO.password(), user.getPassword())) {
+            ReauthenticationResponseDTO response =
+                reauthenticationService.issueForPasswordChange(userId);
+
             // 기존 비밀번호와 일치할 경우 passwordCnt 초기화
             user.updatePasswordCnt(0);
-            return;
+            return response;
         }
 
         // null일 경우 0으로 세팅 후 +1, 값이 있을 경우 해당 값을 가져오고 + 1
@@ -183,17 +194,37 @@ public class UserInfoService {
 
     // 비밀번호 변경
     @Transactional
-    public void updateMyPassword(Long userId, UpdatePasswordRequestDTO updatePasswordRequestDTO) {
-        User user = userReader.readById(userId);
-
-        String encodedPassword = passwordEncoder.encode(updatePasswordRequestDTO.password());
+    public void updateMyPassword(
+        Long userId,
+        String reauthToken,
+        UpdatePasswordRequestDTO updatePasswordRequestDTO
+    ) {
+        reauthenticationService.assertTokenPresent(reauthToken);
+        User user = userRepository.findByIdForUpdate(userId)
+            .orElseThrow(() -> new AppException(ErrorCode.USER_NOT_FOUND));
+        assertLocalPasswordUser(userId);
 
         // 기존에 등록되어 있던 비밀번호와 새로 들어온 비밀번호가 동일할 경우
         if (passwordEncoder.matches(updatePasswordRequestDTO.password(), user.getPassword())) {
             throw new AppException(ErrorCode.SAME_AS_PREVIOUS_PASSWORD);
         }
 
+        reauthenticationService.consumeForPasswordChange(userId, reauthToken);
+
+        String encodedPassword = passwordEncoder.encode(updatePasswordRequestDTO.password());
         user.updatePassword(encodedPassword);
+        user.updatePasswordCnt(0);
+        userSessionRepository.deleteByUser_UserId(userId);
+    }
+
+    private void assertLocalPasswordUser(Long userId) {
+        boolean hasLocalProvider = userAuthRepository.existsByUser_UserIdAndProvider(
+            userId,
+            Provider.LOCAL
+        );
+        if (!hasLocalProvider) {
+            throw new AppException(ErrorCode.SOCIAL_USER_PASSWORD_CHANGE_NOT_ALLOWED);
+        }
     }
 
     // 알림설정 변경

--- a/src/main/java/com/cookeep/cookeep/domain/user/dao/UserAuthRepository.java
+++ b/src/main/java/com/cookeep/cookeep/domain/user/dao/UserAuthRepository.java
@@ -20,4 +20,6 @@ public interface UserAuthRepository extends JpaRepository<UserAuth, Long> {
 	Provider findProviderByUserId(@Param("userId") Long userId);
 
 	Optional<UserAuth> findByProviderAndUser(Provider provider, User user);
+
+	boolean existsByUser_UserIdAndProvider(Long userId, Provider provider);
 }

--- a/src/main/java/com/cookeep/cookeep/domain/user/entity/ReauthenticationPurpose.java
+++ b/src/main/java/com/cookeep/cookeep/domain/user/entity/ReauthenticationPurpose.java
@@ -1,0 +1,5 @@
+package com.cookeep.cookeep.domain.user.entity;
+
+public enum ReauthenticationPurpose {
+	CHANGE_PASSWORD
+}

--- a/src/test/java/com/cookeep/cookeep/api/controller/UserInfoPasswordControllerTest.java
+++ b/src/test/java/com/cookeep/cookeep/api/controller/UserInfoPasswordControllerTest.java
@@ -1,0 +1,73 @@
+package com.cookeep.cookeep.api.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+
+import com.cookeep.cookeep.api.dto.request.UpdatePasswordRequestDTO;
+import com.cookeep.cookeep.api.dto.request.VerifyPasswordRequestDTO;
+import com.cookeep.cookeep.api.dto.response.ReauthenticationResponseDTO;
+import com.cookeep.cookeep.common.dto.DataResponse;
+import com.cookeep.cookeep.domain.user.application.UserInfoService;
+import com.cookeep.cookeep.security.RefreshTokenCookieProvider;
+import com.cookeep.cookeep.security.UserPrincipal;
+
+@ExtendWith(MockitoExtension.class)
+class UserInfoPasswordControllerTest {
+
+	@Mock
+	private UserInfoService userInfoService;
+
+	private UserInfoController controller;
+
+	@BeforeEach
+	void setUp() {
+		controller = new UserInfoController(
+			userInfoService,
+			new RefreshTokenCookieProvider(true)
+		);
+	}
+
+	@Test
+	void verifyPasswordReturnsReauthenticationTokenAndExpiry() {
+		VerifyPasswordRequestDTO request = new VerifyPasswordRequestDTO("old-password1");
+		given(userInfoService.verifyMyPassword(1L, request))
+			.willReturn(new ReauthenticationResponseDTO("reauth-token", 300));
+
+		ResponseEntity<DataResponse<ReauthenticationResponseDTO>> response =
+			controller.verifyMyPassword(new UserPrincipal(1L), request);
+
+		assertThat(response.getBody()).isNotNull();
+		assertThat(response.getBody().getData().reauthToken()).isEqualTo("reauth-token");
+		assertThat(response.getBody().getData().expiresInSeconds()).isEqualTo(300);
+	}
+
+	@Test
+	void updatePasswordPassesHeaderAndExpiresRefreshCookie() {
+		UpdatePasswordRequestDTO request =
+			new UpdatePasswordRequestDTO("new-password1", "new-password1");
+
+		ResponseEntity<DataResponse<Void>> response = controller.updateMyPassword(
+			new UserPrincipal(1L),
+			"reauth-token",
+			request
+		);
+
+		verify(userInfoService).updateMyPassword(1L, "reauth-token", request);
+		assertThat(response.getHeaders().getFirst(HttpHeaders.SET_COOKIE))
+			.contains("refreshToken=")
+			.contains("Path=/api/auth/refresh")
+			.contains("Max-Age=0")
+			.contains("Secure")
+			.contains("HttpOnly")
+			.contains("SameSite=Lax");
+	}
+}

--- a/src/test/java/com/cookeep/cookeep/domain/user/application/PasswordChangeLoginFlowTest.java
+++ b/src/test/java/com/cookeep/cookeep/domain/user/application/PasswordChangeLoginFlowTest.java
@@ -1,0 +1,141 @@
+package com.cookeep.cookeep.domain.user.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import com.cookeep.cookeep.api.dto.request.LoginRequestDTO;
+import com.cookeep.cookeep.api.dto.request.UpdatePasswordRequestDTO;
+import com.cookeep.cookeep.common.exception.AppException;
+import com.cookeep.cookeep.common.exception.ErrorCode;
+import com.cookeep.cookeep.domain.cookie.application.CookieService;
+import com.cookeep.cookeep.domain.notification.dao.WebPushSubscriptionRepository;
+import com.cookeep.cookeep.domain.user.dao.UserAuthRepository;
+import com.cookeep.cookeep.domain.user.dao.UserRepository;
+import com.cookeep.cookeep.domain.user.dao.UserSessionRepository;
+import com.cookeep.cookeep.domain.user.entity.Provider;
+import com.cookeep.cookeep.domain.user.entity.User;
+import com.cookeep.cookeep.domain.user.entity.UserSession;
+import com.cookeep.cookeep.domain.user.entity.UserStatus;
+import com.cookeep.cookeep.domain.verification.application.EmailVerificationService;
+import com.cookeep.cookeep.security.JwtTokenProvider;
+
+@ExtendWith(MockitoExtension.class)
+class PasswordChangeLoginFlowTest {
+
+	@Mock
+	private UserRepository userRepository;
+	@Mock
+	private UserAuthRepository userAuthRepository;
+	@Mock
+	private UserSessionRepository userSessionRepository;
+	@Mock
+	private JwtTokenProvider jwtTokenProvider;
+	@Mock
+	private UserReader userReader;
+	@Mock
+	private LoginPasswordFailureService loginPasswordFailureService;
+	@Mock
+	private NicknameGenerator nicknameGenerator;
+	@Mock
+	private EmailVerificationService emailVerificationService;
+	@Mock
+	private CookieService cookieService;
+	@Mock
+	private WebPushSubscriptionRepository webPushSubscriptionRepository;
+	@Mock
+	private OAuthProvider oAuthProvider;
+	@Mock
+	private ProfileImageService profileImageService;
+	@Mock
+	private ReauthenticationStore reauthenticationStore;
+
+	private final PasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
+
+	private UserInfoService userInfoService;
+	private AuthService authService;
+
+	@BeforeEach
+	void setUp() {
+		userInfoService = new UserInfoService(
+			userRepository,
+			userReader,
+			emailVerificationService,
+			userAuthRepository,
+			passwordEncoder,
+			profileImageService,
+			userSessionRepository,
+			new ReauthenticationService(reauthenticationStore)
+		);
+		authService = new AuthService(
+			userRepository,
+			userAuthRepository,
+			userSessionRepository,
+			jwtTokenProvider,
+			userReader,
+			passwordEncoder,
+			loginPasswordFailureService,
+			nicknameGenerator,
+			emailVerificationService,
+			cookieService,
+			webPushSubscriptionRepository,
+			List.of(oAuthProvider)
+		);
+	}
+
+	@Test
+	void oldPasswordCannotLoginAndNewPasswordCanLoginAfterChange() {
+		User user = User.builder()
+			.userId(1L)
+			.email("test@example.com")
+			.nickname("nickname")
+			.password(passwordEncoder.encode("old-password1"))
+			.passwordCnt(2)
+			.userStatus(UserStatus.ACTIVE)
+			.lastAccessAt(LocalDateTime.now())
+			.build();
+		given(userRepository.findByIdForUpdate(1L)).willReturn(Optional.of(user));
+		given(userAuthRepository.existsByUser_UserIdAndProvider(1L, Provider.LOCAL))
+			.willReturn(true);
+		given(userRepository.findByEmail("test@example.com")).willReturn(Optional.of(user));
+		given(loginPasswordFailureService.increasePasswordFailCount(1L)).willReturn(1);
+		given(jwtTokenProvider.createAccessToken(1L)).willReturn("access-token");
+		given(jwtTokenProvider.createRefreshToken(1L)).willReturn("refresh-token");
+		given(userSessionRepository.findByUser(user)).willReturn(Optional.empty());
+		given(userSessionRepository.save(any(UserSession.class)))
+			.willAnswer(invocation -> invocation.getArgument(0));
+
+		userInfoService.updateMyPassword(
+			1L,
+			"reauth-token",
+			new UpdatePasswordRequestDTO("new-password1", "new-password1")
+		);
+
+		assertThatThrownBy(() -> authService.login(
+			new LoginRequestDTO("test@example.com", "old-password1")
+		))
+			.isInstanceOf(AppException.class)
+			.extracting("errorCode")
+			.isEqualTo(ErrorCode.AUTH_PASSWORD_MISMATCH);
+
+		var loginResult = authService.login(
+			new LoginRequestDTO("test@example.com", "new-password1")
+		);
+
+		assertThat(loginResult.response().accessToken()).isEqualTo("access-token");
+		assertThat(loginResult.refreshToken()).isEqualTo("refresh-token");
+	}
+}

--- a/src/test/java/com/cookeep/cookeep/domain/user/application/PasswordReauthenticationServiceTest.java
+++ b/src/test/java/com/cookeep/cookeep/domain/user/application/PasswordReauthenticationServiceTest.java
@@ -1,0 +1,291 @@
+package com.cookeep.cookeep.domain.user.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import com.cookeep.cookeep.api.dto.request.UpdatePasswordRequestDTO;
+import com.cookeep.cookeep.api.dto.request.VerifyPasswordRequestDTO;
+import com.cookeep.cookeep.api.dto.response.ReauthenticationResponseDTO;
+import com.cookeep.cookeep.common.exception.AppException;
+import com.cookeep.cookeep.common.exception.ErrorCode;
+import com.cookeep.cookeep.domain.user.dao.UserAuthRepository;
+import com.cookeep.cookeep.domain.user.dao.UserRepository;
+import com.cookeep.cookeep.domain.user.dao.UserSessionRepository;
+import com.cookeep.cookeep.domain.user.entity.Provider;
+import com.cookeep.cookeep.domain.user.entity.ReauthenticationPurpose;
+import com.cookeep.cookeep.domain.user.entity.User;
+import com.cookeep.cookeep.domain.verification.application.EmailVerificationService;
+
+@ExtendWith(MockitoExtension.class)
+class PasswordReauthenticationServiceTest {
+
+	@Mock
+	private UserRepository userRepository;
+	@Mock
+	private UserReader userReader;
+	@Mock
+	private EmailVerificationService emailVerificationService;
+	@Mock
+	private UserAuthRepository userAuthRepository;
+	@Mock
+	private PasswordEncoder passwordEncoder;
+	@Mock
+	private ProfileImageService profileImageService;
+	@Mock
+	private UserSessionRepository userSessionRepository;
+	@Mock
+	private ReauthenticationStore reauthenticationStore;
+
+	private UserInfoService userInfoService;
+
+	@BeforeEach
+	void setUp() {
+		ReauthenticationService reauthenticationService =
+			new ReauthenticationService(reauthenticationStore);
+		userInfoService = new UserInfoService(
+			userRepository,
+			userReader,
+			emailVerificationService,
+			userAuthRepository,
+			passwordEncoder,
+			profileImageService,
+			userSessionRepository,
+			reauthenticationService
+		);
+	}
+
+	@Test
+	void correctCurrentPasswordIssuesReauthenticationToken() {
+		User user = user("encoded-old", 3);
+		given(userReader.readById(1L)).willReturn(user);
+		given(userAuthRepository.existsByUser_UserIdAndProvider(1L, Provider.LOCAL))
+			.willReturn(true);
+		given(passwordEncoder.matches("old-password1", "encoded-old")).willReturn(true);
+		given(reauthenticationStore.issue(1L, ReauthenticationPurpose.CHANGE_PASSWORD))
+			.willReturn("reauth-token");
+
+		ReauthenticationResponseDTO response = userInfoService.verifyMyPassword(
+			1L,
+			new VerifyPasswordRequestDTO("old-password1")
+		);
+
+		assertThat(response.reauthToken()).isEqualTo("reauth-token");
+		assertThat(response.expiresInSeconds()).isEqualTo(300);
+		assertThat(user.getPasswordCnt()).isZero();
+	}
+
+	@Test
+	void wrongCurrentPasswordDoesNotIssueToken() {
+		User user = user("encoded-old", 0);
+		given(userReader.readById(1L)).willReturn(user);
+		given(userAuthRepository.existsByUser_UserIdAndProvider(1L, Provider.LOCAL))
+			.willReturn(true);
+		given(passwordEncoder.matches("wrong-password", "encoded-old")).willReturn(false);
+
+		assertThatThrownBy(() -> userInfoService.verifyMyPassword(
+			1L,
+			new VerifyPasswordRequestDTO("wrong-password")
+		))
+			.isInstanceOf(AppException.class)
+			.extracting("errorCode")
+			.isEqualTo(ErrorCode.PASSWORD_MISMATCH);
+
+		assertThat(user.getPasswordCnt()).isEqualTo(1);
+		verify(reauthenticationStore, never()).issue(any(), any());
+	}
+
+	@Test
+	void socialUserCannotIssueToken() {
+		User user = user(null, null);
+		given(userReader.readById(1L)).willReturn(user);
+		given(userAuthRepository.existsByUser_UserIdAndProvider(1L, Provider.LOCAL))
+			.willReturn(false);
+
+		assertThatThrownBy(() -> userInfoService.verifyMyPassword(
+			1L,
+			new VerifyPasswordRequestDTO("password1")
+		))
+			.isInstanceOf(AppException.class)
+			.extracting("errorCode")
+			.isEqualTo(ErrorCode.SOCIAL_USER_PASSWORD_CHANGE_NOT_ALLOWED);
+
+		verify(passwordEncoder, never()).matches(any(), any());
+		verify(reauthenticationStore, never()).issue(any(), any());
+	}
+
+	@Test
+	void redisIssueFailureDoesNotIssueTokenOrResetFailureCount() {
+		User user = user("encoded-old", 2);
+		given(userReader.readById(1L)).willReturn(user);
+		given(userAuthRepository.existsByUser_UserIdAndProvider(1L, Provider.LOCAL))
+			.willReturn(true);
+		given(passwordEncoder.matches("old-password1", "encoded-old")).willReturn(true);
+		given(reauthenticationStore.issue(1L, ReauthenticationPurpose.CHANGE_PASSWORD))
+			.willThrow(new AppException(ErrorCode.REAUTHENTICATION_UNAVAILABLE));
+
+		assertThatThrownBy(() -> userInfoService.verifyMyPassword(
+			1L,
+			new VerifyPasswordRequestDTO("old-password1")
+		))
+			.isInstanceOf(AppException.class)
+			.extracting("errorCode")
+			.isEqualTo(ErrorCode.REAUTHENTICATION_UNAVAILABLE);
+
+		assertThat(user.getPasswordCnt()).isEqualTo(2);
+	}
+
+	@Test
+	void missingTokenCannotChangePassword() {
+		assertThatThrownBy(() -> userInfoService.updateMyPassword(
+			1L,
+			" ",
+			updateRequest("new-password1")
+		))
+			.isInstanceOf(AppException.class)
+			.extracting("errorCode")
+			.isEqualTo(ErrorCode.REAUTH_TOKEN_REQUIRED);
+
+		verify(userRepository, never()).findByIdForUpdate(any());
+	}
+
+	@Test
+	void invalidTokenCannotChangePassword() {
+		User user = user("encoded-old", 2);
+		given(userRepository.findByIdForUpdate(1L)).willReturn(Optional.of(user));
+		given(userAuthRepository.existsByUser_UserIdAndProvider(1L, Provider.LOCAL))
+			.willReturn(true);
+		given(passwordEncoder.matches("new-password1", "encoded-old")).willReturn(false);
+		org.mockito.Mockito.doThrow(new AppException(ErrorCode.INVALID_REAUTH_TOKEN))
+			.when(reauthenticationStore)
+			.consume(1L, ReauthenticationPurpose.CHANGE_PASSWORD, "invalid-token");
+
+		assertThatThrownBy(() -> userInfoService.updateMyPassword(
+			1L,
+			"invalid-token",
+			updateRequest("new-password1")
+		))
+			.isInstanceOf(AppException.class)
+			.extracting("errorCode")
+			.isEqualTo(ErrorCode.INVALID_REAUTH_TOKEN);
+
+		assertThat(user.getPassword()).isEqualTo("encoded-old");
+		verify(passwordEncoder, never()).encode(any());
+		verify(userSessionRepository, never()).deleteByUser_UserId(any());
+	}
+
+	@Test
+	void socialUserCannotChangePassword() {
+		User user = user(null, null);
+		given(userRepository.findByIdForUpdate(1L)).willReturn(Optional.of(user));
+		given(userAuthRepository.existsByUser_UserIdAndProvider(1L, Provider.LOCAL))
+			.willReturn(false);
+
+		assertThatThrownBy(() -> userInfoService.updateMyPassword(
+			1L,
+			"reauth-token",
+			updateRequest("new-password1")
+		))
+			.isInstanceOf(AppException.class)
+			.extracting("errorCode")
+			.isEqualTo(ErrorCode.SOCIAL_USER_PASSWORD_CHANGE_NOT_ALLOWED);
+
+		verify(reauthenticationStore, never()).consume(any(), any(), any());
+	}
+
+	@Test
+	void samePasswordIsRejectedWithoutConsumingToken() {
+		User user = user("encoded-old", 2);
+		given(userRepository.findByIdForUpdate(1L)).willReturn(Optional.of(user));
+		given(userAuthRepository.existsByUser_UserIdAndProvider(1L, Provider.LOCAL))
+			.willReturn(true);
+		given(passwordEncoder.matches("old-password1", "encoded-old")).willReturn(true);
+
+		assertThatThrownBy(() -> userInfoService.updateMyPassword(
+			1L,
+			"reauth-token",
+			updateRequest("old-password1")
+		))
+			.isInstanceOf(AppException.class)
+			.extracting("errorCode")
+			.isEqualTo(ErrorCode.SAME_AS_PREVIOUS_PASSWORD);
+
+		verify(reauthenticationStore, never()).consume(any(), any(), any());
+	}
+
+	@Test
+	void successfulChangeUpdatesPasswordResetsCountAndDeletesRefreshSession() {
+		User user = user("encoded-old", 4);
+		given(userRepository.findByIdForUpdate(1L)).willReturn(Optional.of(user));
+		given(userAuthRepository.existsByUser_UserIdAndProvider(1L, Provider.LOCAL))
+			.willReturn(true);
+		given(passwordEncoder.matches("new-password1", "encoded-old")).willReturn(false);
+		given(passwordEncoder.encode("new-password1")).willReturn("encoded-new");
+
+		userInfoService.updateMyPassword(
+			1L,
+			"reauth-token",
+			updateRequest("new-password1")
+		);
+
+		verify(reauthenticationStore).consume(
+			1L,
+			ReauthenticationPurpose.CHANGE_PASSWORD,
+			"reauth-token"
+		);
+		assertThat(user.getPassword()).isEqualTo("encoded-new");
+		assertThat(user.getPasswordCnt()).isZero();
+		verify(userSessionRepository).deleteByUser_UserId(1L);
+	}
+
+	@Test
+	void redisConsumeFailureDoesNotChangePasswordOrDeleteSession() {
+		User user = user("encoded-old", 2);
+		given(userRepository.findByIdForUpdate(1L)).willReturn(Optional.of(user));
+		given(userAuthRepository.existsByUser_UserIdAndProvider(1L, Provider.LOCAL))
+			.willReturn(true);
+		given(passwordEncoder.matches("new-password1", "encoded-old")).willReturn(false);
+		org.mockito.Mockito.doThrow(new AppException(ErrorCode.REAUTHENTICATION_UNAVAILABLE))
+			.when(reauthenticationStore)
+			.consume(1L, ReauthenticationPurpose.CHANGE_PASSWORD, "reauth-token");
+
+		assertThatThrownBy(() -> userInfoService.updateMyPassword(
+			1L,
+			"reauth-token",
+			updateRequest("new-password1")
+		))
+			.isInstanceOf(AppException.class)
+			.extracting("errorCode")
+			.isEqualTo(ErrorCode.REAUTHENTICATION_UNAVAILABLE);
+
+		assertThat(user.getPassword()).isEqualTo("encoded-old");
+		verify(passwordEncoder, never()).encode(any());
+		verify(userSessionRepository, never()).deleteByUser_UserId(any());
+	}
+
+	private UpdatePasswordRequestDTO updateRequest(String password) {
+		return new UpdatePasswordRequestDTO(password, password);
+	}
+
+	private User user(String password, Integer passwordCnt) {
+		return User.builder()
+			.userId(1L)
+			.email("test@example.com")
+			.nickname("nickname")
+			.password(password)
+			.passwordCnt(passwordCnt)
+			.build();
+	}
+}

--- a/src/test/java/com/cookeep/cookeep/domain/user/application/RedisReauthenticationStoreFailureTest.java
+++ b/src/test/java/com/cookeep/cookeep/domain/user/application/RedisReauthenticationStoreFailureTest.java
@@ -1,0 +1,70 @@
+package com.cookeep.cookeep.domain.user.application;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
+
+import java.time.Duration;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.RedisConnectionFailureException;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+import com.cookeep.cookeep.common.exception.AppException;
+import com.cookeep.cookeep.common.exception.ErrorCode;
+import com.cookeep.cookeep.domain.user.entity.ReauthenticationPurpose;
+
+@ExtendWith(MockitoExtension.class)
+class RedisReauthenticationStoreFailureTest {
+
+	@Mock
+	private StringRedisTemplate redisTemplate;
+	@Mock
+	private ValueOperations<String, String> valueOperations;
+
+	private RedisReauthenticationStore store;
+
+	@BeforeEach
+	void setUp() {
+		when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+		store = new RedisReauthenticationStore(redisTemplate);
+	}
+
+	@Test
+	void issueFailsClosedWhenRedisIsUnavailable() {
+		doThrow(new RedisConnectionFailureException("redis unavailable"))
+			.when(valueOperations)
+			.set(anyString(), anyString(), any(Duration.class));
+
+		assertUnavailable(() -> store.issue(
+			1L,
+			ReauthenticationPurpose.CHANGE_PASSWORD
+		));
+	}
+
+	@Test
+	void consumeFailsClosedWhenRedisIsUnavailable() {
+		when(valueOperations.getAndDelete(anyString()))
+			.thenThrow(new RedisConnectionFailureException("redis unavailable"));
+
+		assertUnavailable(() -> store.consume(
+			1L,
+			ReauthenticationPurpose.CHANGE_PASSWORD,
+			"reauth-token"
+		));
+	}
+
+	private void assertUnavailable(org.assertj.core.api.ThrowableAssert.ThrowingCallable action) {
+		assertThatThrownBy(action)
+			.isInstanceOf(AppException.class)
+			.extracting("errorCode")
+			.isEqualTo(ErrorCode.REAUTHENTICATION_UNAVAILABLE);
+	}
+}

--- a/src/test/java/com/cookeep/cookeep/domain/user/application/RedisReauthenticationStoreTest.java
+++ b/src/test/java/com/cookeep/cookeep/domain/user/application/RedisReauthenticationStoreTest.java
@@ -1,0 +1,218 @@
+package com.cookeep.cookeep.domain.user.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.security.SecureRandom;
+import java.time.Duration;
+import java.util.Base64;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.StringRedisTemplate;
+
+import com.cookeep.cookeep.common.exception.AppException;
+import com.cookeep.cookeep.common.exception.ErrorCode;
+import com.cookeep.cookeep.domain.user.entity.ReauthenticationPurpose;
+
+class RedisReauthenticationStoreTest {
+
+	private static final long USER_ID = 9_900_001L;
+	private static final long OTHER_USER_ID = 9_900_002L;
+	private static final String TEST_KEY_PATTERN = RedisReauthenticationStore.KEY_PREFIX + "990000*";
+
+	private static LettuceConnectionFactory connectionFactory;
+	private static StringRedisTemplate redisTemplate;
+	private static RedisReauthenticationStore store;
+
+	@BeforeAll
+	static void setUpRedis() {
+		RedisStandaloneConfiguration configuration =
+			new RedisStandaloneConfiguration("localhost", 6379);
+		connectionFactory = new LettuceConnectionFactory(configuration);
+		connectionFactory.afterPropertiesSet();
+		connectionFactory.start();
+
+		redisTemplate = new StringRedisTemplate(connectionFactory);
+		redisTemplate.afterPropertiesSet();
+		store = new RedisReauthenticationStore(redisTemplate);
+
+		assertThat(connectionFactory.getConnection().ping()).isEqualTo("PONG");
+	}
+
+	@AfterEach
+	void cleanTestKeys() {
+		Set<String> keys = redisTemplate.keys(TEST_KEY_PATTERN);
+		if (keys != null && !keys.isEmpty()) {
+			redisTemplate.delete(keys);
+		}
+	}
+
+	@AfterAll
+	static void tearDownRedis() {
+		if (connectionFactory != null) {
+			connectionFactory.destroy();
+		}
+	}
+
+	@Test
+	void issueStoresOnlyDigestWithFiveMinuteTtl() {
+		String rawToken = store.issue(USER_ID, ReauthenticationPurpose.CHANGE_PASSWORD);
+		String key = RedisReauthenticationStore.buildKey(
+			USER_ID,
+			ReauthenticationPurpose.CHANGE_PASSWORD,
+			rawToken
+		);
+
+		assertThat(Base64.getUrlDecoder().decode(rawToken)).hasSize(32);
+		assertThat(key)
+			.startsWith("auth:reauth:" + USER_ID + ":CHANGE_PASSWORD:")
+			.doesNotContain(rawToken);
+		assertThat(redisTemplate.opsForValue().get(key)).isEqualTo("1");
+		assertThat(redisTemplate.getExpire(key, TimeUnit.SECONDS)).isBetween(295L, 300L);
+	}
+
+	@Test
+	void invalidTokenIsRejected() {
+		assertInvalidToken(() -> store.consume(
+			USER_ID,
+			ReauthenticationPurpose.CHANGE_PASSWORD,
+			"forged-token"
+		));
+	}
+
+	@Test
+	void expiredTokenIsRejected() throws InterruptedException {
+		RedisReauthenticationStore shortLivedStore = new RedisReauthenticationStore(
+			redisTemplate,
+			new SecureRandom(),
+			Duration.ofMillis(100)
+		);
+		String rawToken = shortLivedStore.issue(
+			USER_ID,
+			ReauthenticationPurpose.CHANGE_PASSWORD
+		);
+
+		Thread.sleep(250);
+
+		assertInvalidToken(() -> shortLivedStore.consume(
+			USER_ID,
+			ReauthenticationPurpose.CHANGE_PASSWORD,
+			rawToken
+		));
+	}
+
+	@Test
+	void tokenBoundToDifferentUserIsRejected() {
+		String rawToken = store.issue(USER_ID, ReauthenticationPurpose.CHANGE_PASSWORD);
+
+		assertInvalidToken(() -> store.consume(
+			OTHER_USER_ID,
+			ReauthenticationPurpose.CHANGE_PASSWORD,
+			rawToken
+		));
+
+		store.consume(USER_ID, ReauthenticationPurpose.CHANGE_PASSWORD, rawToken);
+	}
+
+	@Test
+	void tokenStoredForDifferentPurposeIsRejected() {
+		String rawToken = store.issue(USER_ID, ReauthenticationPurpose.CHANGE_PASSWORD);
+		String changePasswordKey = RedisReauthenticationStore.buildKey(
+			USER_ID,
+			ReauthenticationPurpose.CHANGE_PASSWORD,
+			rawToken
+		);
+		String otherPurposeKey = changePasswordKey.replace(
+			":CHANGE_PASSWORD:",
+			":OTHER_PURPOSE:"
+		);
+		redisTemplate.delete(changePasswordKey);
+		redisTemplate.opsForValue().set(
+			otherPurposeKey,
+			"1",
+			ReauthenticationPolicy.TOKEN_TTL
+		);
+
+		assertInvalidToken(() -> store.consume(
+			USER_ID,
+			ReauthenticationPurpose.CHANGE_PASSWORD,
+			rawToken
+		));
+		assertThat(redisTemplate.opsForValue().get(otherPurposeKey)).isEqualTo("1");
+	}
+
+	@Test
+	void consumedTokenCannotBeReused() {
+		String rawToken = store.issue(USER_ID, ReauthenticationPurpose.CHANGE_PASSWORD);
+
+		store.consume(USER_ID, ReauthenticationPurpose.CHANGE_PASSWORD, rawToken);
+
+		assertInvalidToken(() -> store.consume(
+			USER_ID,
+			ReauthenticationPurpose.CHANGE_PASSWORD,
+			rawToken
+		));
+	}
+
+	@Test
+	void concurrentConsumptionAllowsExactlyOneSuccess() throws Exception {
+		String rawToken = store.issue(USER_ID, ReauthenticationPurpose.CHANGE_PASSWORD);
+		ExecutorService executor = Executors.newFixedThreadPool(2);
+		CountDownLatch ready = new CountDownLatch(2);
+		CountDownLatch start = new CountDownLatch(1);
+
+		Callable<Boolean> consume = () -> {
+			ready.countDown();
+			start.await(5, TimeUnit.SECONDS);
+			try {
+				store.consume(USER_ID, ReauthenticationPurpose.CHANGE_PASSWORD, rawToken);
+				return true;
+			} catch (AppException e) {
+				if (e.getErrorCode() == ErrorCode.INVALID_REAUTH_TOKEN) {
+					return false;
+				}
+				throw e;
+			}
+		};
+
+		try {
+			List<Future<Boolean>> futures = List.of(
+				executor.submit(consume),
+				executor.submit(consume)
+			);
+			assertThat(ready.await(5, TimeUnit.SECONDS)).isTrue();
+			start.countDown();
+
+			long successCount = 0;
+			for (Future<Boolean> future : futures) {
+				if (future.get(5, TimeUnit.SECONDS)) {
+					successCount++;
+				}
+			}
+			assertThat(successCount).isEqualTo(1);
+		} finally {
+			start.countDown();
+			executor.shutdownNow();
+		}
+	}
+
+	private void assertInvalidToken(org.assertj.core.api.ThrowableAssert.ThrowingCallable action) {
+		assertThatThrownBy(action)
+			.isInstanceOf(AppException.class)
+			.extracting("errorCode")
+			.isEqualTo(ErrorCode.INVALID_REAUTH_TOKEN);
+	}
+}


### PR DESCRIPTION
# Related Issue

#301

<br/><br/>

# Description

## 비밀번호 변경 전 일회용 재인증 절차 도입

기존에는 `POST /api/users/me/password/verify`에서 현재 비밀번호를 확인하더라도 서버에 검증 완료 상태가 저장되지 않았습니다.

따라서 _Access Token만 있으면 현재 비밀번호 확인 API를 거치지 않고 `PATCH /api/users/me/password`를 직접 호출할 수 있었습니다._

이를 방지하기 위해 현재 비밀번호 확인 성공 시 **Redis 기반의 일회용 Reauth Token을 발급하고, 비밀번호 변경 시 Access Token과 Reauth Token을 모두 검증하도록** 변경했습니다.

<br/>

### Reauth Token 발급

- 기존 `POST /api/users/me/password/verify` 경로 유지
- 현재 비밀번호 확인 성공 시 Reauth Token과 만료시간 반환
- 클라이언트가 purpose를 전달하지 않고 서버 내부에서 `CHANGE_PASSWORD`로 고정
- LOCAL Provider가 연결된 회원만 발급 가능
- 소셜 Provider만 연결된 회원은 비밀번호 확인 및 변경 불가

```json
{
  "reauthToken": "일회용 재인증 토큰",
  "expiresInSeconds": 300
}
```

<br/>

### Redis 저장 구조

- 기존 `StringRedisTemplate` 사용
- Redis Key prefix를 `auth:reauth:`로 분리
- `SecureRandom`으로 32바이트 무작위 토큰 생성
- Base64 URL-safe 문자열로 변환하여 클라이언트에 반환
- **원본 토큰은 Redis에 저장하지 않고 SHA-256 digest만 저장**
- Redis Key에 **사용자 ID와 `CHANGE_PASSWORD` 목적** 포함
- TTL 300초 적용
- 값은 `"1"`만 저장하여 불필요한 정보 저장 방지

```text
auth:reauth:{userId}:CHANGE_PASSWORD:{tokenDigest}
```

```text
value = "1"
TTL = 300초
```

256비트 무작위 토큰은 충분한 엔트로피를 가지므로 별도 비밀키가 필요한 HMAC 대신 SHA-256 digest를 사용했습니다.

여러 번 발급된 미사용 Reauth Token은 각각 독립적인 일회용 토큰으로 5분 동안 유지됩니다.

<br/>

### 원자적인 일회용 토큰 소비

- Redis의 `getAndDelete()`를 사용하여 **토큰 조회와 삭제를 원자적으로 처리**
- 동일 토큰으로 동시에 요청하더라도 **하나의 요청만 성공**
- 만료·재사용·위조·다른 회원·다른 목적의 토큰을 모두 동일한 인증 오류로 처리
- Redis 장애 시 비밀번호 변경을 허용하지 않는 **fail-closed 방식 적용**

Redis 토큰 소비와 DB 변경은 하나의 분산 트랜잭션이 아니므로, **토큰 소비 후 DB 변경이 실패하면 현재 비밀번호 확인부터 다시 진행해야 합니다.**

<br/>

### 비밀번호 변경 API 인증 강화

`PATCH /api/users/me/password` 요청에 다음 헤더가 추가되었습니다.

```http
Authorization: Bearer <access-token>
X-Reauth-Token: <reauth-token>
```

비밀번호 변경은 다음 순서로 처리합니다.

1. Reauth Token 누락 여부 확인
2. `findByIdForUpdate()`를 통한 사용자 행 비관적 잠금
3. LOCAL Provider 연결 여부 확인
4. 새 비밀번호와 기존 비밀번호가 동일한지 확인
5. `CHANGE_PASSWORD` 목적의 Reauth Token 원자적 소비
6. 새 비밀번호 암호화 및 저장
7. `passwordCnt` 초기화
8. 기존 Refresh Session 삭제

<br/>

### LOCAL Provider 확인 방식 변경

- 기존
  - `findProviderByUserId()`는 하나의 사용자가 복수 Provider를 가질 경우 단일 Provider 조회에 문제가 생길 수 있었음
- 개선
  - 존재 여부 조회 메서드 추가
  - **LOCAL Provider 연결 여부를 기준으로 판단하도록 변경**

```java
boolean existsByUser_UserIdAndProvider(
    Long userId,
    Provider provider
);
```

- LOCAL 회원: 비밀번호 확인 및 변경 가능
- LOCAL과 소셜 Provider가 함께 연결된 회원: 가능
- **소셜 Provider만 연결된 회원: 불가**

<br/>

### 동시 비밀번호 변경 방지

- 기존
  - 일반 사용자 조회를 사용하여 동시에 들어오는 비밀번호 변경 요청을 제어하지 않았음
- 개선
  - 기존 `UserRepository.findByIdForUpdate()` 사용
  - **사용자 행에 비관적 잠금을 적용하여 동시 변경 요청을 순차 처리**
  - 사용자 잠금 이후 LOCAL Provider와 기존 비밀번호를 다시 검증

<br/>

### Refresh Session 및 Cookie 만료

비밀번호 변경 성공 시 기존 인증 상태를 함께 정리하도록 변경했습니다.

- **같은 DB 트랜잭션에서 사용자의 Refresh Session 삭제**
- 기존 Refresh Token으로 Access Token을 재발급할 수 없도록 처리
- 성공 응답에 `Max-Age=0`인 Refresh Token Cookie 추가
- **브라우저의 기존 Refresh Cookie 즉시 만료**
- 기존 Access Token은 현재 정책대로 **최대 30분 동안 유지**

<br/>

### Swagger 명세 반영

- 현재 비밀번호 확인 성공 응답에 `ReauthenticationResponseDTO` 추가
- 비밀번호 변경 요청에 필수 `X-Reauth-Token` 헤더 명세 추가
- 비밀번호 변경 성공 시 Refresh Cookie 만료 명세 추가
- 소셜 회원 제한, Reauth Token 오류 및 Redis 장애 응답 추가

<br/><br/>

# API Changes

| API | 변경 전 | 변경 후 |
| --- | --- | --- |
| `POST /api/users/me/password/verify` | 비밀번호 검증 후 `Void` 응답 | 성공 시 5분짜리 Reauth Token 반환 |
| `PATCH /api/users/me/password` | Access Token만으로 변경 가능 | Access Token과 `X-Reauth-Token` 모두 필요 |
| `PATCH /api/users/me/password` | 일반 사용자 조회 | `findByIdForUpdate()`로 동시 변경 방지 |
| `PATCH /api/users/me/password` | Refresh Session 및 Cookie 유지 | 성공 시 Refresh Session 삭제 및 Cookie 만료 |

<br/><br/>

# Error Codes

| Error Code | HTTP Status | 설명 |
| --- | --- | --- |
| `AUTH-011` | 401 | Reauth Token 누락 |
| `AUTH-012` | 401 | Reauth Token 만료·재사용·위조·사용자/목적 불일치 |
| `AUTH-013` | 403 | 소셜 회원의 비밀번호 확인 및 변경 |
| `AUTH-014` | 503 | Redis 재인증 서비스 사용 불가 |

<br/><br/>

# Changes

### 추가

- `ReauthenticationPurpose`
- `ReauthenticationPolicy`
- `ReauthenticationStore`
- `RedisReauthenticationStore`
- `ReauthenticationService`
- `ReauthenticationResponseDTO`
- Redis 저장소 및 비밀번호 재인증 흐름 테스트

### 변경

- 현재 비밀번호 확인 성공 시 Reauth Token 반환
- 비밀번호 변경 API에 `X-Reauth-Token` 헤더 추가
- 비밀번호 변경 시 비관적 잠금 적용
- LOCAL Provider 연결 여부를 기준으로 비밀번호 기능 사용 가능 여부 판단
- 비밀번호 변경 성공 시 `passwordCnt` 초기화
- 비밀번호 변경 성공 시 Refresh Session 삭제
- 비밀번호 변경 성공 응답에서 Refresh Cookie 만료
- Swagger 요청·응답·오류 명세 반영

<br/><br/>

# Test

- 기능 커밋별 `compileJava` 성공
- 회원·인증 및 실제 Redis 관련 테스트 39개 성공
- 다음 시나리오 검증
  - 올바른 비밀번호 확인 시 Reauth Token 발급
  - 잘못된 비밀번호 및 소셜 회원 발급 거부
  - 토큰 누락·무효·만료·재사용 거부
  - 다른 회원 및 다른 목적의 토큰 거부
  - 동일 토큰 동시 소비 시 하나의 요청만 성공
  - 기존 비밀번호와 동일한 비밀번호 거부
  - 비밀번호 변경 및 `passwordCnt` 초기화
  - Refresh Session 삭제 및 Cookie 만료
  - 기존 비밀번호 로그인 실패 및 새 비밀번호 로그인 성공

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 비밀번호 확인 후 5분간 유효한 재인증 토큰을 발급합니다.
  * 재인증 토큰이 있어야 비밀번호를 변경할 수 있습니다.
  * 비밀번호 변경이 완료되면 기존 세션과 리프레시 토큰이 만료됩니다.
  * 소셜 로그인 계정의 비밀번호 변경을 제한합니다.

* **개선 사항**
  * 재인증 토큰 누락, 만료, 무효 및 관련 서비스 장애에 대한 안내를 제공합니다.
  * 비밀번호 변경 후 새 비밀번호로 로그인할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->