### PR TITLE
[COOKEEP-103] fix: dev 환경 cross-site 로그인을 위한 refreshToken 쿠키 SameSite 분기 처리

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -168,5 +168,6 @@ jobs:
               -e "EMAIL_USERNAME=${{ secrets.EMAIL_USERNAME }}" \
               -e "EMAIL_PASSWORD=${{ secrets.EMAIL_PASSWORD }}" \
               -e "REFRESH_COOKIE_SECURE=true" \
+              -e "REFRESH_COOKIE_SAMESITE=None" \
               ${{ secrets.DOCKER_USERNAME }}/cookeep:dev
             docker image prune -f

--- a/src/main/java/com/cookeep/cookeep/security/RefreshTokenCookieProvider.java
+++ b/src/main/java/com/cookeep/cookeep/security/RefreshTokenCookieProvider.java
@@ -13,18 +13,21 @@ public class RefreshTokenCookieProvider {
 	private static final String COOKIE_PATH = "/api/auth/refresh";
 
 	private final boolean secure;
+	private final String sameSite;
 
 	public RefreshTokenCookieProvider(
-		@Value("${REFRESH_COOKIE_SECURE:true}") boolean secure
+		@Value("${REFRESH_COOKIE_SECURE:true}") boolean secure,
+		@Value("${REFRESH_COOKIE_SAMESITE:Lax}") String sameSite
 	) {
 		this.secure = secure;
+		this.sameSite = sameSite;
 	}
 
 	public ResponseCookie create(String refreshToken, Duration maxAge) {
 		return baseCookie(refreshToken)
 			.httpOnly(true)
 			.secure(secure)
-			.sameSite("Lax")
+			.sameSite(sameSite)
 			.path(COOKIE_PATH)
 			.maxAge(maxAge)
 			.build();
@@ -34,7 +37,7 @@ public class RefreshTokenCookieProvider {
 		return baseCookie("")
 			.httpOnly(true)
 			.secure(secure)
-			.sameSite("Lax")
+			.sameSite(sameSite)
 			// 브라우저가 기존 쿠키를 찾아 삭제하려면 발급할 때와 이름 및 Path가 같아야 한다.
 			.path(COOKIE_PATH)
 			.maxAge(Duration.ZERO)

--- a/src/test/java/com/cookeep/cookeep/api/controller/AuthControllerTest.java
+++ b/src/test/java/com/cookeep/cookeep/api/controller/AuthControllerTest.java
@@ -51,9 +51,9 @@ class AuthControllerTest {
 
 	@BeforeEach
 	void setUp() {
-		authController = new AuthController(authService, new RefreshTokenCookieProvider(true));
+		authController = new AuthController(authService, new RefreshTokenCookieProvider(true, "Lax"));
 		mockMvc = MockMvcBuilders.standaloneSetup(authController)
-			.setControllerAdvice(new GlobalExceptionHandler(new RefreshTokenCookieProvider(true)))
+			.setControllerAdvice(new GlobalExceptionHandler(new RefreshTokenCookieProvider(true, "Lax")))
 			.build();
 	}
 

--- a/src/test/java/com/cookeep/cookeep/api/controller/UserInfoPasswordControllerTest.java
+++ b/src/test/java/com/cookeep/cookeep/api/controller/UserInfoPasswordControllerTest.java
@@ -32,7 +32,7 @@ class UserInfoPasswordControllerTest {
 	void setUp() {
 		controller = new UserInfoController(
 			userInfoService,
-			new RefreshTokenCookieProvider(true)
+			new RefreshTokenCookieProvider(true, "Lax")
 		);
 	}
 

--- a/src/test/java/com/cookeep/cookeep/security/RefreshTokenCookieProviderTest.java
+++ b/src/test/java/com/cookeep/cookeep/security/RefreshTokenCookieProviderTest.java
@@ -11,7 +11,7 @@ class RefreshTokenCookieProviderTest {
 
 	@Test
 	void create_buildsSecureHttpOnlyRefreshTokenCookie() {
-		RefreshTokenCookieProvider provider = new RefreshTokenCookieProvider(true);
+		RefreshTokenCookieProvider provider = new RefreshTokenCookieProvider(true, "Lax");
 
 		ResponseCookie cookie = provider.create("refresh-token", Duration.ofDays(14));
 
@@ -27,7 +27,7 @@ class RefreshTokenCookieProviderTest {
 
 	@Test
 	void create_canDisableSecureForLocalHttpTools() {
-		RefreshTokenCookieProvider provider = new RefreshTokenCookieProvider(false);
+		RefreshTokenCookieProvider provider = new RefreshTokenCookieProvider(false, "Lax");
 
 		ResponseCookie cookie = provider.create("refresh-token", Duration.ofDays(14));
 
@@ -37,7 +37,7 @@ class RefreshTokenCookieProviderTest {
 
 	@Test
 	void delete_expiresCookieWithSameScope() {
-		RefreshTokenCookieProvider provider = new RefreshTokenCookieProvider(true);
+		RefreshTokenCookieProvider provider = new RefreshTokenCookieProvider(true, "Lax");
 
 		ResponseCookie cookie = provider.delete();
 


### PR DESCRIPTION
# Description

QA Preview(`cookeep.vercel.app`)에서 dev 서버(`dev-api.cookeep.kr`)로 로그인이 되지 않는 문제가 있었습니다.

원인을 추적해보니 두 가지가 겹쳐 있었습니다.
1. dev 서버가 HTTP로만 노출되어 있어 HTTPS로 서빙되는 QA Preview에서 Mixed Content로 요청 자체가 차단됨 → Oracle Cloud 인스턴스에 `dev-api.cookeep.kr` 서브도메인을 연결하고 Caddy 리버스 프록시로 HTTPS를 적용해 해결
2. `refreshToken` 쿠키의 `SameSite=Lax` 설정 때문에, 서로 다른 도메인인 `cookeep.vercel.app`(프론트)과 `dev-api.cookeep.kr`(백엔드) 사이의 cross-site 요청에는 브라우저가 쿠키를 실어 보내지 않아, 로그인 자체는 되어도 `/api/auth/refresh` 등 이후 인증 흐름이 끊기는 문제

이 PR은 2번 문제를 해결합니다. 운영(`cookeep.kr` ↔ `api.cookeep.kr`)은 같은 상위 도메인의 서브도메인 관계라 same-site이므로 `SameSite=Lax`로도 문제가 없고, 오히려 CSRF 방어 차원에서 유지하는 게 낫습니다. 반면 dev 환경은 완전히 다른 도메인 조합이라 `SameSite=None`이 필요합니다. 그래서 환경별로 값을 분기하도록 변경했습니다.

# Changes

- `RefreshTokenCookieProvider`: `REFRESH_COOKIE_SAMESITE` 환경변수(기본값 `Lax`)를 주입받아 쿠키의 `SameSite` 속성을 결정하도록 변경 (기존엔 `"Lax"` 하드코딩)
- `deploy.yml`: dev 배포 job에 `REFRESH_COOKIE_SAMESITE=None` 환경변수 추가 (prod job은 미설정 → 기본값 `Lax` 유지)
- `RefreshTokenCookieProviderTest`, `AuthControllerTest`, `UserInfoPasswordControllerTest`: 생성자 시그니처 변경에 맞춰 `"Lax"` 인자 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 리프레시 토큰 쿠키의 `SameSite` 설정을 환경에 맞게 구성할 수 있도록 개선했습니다.
  * 개발 환경에서 쿠키가 정상적으로 전송되도록 `SameSite=None` 설정을 지원합니다.
  * 기존 환경에서는 `Lax` 설정을 유지해 인증 흐름의 호환성을 보장합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->