### PR TITLE
[COOKEEP-112] feat: 재료 등록시 직접입력 단위 사용 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,7 @@ dependencies {
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-flyway'
 	implementation 'org.flywaydb:flyway-core'
 	implementation 'org.flywaydb:flyway-mysql'
 	implementation 'org.springframework.boot:spring-boot-starter-jdbc'

--- a/src/main/java/com/cookeep/cookeep/api/controller/UserIngredientController.java
+++ b/src/main/java/com/cookeep/cookeep/api/controller/UserIngredientController.java
@@ -76,13 +76,19 @@ public class UserIngredientController {
             ErrorCode.USER_NOT_FOUND,
             ErrorCode.INGREDIENT_REFERENCE_NOT_FOUND,
             ErrorCode.INTERNAL_SERVER_ERROR,
-            ErrorCode.INVALID_INGREDIENT_REQUEST
+            ErrorCode.INVALID_INGREDIENT_REQUEST,
+            ErrorCode.CUSTOM_UNIT_NAME_REQUIRED,
+            ErrorCode.CUSTOM_UNIT_NAME_NOT_ALLOWED,
+            ErrorCode.CUSTOM_UNIT_NAME_TOO_LONG
     })
     @ApiResponses(value = {
             @ApiResponse(responseCode = "201", description = "식재료 등록 성공"),
             @ApiResponse(responseCode = "400", description = """
                     잘못된 요청입니다.
                     - INVALID_INGREDIENT_REQUEST: 필수값 누락 또는 ENUM 값 오류
+                    - CUSTOM_UNIT_NAME_REQUIRED: "직접입력" 시 사용할 custom_unit_name 입력 필요
+                    - CUSTOM_UNIT_NAME_NOT_ALLOWED: "직접입력"이 아닌 기본 단위 사용 시 custom_unit_name 입력 불가
+                    - CUSTOM_UNIT_NAME_TOO_LONG: custom_unit_name 길이 초과 (VARCHAR(500)
                     """, content = @Content),
             @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content),
             @ApiResponse(responseCode = "404", description = """

--- a/src/main/java/com/cookeep/cookeep/api/dto/request/UserIngredientCreateRequestDto.java
+++ b/src/main/java/com/cookeep/cookeep/api/dto/request/UserIngredientCreateRequestDto.java
@@ -70,4 +70,11 @@ public class UserIngredientCreateRequestDto {
             requiredMode = Schema.RequiredMode.NOT_REQUIRED
     )
     private String memo;
+
+    @Schema(
+            description = "직접 입력한 단위명. unit == CUSTOM일 때만 사용, 필수",
+            example = "상자",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    private String customUnitName;
 }

--- a/src/main/java/com/cookeep/cookeep/api/dto/response/RefrigeratorSearchResponseDto.java
+++ b/src/main/java/com/cookeep/cookeep/api/dto/response/RefrigeratorSearchResponseDto.java
@@ -105,5 +105,12 @@ public class RefrigeratorSearchResponseDto {
                 requiredMode = Schema.RequiredMode.REQUIRED
         )
         private Unit unit;
+
+        @Schema(
+                description = "직접 입력한 단위명 (unit이 CUSTOM일 때만 값 존재)",
+                example = "상자",
+                requiredMode = Schema.RequiredMode.NOT_REQUIRED
+        )
+        private String customUnitName;
     }
 }

--- a/src/main/java/com/cookeep/cookeep/api/dto/response/UserIngredientCreateResponseDto.java
+++ b/src/main/java/com/cookeep/cookeep/api/dto/response/UserIngredientCreateResponseDto.java
@@ -33,6 +33,9 @@ public class UserIngredientCreateResponseDto {
     @Schema(description = "단위", example = "PIECE")
     private String unit;
 
+    @Schema(description = "직접 입력한 단위명 (unit이 CUSTOM일 때만 값 존재)", example = "상자")
+    private String customUnitName;
+
     @Schema(description = "보관 장소", example = "FRIDGE")
     private String storage;
 
@@ -63,6 +66,7 @@ public class UserIngredientCreateResponseDto {
                 ingredientName,
                 userIngredient.getQuantity(),
                 userIngredient.getUnit().name(),
+                userIngredient.getCustomUnitName(),
                 userIngredient.getStorage().name(),
                 userIngredient.getExpirationDate(),
                 userIngredient.getLeftDays(),

--- a/src/main/java/com/cookeep/cookeep/api/dto/response/UserIngredientDetailResponseDto.java
+++ b/src/main/java/com/cookeep/cookeep/api/dto/response/UserIngredientDetailResponseDto.java
@@ -70,6 +70,13 @@ public class UserIngredientDetailResponseDto {
     private Unit unit;
 
     @Schema(
+            description = "직접 입력한 단위명 (unit이 CUSTOM일 때만 값 존재)",
+            example = "상자",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    private String customUnitName;
+
+    @Schema(
             description = "메모",
             example = "샐러드용",
             requiredMode = Schema.RequiredMode.NOT_REQUIRED

--- a/src/main/java/com/cookeep/cookeep/common/exception/ErrorCode.java
+++ b/src/main/java/com/cookeep/cookeep/common/exception/ErrorCode.java
@@ -32,6 +32,9 @@ public enum ErrorCode {
 	MEMO_TOO_LONG(HttpStatus.BAD_REQUEST, "식재료 메모는 최대 100자까지 입력 가능합니다.", "INGREDIENT_009"),
 	INVALID_DELETE_REQUEST(HttpStatus.BAD_REQUEST, "삭제할 식재료를 입력해주세요.", "INGREDIENT_010"),
 	INVALID_INGREDIENT_REQUEST(HttpStatus.BAD_REQUEST, "type과 referenceId는 필수 입력입니다.", "INGREDIENT-011"),
+	CUSTOM_UNIT_NAME_REQUIRED(HttpStatus.BAD_REQUEST, "직접입력 시 사용할 단위명을 입력하세요.", "INGREDIENT-012"),
+	CUSTOM_UNIT_NAME_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "CUSTOM unit 사용 시에만 단위명을 입력하세요.", "INGREDIENT-013"),
+	CUSTOM_UNIT_NAME_TOO_LONG(HttpStatus.BAD_REQUEST, "직접 입력 단위명은 최대 255자까지 입력 가능합니다.", "INGREDIENT-014"),
 
 	// COOKIE
 	NOT_ENOUGH_COOKIES(HttpStatus.BAD_REQUEST, "보유한 쿠키가 부족합니다.", "COOKIE-001"),

--- a/src/main/java/com/cookeep/cookeep/domain/ingredient/common/domain/Unit.java
+++ b/src/main/java/com/cookeep/cookeep/domain/ingredient/common/domain/Unit.java
@@ -9,7 +9,8 @@ public enum Unit {
     BUNDLE("묶음"),
     CAN("캔"),
     GRAM("g"),
-    MILLILITER("ml");
+    MILLILITER("ml"),
+    CUSTOM("직접입력");
 
     private final String displayName;
 

--- a/src/main/java/com/cookeep/cookeep/domain/ingredient/useringredient/application/UserIngredientServiceImpl.java
+++ b/src/main/java/com/cookeep/cookeep/domain/ingredient/useringredient/application/UserIngredientServiceImpl.java
@@ -36,6 +36,7 @@ public class UserIngredientServiceImpl implements UserIngredientService {
 
     private static final int DEFAULT_QUANTITY = 1;
     private static final Unit DEFAULT_CUSTOM_UNIT = Unit.PIECE;
+    private static final int CUSTOM_UNIT_NAME_MAX_LENGTH = 255;
 
     private final UserIngredientRepository userIngredientRepository;
     private final DefaultIngredientRepository defaultIngredientRepository;
@@ -124,6 +125,7 @@ public class UserIngredientServiceImpl implements UserIngredientService {
 
         int quantity = req.getQuantity()!= null ? req.getQuantity():DEFAULT_QUANTITY;
         Unit unit = req.getUnit()!= null ? req.getUnit():ref.getUnit();
+        String customUnitName = resolveCustomUnitName(unit, req.getCustomUnitName());
         Storage storage = req.getStorage()!= null ? req.getStorage():ref.getDefaultStorage();
         LocalDate expiration = req.getExpirationDate()!= null ? req.getExpirationDate():calcExpiration(ref.getDefaultExpirationDays());
         String memo = req.getMemo();
@@ -134,6 +136,7 @@ public class UserIngredientServiceImpl implements UserIngredientService {
                 .referenceId(ref.getId())
                 .quantity(quantity)
                 .unit(unit)
+                .customUnitName(customUnitName)
                 .storage(storage)
                 .expirationDate(expiration)
                 .memo(memo)
@@ -160,6 +163,7 @@ public class UserIngredientServiceImpl implements UserIngredientService {
 
         int quantity = req.getQuantity()!= null ? req.getQuantity():DEFAULT_QUANTITY;
         Unit unit = req.getUnit()!= null ? req.getUnit():DEFAULT_CUSTOM_UNIT;
+        String customUnitName = resolveCustomUnitName(unit, req.getCustomUnitName());
         Storage storage = req.getStorage()!= null ? req.getStorage():ref.getStorage();
         LocalDate expiration = req.getExpirationDate() != null ? req.getExpirationDate():calcExpiration(ref.getExpirationDays());
         String memo = req.getMemo();
@@ -170,6 +174,7 @@ public class UserIngredientServiceImpl implements UserIngredientService {
                 .referenceId(ref.getId())
                 .quantity(quantity)
                 .unit(unit)
+                .customUnitName(customUnitName)
                 .storage(storage)
                 .expirationDate(expiration)
                 .memo(memo)
@@ -197,6 +202,29 @@ public class UserIngredientServiceImpl implements UserIngredientService {
             return true;
         }
         return false;
+    }
+
+    // [직접입력] 선택 시 단위 입력
+    private String resolveCustomUnitName(Unit unit, String customUnitName) {
+        if (unit == Unit.CUSTOM) {
+            if (customUnitName == null || customUnitName.isBlank()) {
+                throw new AppException(ErrorCode.CUSTOM_UNIT_NAME_REQUIRED);
+            }
+            String trimmed = customUnitName.trim();
+
+            if (trimmed.length() > CUSTOM_UNIT_NAME_MAX_LENGTH) {
+                throw new AppException(ErrorCode.CUSTOM_UNIT_NAME_TOO_LONG);
+            }
+
+            return trimmed;
+        }
+
+        // CUSTOM이 아닌데 값이 들어온 경우 명시적으로 거부
+        if (customUnitName != null && !customUnitName.isBlank()) {
+            throw new AppException(ErrorCode.CUSTOM_UNIT_NAME_NOT_ALLOWED);
+        }
+
+        return null; // CUSTOM이 아니면 항상 null
     }
 
 }

--- a/src/main/java/com/cookeep/cookeep/domain/ingredient/useringredient/entity/UserIngredient.java
+++ b/src/main/java/com/cookeep/cookeep/domain/ingredient/useringredient/entity/UserIngredient.java
@@ -39,6 +39,9 @@ public class UserIngredient extends BaseEntity {
     @Column(nullable = false)
     private Unit unit;
 
+    @Column(name = "custom_unit_name", nullable = true)
+    private String customUnitName;
+
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private Storage storage;
@@ -65,6 +68,7 @@ public class UserIngredient extends BaseEntity {
             Long referenceId,
             Integer quantity,
             Unit unit, Storage storage,
+            String customUnitName,
             LocalDate expirationDate,
             String memo,
             User user,
@@ -75,6 +79,7 @@ public class UserIngredient extends BaseEntity {
         this.quantity = quantity;
         this.unit = unit;
         this.storage = storage;
+        this.customUnitName = customUnitName;
         this.expirationDate = expirationDate;
         this.memo = memo;
         this.user = user;

--- a/src/main/java/com/cookeep/cookeep/domain/refrigerator/application/RefrigeratorService.java
+++ b/src/main/java/com/cookeep/cookeep/domain/refrigerator/application/RefrigeratorService.java
@@ -130,6 +130,7 @@ public class RefrigeratorService {
                 .expirationDate(userIngredient.getExpirationDate())
                 .quantity(userIngredient.getQuantity())
                 .unit(userIngredient.getUnit())
+                .customUnitName(userIngredient.getCustomUnitName())
                 .leftDays(userIngredient.getLeftDays())
                 .memo(userIngredient.getMemo())
                 .aiTip(aiTip)
@@ -196,6 +197,7 @@ public class RefrigeratorService {
                             .expirationDate(ui.getExpirationDate())
                             .quantity(ui.getQuantity())
                             .unit(ui.getUnit())
+                            .customUnitName(ui.getCustomUnitName())
                             .build();
                 })
                 .collect(Collectors.toList());

--- a/src/main/resources/db/migration/V5__add_custom_unit_name_to_user_ingredients.sql
+++ b/src/main/resources/db/migration/V5__add_custom_unit_name_to_user_ingredients.sql
@@ -1,0 +1,9 @@
+-- V5__add_custom_unit_name_to_user_ingredient.sql
+-- 식재료 등록 시 "직접입력" 단위 선택을 지원하기 위한 스키마 변경
+
+ALTER TABLE `user_ingredients`
+    MODIFY COLUMN `unit` ENUM('PIECE','PACK','BAG','BOTTLE','BUNDLE','CAN','GRAM','MILLILITER','CUSTOM')
+    COLLATE utf8mb4_unicode_ci NOT NULL;
+
+ALTER TABLE `user_ingredients`
+    ADD COLUMN `custom_unit_name` VARCHAR(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL AFTER `unit`;


### PR DESCRIPTION
# Issue
#314 

# Description
dev 서버 PR #303 ([COOKEEP-85] 재료 등록 시 '직접 입력' 선택 가능하도록 수정)에서 구현된 기능을 main 서버에 반영합니다.
동일한 기능(식재료 등록 시 unit을 "직접입력"으로 선택하고 사용자가 임의의 단위명을 입력할 수 있도록 하는 기능)을 main 코드베이스 기준으로 재구현했습니다.

# Changes
### 기능 구현
- `Unit` enum에 `CUSTOM("직접입력")` 값 추가
- `UserIngredient` 엔티티에 `customUnitName` 필드 추가 (unit이 CUSTOM일 때만 값 존재)
- `UserIngredientServiceImpl`에 `resolveCustomUnitName()` 검증 로직 추가
  - unit == CUSTOM인데 customUnitName 미입력 시 → `CUSTOM_UNIT_NAME_REQUIRED`
  - unit != CUSTOM인데 customUnitName 입력 시 → `CUSTOM_UNIT_NAME_NOT_ALLOWED`
  - customUnitName 255자 초과 시 → `CUSTOM_UNIT_NAME_TOO_LONG`
- `ErrorCode`에 위 3개 에러코드 추가 (INGREDIENT-012 ~ 014)

### DTO 반영
- `UserIngredientCreateRequestDto`: `customUnitName` 필드 추가, `unit` allowableValues에 `CUSTOM` 추가
- `UserIngredientCreateResponseDto`: `customUnitName` 필드 추가
- `UserIngredientDetailResponseDto`: `customUnitName` 필드 추가
- `RefrigeratorSearchResponseDto.SearchResultItem`: `customUnitName` 필드 추가
- `RefrigeratorService`: 상세조회 / 검색 응답 생성 시 `customUnitName` 매핑 반영

### DB 마이그레이션
- `V5__add_custom_unit_name_to_user_ingredient.sql` 추가
  - `user_ingredients.unit` 네이티브 ENUM에 `CUSTOM` 값 추가 (`MODIFY COLUMN`)
  - `user_ingredients`에 `custom_unit_name VARCHAR(255)` 컬럼 추가

### 빌드 설정
- Flyway 마이그레이션이 자동 실행되지 않는 문제가 있어 `build.gradle`에 의존성 추가

# Test Checklist
- CUSTOM 단위 사용 시 custom_unit_name 미입력 에러 정상 처리 확인
- 기본 단위 사용 시 custom_unit_name에 값 입력 시도 시 에러 정상 처리 확인
- CUSTOM unit으로 재료 저장 후 상세 조회 시 직접 입력한 단위 정상 노출 확인
- CUSTOM unit으로 재료 저장 후 냉장고 내 재료 검색 시 직접 입력한 단위 정상 노출 확인
- 커스텀 식재료 등록 후 냉장고 등록 시 CUSTOM unit 사용 정상 처리 확인

[COOKEEP-85]: https://cookeep.atlassian.net/browse/COOKEEP-85?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ